### PR TITLE
Adding security group management to machine actuator

### DIFF
--- a/pkg/cloud/openstack/machine/annotations.go
+++ b/pkg/cloud/openstack/machine/annotations.go
@@ -1,0 +1,152 @@
+// Copyright © 2018 The Kubernetes Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package machine
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+
+	openstackconfigv1 "sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/openstack/clients"
+	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+)
+
+const (
+	OpenstackIPAnnotationKey = "openstack-ip-address"
+	OpenstackIdAnnotationKey = "openstack-resourceId"
+	// LastKnownSecurityGroups is the key to fetch the machine object annotation data,
+	// which contains the security groups that the machine actuator manages.
+	LastKnownSecurityGroups = "openstack-security-groups"
+)
+
+func (oc *OpenstackClient) updateAnnotation(machine *clusterv1.Machine, instance *clients.Instance, providerConfig *openstackconfigv1.OpenstackProviderConfig) error {
+
+	if machine.ObjectMeta.Annotations == nil {
+		machine.ObjectMeta.Annotations = make(map[string]string)
+	}
+
+	ip, err := getIPFromInstance(instance)
+	if err != nil {
+		return err
+	}
+
+	oc.updateMachineAnnotation(machine, OpenstackIPAnnotationKey, ip)
+	oc.updateMachineAnnotation(machine, OpenstackIdAnnotationKey, instance.ID)
+	if err := oc.updateMachineAnnotationJSON(machine, LastKnownSecurityGroups, listToMap(providerConfig.SecurityGroups)); err != nil {
+		return err
+	}
+
+	return oc.updateInstanceStatus(machine)
+}
+
+// updateMachineAnnotationJSON updates the `annotation` on `machine` with
+// `content`. `content` in this case should be a `map[string]interface{}`
+// suitable for turning into JSON. This `content` map will be marshalled into a
+// JSON string before being set as the given `annotation`.
+func (oc *OpenstackClient) updateMachineAnnotationJSON(machine *clusterv1.Machine, annotation string, content map[string]interface{}) error {
+	b, err := json.Marshal(content)
+	if err != nil {
+		return err
+	}
+
+	oc.updateMachineAnnotation(machine, annotation, string(b))
+
+	if err := oc.client.Update(nil, machine); err != nil {
+		return err
+	}
+	return nil
+}
+
+// updateMachineAnnotation updates the `annotation` on the given `machine` with
+// `content`.
+func (oc *OpenstackClient) updateMachineAnnotation(machine *clusterv1.Machine, annotation string, content string) {
+	// Get the annotations
+	annotations := machine.GetAnnotations()
+
+	// Set our annotation to the given content.
+	annotations[annotation] = content
+
+	// Update the machine object with these annotations
+	machine.SetAnnotations(annotations)
+}
+
+// Returns a map[string]interface from a JSON annotation.
+// This method gets the given `annotation` from the `machine` and unmarshalls it
+// from a JSON string into a `map[string]interface{}`.
+func (oc *OpenstackClient) machineAnnotationJSON(machine *clusterv1.Machine, annotation string) (map[string]interface{}, error) {
+	out := map[string]interface{}{}
+
+	jsonAnnotation := oc.machineAnnotation(machine, annotation)
+	if len(jsonAnnotation) == 0 {
+		return out, nil
+	}
+
+	err := json.Unmarshal([]byte(jsonAnnotation), &out)
+	if err != nil {
+		return out, err
+	}
+
+	return out, nil
+}
+
+// Fetches the specific machine annotation.
+func (oc *OpenstackClient) machineAnnotation(machine *clusterv1.Machine, annotation string) string {
+	return machine.GetAnnotations()[annotation]
+}
+
+func getIPFromInstance(instance *clients.Instance) (string, error) {
+	if instance.AccessIPv4 != "" && net.ParseIP(instance.AccessIPv4) != nil {
+		return instance.AccessIPv4, nil
+	}
+	type networkInterface struct {
+		Address string  `json:"addr"`
+		Version float64 `json:"version"`
+		Type    string  `json:"OS-EXT-IPS:type"`
+	}
+	var addrList []string
+
+	for _, b := range instance.Addresses {
+		list, err := json.Marshal(b)
+		if err != nil {
+			return "", fmt.Errorf("extract IP from instance err: %v", err)
+		}
+		var networks []interface{}
+		json.Unmarshal(list, &networks)
+		for _, network := range networks {
+			var netInterface networkInterface
+			b, _ := json.Marshal(network)
+			json.Unmarshal(b, &netInterface)
+			if netInterface.Version == 4.0 {
+				if netInterface.Type == "floating" {
+					return netInterface.Address, nil
+				}
+				addrList = append(addrList, netInterface.Address)
+			}
+		}
+	}
+	if len(addrList) != 0 {
+		return addrList[0], nil
+	}
+	return "", fmt.Errorf("extract IP from instance err")
+}
+
+// TODO make this a utility method elsewhere?
+func listToMap(content []string) map[string]interface{} {
+	mapK := make(map[string]interface{}, len(content))
+	for _, k := range content {
+		mapK[k] = struct{}{}
+	}
+	return mapK
+}

