### PR TITLE
Added Role to kube-system to allow CAP-OS to create secrets

### DIFF
--- a/config/rbac/secrets_role.yaml
+++ b/config/rbac/secrets_role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: openstack-provider-manager-secrets-role
+  name: openstack-provider-manager-secrets
   namespace: kube-system
 rules:
 - apiGroups:

--- a/config/rbac/secrets_role.yaml
+++ b/config/rbac/secrets_role.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openstack-provider-manager-secrets-role
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create

--- a/config/rbac/secrets_role_binding.yaml
+++ b/config/rbac/secrets_role_binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openstack-provider-manager-secrets-rolebinding
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openstack-provider-manager-secrets-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: openstack-provider-system

--- a/config/rbac/secrets_role_binding.yaml
+++ b/config/rbac/secrets_role_binding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: openstack-provider-manager-secrets-rolebinding
+  name: openstack-provider-manager-secrets
   namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: openstack-provider-manager-secrets-role
+  name: openstack-provider-manager-secrets
 subjects:
 - kind: ServiceAccount
   name: default


### PR DESCRIPTION
**What this PR does / why we need it**:

When CAP-OS is deployed to the resulted cluster, it runs in the
namespace openstack-provider-system, and gets the default ServiceAccount
mounted in. Because of #78, CAP-OS needs to create secrets (bootstrap
tokens essentially are secrets) in namespace kube-system.

Created a Role and RoleBinding to allow this.

Using yaml files in config/rbac in favor of kubebuilder auto generation,
because this only works for ClusterRoles so far.
See https://github.com/kubernetes-sigs/kubebuilder/issues/401

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #93

**Special notes for your reviewer**:
How to test:

```
generate-yaml.sh -c ... -p ubuntu

configure machines.yaml and provider-components.yaml

clusterctl create cluster \
--minikube kubernetes-version=v1.12.2 \
--vm-driver hyperkit \
--provider openstack \
-c examples/openstack/ubuntu/out/cluster.yaml \
-m examples/openstack/ubuntu/out/machines.yaml \
-p examples/openstack/ubuntu/out/provider-components.yaml

wait until master and the one node appear.

create a new machine manually by hand. It should be created, come up
and join the cluster. (before there was an error in CAP-OS logs, see #93)
e.g.

apiVersion: cluster.k8s.io/v1alpha1
kind: Machine
metadata:
  generateName: openstack-node-
  labels:
    set: node
  name: openstack-node-manual
  namespace: default
spec:
  providerConfig:
    value:
      apiVersion: openstackproviderconfig/v1alpha1
      availabilityZone: es1
      flavor: m1.medium
      image: Ubuntu 16.04 Xenial Xerus - Latest
      kind: OpenstackProviderConfig
      networks:
      - uuid: e21aeb04-f98a-4c05-bc84-69441dbb304c
      securityGroups:
      - default
      - secgrp_docs
      sshUserName: ubuntu
  versions:
    kubelet: 1.12.1
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
