### PR TITLE
Switch from alpine to debian-base

### DIFF
--- a/cmd/machine-controller/Dockerfile
+++ b/cmd/machine-controller/Dockerfile
@@ -10,9 +10,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.7
+FROM k8s.gcr.io/debian-base-amd64:0.3.2
 
-RUN apk add --no-cache ca-certificates
+RUN echo CACHEBUST>/dev/null && clean-install \
+    ca-certificates
 
 ADD openstack-machine-controller /bin/
 


### PR DESCRIPTION
Resolves #10

Changes the base image for machine-controller from Alpine to the
Kubernetes debian-base images and installs the ca-certificates package
using the clean-install tool