### PR TITLE
Make providerConfig keys consistent

### DIFF
--- a/cmd/clusterctl/examples/openstack/machines.yaml.template
+++ b/cmd/clusterctl/examples/openstack/machines.yaml.template
@@ -13,11 +13,11 @@ items:
         name: master
         flavor: m1.medium
         image: Ubuntu-Server-16.04-x64
-        availability_zone: nova
+        availabilityZone: nova
         networks:
         - uuid: ab14ce0d-5e1f-4e32-bf65-00416e3cc19c
         floatingIP: 129.114.111.153
-        security_groups:
+        securityGroups:
         - default
     versions:
       kubelet: 1.9.4
@@ -36,11 +36,11 @@ items:
         name: node01
         flavor: m1.medium
         image: Ubuntu-Server-16.04-x64
-        availability_zone: nova
+        availabilityZone: nova
         networks:
         - uuid: ab14ce0d-5e1f-4e32-bf65-00416e3cc19c
         floatingIP: 129.114.111.153
-        security_groups:
+        securityGroups:
         - default
     versions:
       kubelet: 1.9.4

--- a/config/crd/openstackproviderconfig_v1alpha1.yaml
+++ b/config/crd/openstackproviderconfig_v1alpha1.yaml
@@ -31,9 +31,9 @@ spec:
           type: array
         floatingIP:
           type: string
-        availability_zone:
+        availabilityZone:
           type: string
-        security_groups:
+        securityGroups:
           items:
             type: string
           type: array

--- a/pkg/apis/openstackproviderconfig/v1alpha1/types.go
+++ b/pkg/apis/openstackproviderconfig/v1alpha1/types.go
@@ -37,10 +37,10 @@ type OpenstackProviderConfig struct {
 	FloatingIP string `json:"floatingIP,omitempty"`
 
 	// The availability zone from which to launch the server.
-	AvailabilityZone string `json:"availability_zone,omitempty"`
+	AvailabilityZone string `json:"availabilityZone,omitempty"`
 
 	// The names of the security groups to assign to the instance
-	SecurityGroups []string `json:"security_groups,omitempty"`
+	SecurityGroups []string `json:"securityGroups,omitempty"`
 
 	RootVolume RootVolume `json:"root_volume,omitempty"`
 }


### PR DESCRIPTION
Reference: https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/44
Changes: The security_group and availability_zone keys are now lowerCamelCase
