### PR TITLE
Be explicit that minikube <= 0.28.0 is required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 ### Prerequisites
 
 1. Install `kubectl` (see [here](http://kubernetes.io/docs/user-guide/prereqs/)).
-2. Install [minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/).
+2. Install [minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/), version <= 0.28.0 (see: [cluster-api/issues/475](https://github.com/kubernetes-sigs/cluster-api/issues/475)).
 3. Install a [driver](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md) for minikube. For Linux, we recommend kvm2. For MacOS, we recommend VirtualBox.
 4. Build the `clusterctl` tool
 


### PR DESCRIPTION
Current version of the minikube (0.28.2) won't work. There is an opened issue
upstream (kubernetes-sigs/cluster-api#475).

See also:
https://github.com/kubernetes-sigs/cluster-api-provider-gcp/commit/e854ca60b92cc251a30042dab16e9f27b6669664