### PR TITLE
return AssociateFloatingIP error only if != nil

### DIFF
--- a/cloud/openstack/machineactuator.go
+++ b/cloud/openstack/machineactuator.go
@@ -242,8 +242,11 @@ func (oc *OpenstackClient) Create(cluster *clusterv1.Cluster, machine *clusterv1
 
 	if providerConfig.FloatingIP != "" {
 		err := oc.machineService.AssociateFloatingIP(instance.ID, providerConfig.FloatingIP)
-		return oc.handleMachineError(machine, apierrors.CreateMachine(
-			"Associate floatingIP err: %v", err))
+		if err != nil {
+			return oc.handleMachineError(machine, apierrors.CreateMachine(
+				"Associate floatingIP err: %v", err))
+		}
+
 	}
 
 	return oc.updateAnnotation(machine, instance.ID)


### PR DESCRIPTION
Currently if a `FloatingIP` is assigned to a machine we return an error in all cases, instead of only if an error has been returned by `AssociateFloatingIP()`. This also has the side effect of preventing the machine's annotation being updated with the `FloatingIP`.