### PR TITLE
Fix shabang of generate-yaml.sh

### DIFF
--- a/cmd/clusterctl/examples/openstack/generate-yaml.sh
+++ b/cmd/clusterctl/examples/openstack/generate-yaml.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 PWD=$(cd `dirname $0`; pwd)
 HOME_DIR=${PWD%%/cmd/clusterctl/examples/*}


### PR DESCRIPTION
**What this PR does / why we need it**:

This patch updates shebang from /bin/sh to /bin/bash of generate-yaml.sh

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #81 