--- a/pkg/cloud/openstack/machine/security_groups.go
+++ b/pkg/cloud/openstack/machine/security_groups.go
@@ -1,0 +1,102 @@
+// Copyright © 2018 The Kubernetes Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package machine
+
+import (
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/secgroups"
+	openstackconfigv1 "sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1"
+	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+)
+
+func (oc *OpenstackClient) updateSecurityGroups(cluster *clusterv1.Cluster, machine *clusterv1.Machine, providerConfig *openstackconfigv1.OpenstackProviderConfig) (err error) {
+
+	serverID := machine.ObjectMeta.Annotations[OpenstackIdAnnotationKey]
+
+	annotationSecurityGroups, err := oc.machineAnnotationJSON(machine, LastKnownSecurityGroups)
+	if err != nil {
+		return err
+	}
+
+	specSecurityGroups := providerConfig.SecurityGroups
+	openstackServerSecurityGroups, err := oc.machineService.GetOpenstackSecurityGroups(serverID)
+	if err != nil {
+		return err
+	}
+
+	updatedSG := false
+	updatedAnnotation := copyAnnotation(annotationSecurityGroups)
+
+	// add security groups added to spec
+	addedSecurityGroups := []string{}
+	for _, sgName := range specSecurityGroups {
+		if _, ok := openstackServerSecurityGroups[sgName]; !ok {
+			addedSecurityGroups = append(addedSecurityGroups, sgName)
+		}
+	}
+
+	openstackProjectSecurityGroups := map[string]secgroups.SecurityGroup{}
+	if len(addedSecurityGroups) > 0 {
+		// need to get all openstack project security groups to correlate the sg name and sg ID
+		openstackProjectSecurityGroups, err = oc.machineService.GetAllOpenstackSecurityGroups()
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, sgName := range addedSecurityGroups {
+		if updatedSG, err = oc.machineService.AddSecurityGroup(sgName, serverID, openstackProjectSecurityGroups, updatedAnnotation); err != nil {
+			return err
+		}
+	}
+
+	// remove security groups deleted from spec
+	for sgName, sg := range openstackServerSecurityGroups {
+		_, previouslyExisted := annotationSecurityGroups[sgName]
+		if ok := !contains(specSecurityGroups, sgName) && previouslyExisted; ok {
+			if updatedSG, err = oc.machineService.RemoveSecurityGroup(sgName, sg.ID, serverID, updatedAnnotation); err != nil {
+				if updatedSG {
+					// If adding SG succeeds, but removing SG fails, still update annotation. Otherwise we can never remove that SG
+					oc.updateMachineAnnotationJSON(machine, LastKnownSecurityGroups, updatedAnnotation)
+				}
+				return err
+			}
+		}
+	}
+
+	if updatedSG {
+		if err := oc.updateMachineAnnotationJSON(machine, LastKnownSecurityGroups, updatedAnnotation); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func copyAnnotation(annotationSecurityGroups map[string]interface{}) map[string]interface{} {
+	copy := make(map[string]interface{}, len(annotationSecurityGroups))
+	for key, value := range annotationSecurityGroups {
+		copy[key] = value
+	}
+	return copy
+}
+
+func contains(slice []string, item string) bool {
+	set := make(map[string]struct{}, len(slice))
+	for _, s := range slice {
+		set[s] = struct{}{}
+	}
+
+	_, ok := set[item]
+	return ok
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**: Adding logic to machine actuator that allows addition and removal of security groups by editing the Machine Spec. This PR is currently assuming that all added security groups are already created in the OpenStack project, and therefore does not handle the actual creation or deletion of a security group. It simply adds/removes a security group to a machine. 

It stores all security groups that it manages within an annotation "openstack-security-groups". This allows a machine to have additional security groups that are managed externally to cluster-api if a user desires this behavior.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
