### PR TITLE
Fix indentation for floatingIP in example machines.yaml

### DIFF
--- a/clusterctl/examples/openstack/machines.yaml.template
+++ b/clusterctl/examples/openstack/machines.yaml.template
@@ -16,7 +16,7 @@ items:
         availability_zone: nova
         networks:
         - uuid: ab14ce0d-5e1f-4e32-bf65-00416e3cc19c
-          floatingIP: 129.114.111.153
+        floatingIP: 129.114.111.153
     versions:
       kubelet: 1.9.4
       controlPlane: 1.9.4
@@ -37,7 +37,6 @@ items:
         availability_zone: nova
         networks:
         - uuid: ab14ce0d-5e1f-4e32-bf65-00416e3cc19c
-          floatingIP: 129.114.111.153
+        floatingIP: 129.114.111.153
     versions:
       kubelet: 1.9.4
-


### PR DESCRIPTION
The current indentation for the example places `floatingIP` under the `networks` block, leading the `floatingIP` to be discarded and therefore not assigned to the machine. This patch fixes the example.