### PR TITLE
Use machine.Name rather than an arbitrary Name

### DIFF
--- a/cmd/clusterctl/examples/openstack/machines.yaml.template
+++ b/cmd/clusterctl/examples/openstack/machines.yaml.template
@@ -10,7 +10,6 @@ items:
       value:
         apiVersion: "openstackproviderconfig/v1alpha1"
         kind: "OpenstackProviderConfig"
-        name: master
         flavor: m1.medium
         image: Ubuntu-Server-16.04-x64
         availabilityZone: nova
@@ -33,7 +32,6 @@ items:
       value:
         apiVersion: "openstackproviderconfig/v1alpha1"
         kind: "OpenstackProviderConfig"
-        name: node01
         flavor: m1.medium
         image: Ubuntu-Server-16.04-x64
         availabilityZone: nova

--- a/pkg/apis/openstackproviderconfig/v1alpha1/types.go
+++ b/pkg/apis/openstackproviderconfig/v1alpha1/types.go
@@ -23,8 +23,6 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type OpenstackProviderConfig struct {
 	metav1.TypeMeta `json:",inline"`
-	// The name of your server instance.
-	Name string `json:"name"`
 	// The flavor reference for the flavor for your server instance.
 	Flavor string `json:"flavor"`
 	// The name of the image to use for your server instance.

--- a/pkg/cloud/openstack/clients/machineservice.go
+++ b/pkg/cloud/openstack/clients/machineservice.go
@@ -158,14 +158,14 @@ func (is *InstanceService) GetAcceptableFloatingIP() (string, error) {
 	return "", fmt.Errorf("Don't have acceptable floating IP.")
 }
 
-func (is *InstanceService) InstanceCreate(config *openstackconfigv1.OpenstackProviderConfig, cmd string, keyName string) (instance *Instance, err error) {
+func (is *InstanceService) InstanceCreate(name string, config *openstackconfigv1.OpenstackProviderConfig, cmd string, keyName string) (instance *Instance, err error) {
 	var createOpts servers.CreateOpts
 	if config == nil {
 		return nil, fmt.Errorf("create Options need be specified to create instace.")
 	}
 	userData := base64.StdEncoding.EncodeToString([]byte(cmd))
 	createOpts = servers.CreateOpts{
-		Name:             config.Name,
+		Name:             name,
 		ImageName:        config.Image,
 		FlavorName:       config.Flavor,
 		AvailabilityZone: config.AvailabilityZone,

--- a/pkg/cloud/openstack/machineactuator.go
+++ b/pkg/cloud/openstack/machineactuator.go
@@ -218,7 +218,7 @@ func (oc *OpenstackClient) Create(cluster *clusterv1.Cluster, machine *clusterv1
 		}
 	}
 
-	instance, err = oc.machineService.InstanceCreate(providerConfig, startupScript, oc.sshCred.user)
+	instance, err = oc.machineService.InstanceCreate(machine.Name, providerConfig, startupScript, oc.sshCred.user)
 	if err != nil {
 		return oc.handleMachineError(machine, apierrors.CreateMachine(
 			"error creating Openstack instance: %v", err))
@@ -431,7 +431,7 @@ func (oc *OpenstackClient) instanceExists(machine *clusterv1.Machine) (instance 
 		return nil, err
 	}
 	opts := &clients.InstanceListOpts{
-		Name:   machineConfig.Name,
+		Name:   machine.Name,
 		Image:  machineConfig.Image,
 		Flavor: machineConfig.Flavor,
 	}


### PR DESCRIPTION
This commit removes the Name field from the provider config. Instead of accepting an arbitrary name, we should be using the one provided by the machine resource itself.

Closes #42 