### PR TITLE
Get only the last line of the kubeadm token cmd

### DIFF
--- a/pkg/cloud/openstack/machineactuator.go
+++ b/pkg/cloud/openstack/machineactuator.go
@@ -445,7 +445,9 @@ func (oc *OpenstackClient) getKubeadmToken() (string, error) {
 		glog.Errorf("unable to create token: %v", err)
 		return "", err
 	}
-	return strings.TrimSpace(output), err
+
+	soutput := strings.Split(output, "\n")
+	return strings.TrimSpace(soutput[len(soutput)-1]), err
 }
 
 func (oc *OpenstackClient) validateMachine(machine *clusterv1.Machine, config *openstackconfigv1.OpenstackProviderConfig) *apierrors.MachineError {


### PR DESCRIPTION
Depending on the arguments passed to kubeadm, it may or may not output
more data to stdout. Since we're shelling out and depending on the
kubeadm cli to generate the token, this commit fixes the token parsing
by splitting the output into lines and getting the very last one.

This is far from ideal, as in we should not be depending on kubeadm to
generate the token. Until that is fixed, this patch seems to be a good
compromise.

Closes #74