### PR TITLE
Don't hide manager's CLI flags

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -21,7 +21,6 @@ import (
 	"log"
 
 	"github.com/golang/glog"
-	"github.com/spf13/pflag"
 
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/apis"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/controller"
@@ -33,8 +32,7 @@ import (
 
 func main() {
 	// the following line exists to make glog happy, for more information, see: https://github.com/kubernetes/kubernetes/issues/17162
-	flag.CommandLine.Parse([]string{})
-	pflag.Parse()
+	flag.Parse()
 
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()


### PR DESCRIPTION
We were overriding the default flags with an empty list of flags and by parsing an empty string array.