### PR TITLE
Remove hardcoded machine username

### DIFF
--- a/cmd/clusterctl/examples/openstack/machines.yaml.template
+++ b/cmd/clusterctl/examples/openstack/machines.yaml.template
@@ -12,6 +12,7 @@ items:
         kind: "OpenstackProviderConfig"
         flavor: m1.medium
         image: Ubuntu-Server-16.04-x64
+        sshUserName: ubuntu
         availabilityZone: nova
         networks:
         - uuid: ab14ce0d-5e1f-4e32-bf65-00416e3cc19c
@@ -34,6 +35,7 @@ items:
         kind: "OpenstackProviderConfig"
         flavor: m1.medium
         image: Ubuntu-Server-16.04-x64
+        sshUserName: ubuntu
         availabilityZone: nova
         networks:
         - uuid: ab14ce0d-5e1f-4e32-bf65-00416e3cc19c

--- a/pkg/apis/openstackproviderconfig/v1alpha1/types.go
+++ b/pkg/apis/openstackproviderconfig/v1alpha1/types.go
@@ -27,6 +27,10 @@ type OpenstackProviderConfig struct {
 	Flavor string `json:"flavor"`
 	// The name of the image to use for your server instance.
 	Image string `json:"image"`
+
+	// The machine ssh username
+	SshUserName string `json:"sshUserName,omitempty"`
+
 	// A networks object. Required parameter when there are multiple networks defined for the tenant.
 	// When you do not specify the networks parameter, the server attaches to the only network created for the current tenant.
 	Networks []NetworkParam `json:"networks,omitempty"`

--- a/pkg/cloud/openstack/machineactuator.go
+++ b/pkg/cloud/openstack/machineactuator.go
@@ -47,7 +47,6 @@ const (
 	SshPrivateKeyPath        = "/etc/sshkeys/private"
 	SshPublicKeyPath         = "/etc/sshkeys/public"
 	SshKeyUserPath           = "/etc/sshkeys/user"
-	SshUserName              = "ubuntu"
 	CloudConfigPath          = "/etc/cloud/cloud_config.yaml"
 	OpenstackIPAnnotationKey = "openstack-ip-address"
 	OpenstackIdAnnotationKey = "openstack-resourceId"
@@ -349,11 +348,16 @@ func (oc *OpenstackClient) GetKubeConfig(cluster *clusterv1.Cluster, master *clu
 		return "", err
 	}
 
+	machineConfig, err := oc.providerconfig(master.Spec.ProviderConfig)
+	if err != nil {
+		return "", err
+	}
+
 	result := strings.TrimSpace(util.ExecCommand(
 		"ssh", "-i", oc.sshCred.privateKeyPath,
 		"-o", "StrictHostKeyChecking no",
 		"-o", "UserKnownHostsFile /dev/null",
-		fmt.Sprintf("%s@%s", SshUserName, ip),
+		fmt.Sprintf("%s@%s", machineConfig.SshUserName, ip),
 		"echo STARTFILE; sudo cat /etc/kubernetes/admin.conf"))
 	parts := strings.Split(result, "STARTFILE")
 	if len(parts) != 2 {


### PR DESCRIPTION
Allow for passing the machine username in the providerConfig. This is
mostly needed by the `clusterctl` command and we should probably find a
better way to get the kubeconfig data. Until then, let's not hardcode
the username in the implementation.

Closes #66