### PR TITLE
 Recommend using v1.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 2. Create a cluster:
 
    ```bash
-   clusterctl create cluster --provider openstack -c examples/openstack/out/cluster.yaml -m examples/openstack/out/machines.yaml -p examples/openstack/out/provider-components.yaml
+   clusterctl create cluster --minikube kubernetes-version=v1.12.1 --provider openstack -c examples/openstack/out/cluster.yaml -m examples/openstack/out/machines.yaml -p examples/openstack/out/provider-components.yaml
    ```
 
 To choose a specific minikube driver, please use the `--vm-driver` command line parameter. For example to use the kvm2 driver with clusterctl you woud add `--vm-driver kvm2`, for linux, if you haven't installed any driver, you can add `--vm-driver none`.

--- a/cmd/clusterctl/examples/openstack/machines.yaml.template
+++ b/cmd/clusterctl/examples/openstack/machines.yaml.template
@@ -19,8 +19,8 @@ items:
         securityGroups:
         - default
     versions:
-      kubelet: 1.9.4
-      controlPlane: 1.9.4
+      kubelet: 1.12.1
+      controlPlane: 1.12.1
 - apiVersion: "cluster.k8s.io/v1alpha1"
   kind: Machine
   metadata:
@@ -41,4 +41,4 @@ items:
         securityGroups:
         - default
     versions:
-      kubelet: 1.9.4
+      kubelet: 1.12.1

--- a/cmd/clusterctl/examples/openstack/provider-components.yaml.template
+++ b/cmd/clusterctl/examples/openstack/provider-components.yaml.template
@@ -87,12 +87,18 @@ data:
 
         # Set up kubeadm config file to pass parameters to kubeadm init.
         cat > /etc/kubernetes/kubeadm_config.yaml <<EOF
-        apiVersion: kubeadm.k8s.io/v1alpha1
-        kind: MasterConfiguration
+        apiVersion: kubeadm.k8s.io/v1alpha3
+        kind: InitConfiguration
+        bootstrapTokens:
+        - token: ${TOKEN}
+        ---
+        apiVersion: kubeadm.k8s.io/v1alpha3
+        kind: ClusterConfiguration
+        kubernetesVersion: v${CONTROL_PLANE_VERSION}
         networking:
           serviceSubnet: ${SERVICE_CIDR}
-        kubernetesVersion: v${CONTROL_PLANE_VERSION}
-        token: ${TOKEN}
+        clusterName: kubernetes
+        controlPlaneEndpoint: ""
         controllerManagerExtraArgs:
           cluster-cidr: ${POD_CIDR}
           service-cluster-ip-range: ${SERVICE_CIDR}

--- a/cmd/clusterctl/examples/openstack/provider-components.yaml.template
+++ b/cmd/clusterctl/examples/openstack/provider-components.yaml.template
@@ -27,8 +27,8 @@ data:
   machine_setup_configs.yaml: |-
     items:
     - versions:
-          kubelet: 1.9.4
-          controlPlane: 1.9.4
+          kubelet: 1.12.1
+          controlPlane: 1.12.1
       startupScript: |
         set -e
         set -x
@@ -115,7 +115,7 @@ data:
         echo done.
         ) 2>&1 | tee /var/log/startup.log
     - versions:
-          kubelet: 1.9.4
+          kubelet: 1.12.1
       startupScript: |
         set -e
         set -x


### PR DESCRIPTION
Deployments using v1.10.0 are broken unless `--feature-gates=CustomResourceSubresources=true` is passed to the cluster creation and `.spec.subresources.status` is added to the CRD definition.

Rather than doing that and forcing the use of an older version of k8s, let's take this opportunity to update the minimum required version to the latest available.

More about this here: https://github.com/kubernetes-sigs/cluster-api/issues/533#issuecomment-430127733

/cc @Lion-Wei @chaosaffe