### PR TITLE
Add rudimentary cloud.conf support.

### DIFF
--- a/cmd/clusterctl/examples/openstack/centos/provider-components.yaml.template
+++ b/cmd/clusterctl/examples/openstack/centos/provider-components.yaml.template
@@ -76,11 +76,14 @@ data:
         cat <<EOF > /etc/default/kubelet
         KUBELET_KUBEADM_EXTRA_ARGS=--cgroup-driver=systemd
         EOF
+
         systemctl enable kubelet.service
 
         modprobe br_netfilter
         echo '1' > /proc/sys/net/bridge/bridge-nf-call-iptables
         echo '1' > /proc/sys/net/ipv4/ip_forward
+
+        echo $OPENSTACK_CLOUD_PROVIDER_CONF | base64 -d > /etc/kubernetes/cloud.conf
 
         # Set up kubeadm config file to pass parameters to kubeadm init.
         cat > /etc/kubernetes/kubeadm_config.yaml <<EOF
@@ -88,6 +91,10 @@ data:
         kind: InitConfiguration
         bootstrapTokens:
         - token: ${TOKEN}
+        nodeRegistration:
+          kubeletExtraArgs:
+            cloud-provider: "openstack"
+            cloud-config: "/etc/kubernetes/cloud.conf"
         ---
         apiVersion: kubeadm.k8s.io/v1alpha3
         kind: ClusterConfiguration
@@ -95,11 +102,24 @@ data:
         networking:
           serviceSubnet: ${SERVICE_CIDR}
         clusterName: kubernetes
+        apiServerExtraArgs:
+          cloud-provider: "openstack"
+          cloud-config: "/etc/kubernetes/cloud.conf"
+        apiServerExtraVolumes:
+        - name: cloud
+          hostPath: "/etc/kubernetes/cloud.conf"
+          mountPath: "/etc/kubernetes/cloud.conf"
         controlPlaneEndpoint: ""
         controllerManagerExtraArgs:
           cluster-cidr: ${POD_CIDR}
           service-cluster-ip-range: ${SERVICE_CIDR}
           allocate-node-cidrs: "true"
+          cloud-provider: "openstack"
+          cloud-config: "/etc/kubernetes/cloud.conf"
+        controllerManagerExtraVolumes:
+        - name: cloud
+          hostPath: "/etc/kubernetes/cloud.conf"
+          mountPath: "/etc/kubernetes/cloud.conf"
         EOF
         
         kubeadm init --config /etc/kubernetes/kubeadm_config.yaml

--- a/cmd/clusterctl/examples/openstack/ubuntu/provider-components.yaml.template
+++ b/cmd/clusterctl/examples/openstack/ubuntu/provider-components.yaml.template
@@ -93,6 +93,9 @@ data:
         [Service]
         Environment="KUBELET_DNS_ARGS=--cluster-dns=${CLUSTER_DNS_SERVER} --cluster-domain=${CLUSTER_DNS_DOMAIN}"
         EOF
+
+        echo $OPENSTACK_CLOUD_PROVIDER_CONF | base64 -d > /etc/kubernetes/cloud.conf
+
         systemctl daemon-reload
         systemctl restart kubelet.service
 
@@ -106,6 +109,10 @@ data:
         - token: ${TOKEN}
         apiEndpoint:
           bindPort: 443
+        nodeRegistration:
+          kubeletExtraArgs:
+            cloud-provider: "openstack"
+            cloud-config: "/etc/kubernetes/cloud.conf"
         ---
         apiVersion: kubeadm.k8s.io/v1alpha3
         kind: ClusterConfiguration
@@ -114,10 +121,23 @@ data:
           serviceSubnet: ${SERVICE_CIDR}
         clusterName: kubernetes
         controlPlaneEndpoint: ""
+        apiServerExtraArgs:
+          cloud-provider: "openstack"
+          cloud-config: "/etc/kubernetes/cloud.conf"
+        apiServerExtraVolumes:
+        - name: cloud
+          hostPath: "/etc/kubernetes/cloud.conf"
+          mountPath: "/etc/kubernetes/cloud.conf"
         controllerManagerExtraArgs:
           cluster-cidr: ${POD_CIDR}
           service-cluster-ip-range: ${SERVICE_CIDR}
           allocate-node-cidrs: "true"
+          cloud-provider: "openstack"
+          cloud-config: "/etc/kubernetes/cloud.conf"
+        controllerManagerExtraVolumes:
+        - name: cloud
+          hostPath: "/etc/kubernetes/cloud.conf"
+          mountPath: "/etc/kubernetes/cloud.conf"
         EOF
 
         # Create and set bridge-nf-call-iptables to 1 to pass the kubeadm preflight check.


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch adds rudimentary cloud provider support. It reuses the credentials given to generate-yaml.sh.

This changes the following:
    
* This uses yq to parse clouds.yaml, either the supplied one or the generated one.
* It changes region to region_name in the generated clouds.yaml.
* It embeds the cloud.conf in the provider-components, base64 encoded so that there will be no indentation problems.
* It adds the cloud-provider and cloud-config arguments.

**Which issue(s) this PR fixes**:
Fixes #65 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
Add support for cloud.conf. We will now generate and enable a cloud provider for the new cluster.
```
