### PR TITLE
Let clientconfig create the AuthOptions instance

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -60,7 +60,7 @@ spec:
         - name: machine-setup
           mountPath: /etc/machinesetup
         - name: cloud-config
-          mountPath: /etc/cloud
+          mountPath: /etc/openstack
         - name: kubeadm
           mountPath: /usr/bin/kubeadm
         resources:
@@ -70,6 +70,11 @@ spec:
           limits:
             cpu: 100m
             memory: 30Mi
+        env:
+          - name: USER
+            value: root
+          - name: OS_CLOUD
+            value: openstack
       volumes:
       - name: config
         hostPath:

--- a/pkg/cloud/openstack/clients/machineservice.go
+++ b/pkg/cloud/openstack/clients/machineservice.go
@@ -68,16 +68,11 @@ type InstanceListOpts struct {
 	Name string `q:"name"`
 }
 
-func NewInstanceService(cfg *clientconfig.Cloud) (*InstanceService, error) {
-	opts := &gophercloud.AuthOptions{
-		IdentityEndpoint: cfg.AuthInfo.AuthURL,
-		Username:         cfg.AuthInfo.Username,
-		Password:         cfg.AuthInfo.Password,
-		DomainName:       cfg.AuthInfo.DomainName,
-		TenantID:         cfg.AuthInfo.ProjectDomainID,
-		TenantName:       cfg.AuthInfo.ProjectDomainName,
-		TokenID:          cfg.AuthInfo.Token,
-		AllowReauth:      true,
+func NewInstanceService() (*InstanceService, error) {
+	clientOpts := new(clientconfig.ClientOpts)
+	opts, err := clientconfig.AuthOptions(clientOpts)
+	if err != nil {
+		return nil, err
 	}
 	provider, err := openstack.AuthenticatedClient(*opts)
 	if err != nil {
@@ -91,7 +86,7 @@ func NewInstanceService(cfg *clientconfig.Cloud) (*InstanceService, error) {
 		return nil, fmt.Errorf("Create identityClient err: %v", err)
 	}
 	serverClient, err := openstack.NewComputeV2(provider, gophercloud.EndpointOpts{
-		Region: cfg.RegionName,
+		Region: clientOpts.RegionName,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("Create serviceClient err: %v", err)

--- a/pkg/cloud/openstack/clients/machineservice_test.go
+++ b/pkg/cloud/openstack/clients/machineservice_test.go
@@ -19,18 +19,11 @@ package clients
 import (
 	"strings"
 	"testing"
-
-	"github.com/gophercloud/utils/openstack/clientconfig"
 )
 
 func TestMachineServiceInstance(t *testing.T) {
-	clientOpts := new(clientconfig.ClientOpts)
-	cloud, err := clientconfig.GetCloudFromYAML(clientOpts)
-	if err != nil {
-		t.Errorf("Couldn't create clientconfig")
-	}
-	_, err = NewInstanceService(cloud)
-	if !(strings.Contains(err.Error(), "i/o timeout")) {
+	_, err := NewInstanceService()
+	if !(strings.Contains(err.Error(), "[auth_url]")) {
 		t.Errorf("Couldn't create instance service: %v", err)
 	}
 }

--- a/pkg/cloud/openstack/machineactuator.go
+++ b/pkg/cloud/openstack/machineactuator.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
-	"github.com/gophercloud/utils/openstack/clientconfig"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	openstackconfigv1 "sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1"
@@ -73,12 +72,7 @@ type OpenstackClient struct {
 }
 
 func NewMachineActuator(machineClient client.Client, scheme *runtime.Scheme) (*OpenstackClient, error) {
-	clientOpts := new(clientconfig.ClientOpts)
-	cloud, err := clientconfig.GetCloudFromYAML(clientOpts)
-	if err != nil {
-		return nil, err
-	}
-	machineService, err := clients.NewInstanceService(cloud)
+	machineService, err := clients.NewInstanceService()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We were creating our own copy of AuthOptions rather than relying on the
utilities provided by clientconfig. Our copy didn't have all the info
required by gophercloud to authenticate.

Closes #69

