### PR TITLE
iterate over all instance interfaces

### DIFF
--- a/cloud/openstack/machineactuator.go
+++ b/cloud/openstack/machineactuator.go
@@ -325,8 +325,8 @@ func getIPFromInstance(instance *clients.Instance) (string, error) {
 	if instance.AccessIPv4 != "" && net.ParseIP(instance.AccessIPv4) != nil {
 		return instance.AccessIPv4, nil
 	}
-	type network struct {
-		Addr    string  `json:"addr"`
+	type networkInterface struct {
+		Address string  `json:"addr"`
 		Version float64 `json:"version"`
 		Type    string  `json:"OS-EXT-IPS:type"`
 	}
@@ -337,17 +337,17 @@ func getIPFromInstance(instance *clients.Instance) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("extract IP from instance err: %v", err)
 		}
-		var address []interface{}
-		json.Unmarshal(list, &address)
-		for _, addr := range address {
-			var net network
-			b, _ := json.Marshal(addr)
-			json.Unmarshal(b, &net)
-			if net.Version == 4.0 {
-				if net.Type == "floating" {
-					return net.Addr, nil
+		var networks []interface{}
+		json.Unmarshal(list, &networks)
+		for _, network := range networks {
+			var netInterface networkInterface
+			b, _ := json.Marshal(network)
+			json.Unmarshal(b, &netInterface)
+			if netInterface.Version == 4.0 {
+				if netInterface.Type == "floating" {
+					return netInterface.Address, nil
 				}
-				addrList = append(addrList, net.Addr)
+				addrList = append(addrList, netInterface.Address)
 			}
 		}
 	}

--- a/cloud/openstack/machineactuator.go
+++ b/cloud/openstack/machineactuator.go
@@ -330,6 +330,7 @@ func getIPFromInstance(instance *clients.Instance) (string, error) {
 		Version float64 `json:"version"`
 		Type    string  `json:"OS-EXT-IPS:type"`
 	}
+	var addrList []string
 
 	for _, b := range instance.Addresses {
 		list, err := json.Marshal(b)
@@ -338,7 +339,6 @@ func getIPFromInstance(instance *clients.Instance) (string, error) {
 		}
 		var address []interface{}
 		json.Unmarshal(list, &address)
-		var addrList []string
 		for _, addr := range address {
 			var net network
 			b, _ := json.Marshal(addr)
@@ -349,10 +349,10 @@ func getIPFromInstance(instance *clients.Instance) (string, error) {
 				}
 				addrList = append(addrList, net.Addr)
 			}
-			if len(addrList) != 0 {
-				return addrList[0], nil
-			}
 		}
+	}
+	if len(addrList) != 0 {
+		return addrList[0], nil
 	}
 	return "", fmt.Errorf("extract IP from instance err")
 }


### PR DESCRIPTION
There is a bug in the `getIPFromInstance` logic that will return the `Addr` of the first interface instead of iterating over all interfaces and returning a `floating` `Addr` if assigned to the instance.

This patch changes the logic to iterate over all instance networks and interfaces to check for a `floating` `Addr` and returns the first `Addr` only if no `floating` `Addr`'s are found