### PR TITLE
Upgrade docker version on node

### DIFF
--- a/cmd/clusterctl/examples/openstack/ubuntu/provider-components.yaml.template
+++ b/cmd/clusterctl/examples/openstack/ubuntu/provider-components.yaml.template
@@ -166,7 +166,7 @@ data:
             echo "exit 101" > /usr/sbin/policy-rc.d
             chmod +x /usr/sbin/policy-rc.d
             trap "rm /usr/sbin/policy-rc.d" RETURN
-            apt-get install -y docker-engine=1.12.0-0~xenial
+            apt-get install -y docker.io
             echo 'DOCKER_OPTS="--iptables=false --ip-masq=false"' > /etc/default/docker
             systemctl daemon-reload
             systemctl enable docker


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR upgrades the docker version on nodes and makes it same as the master node. We need it because without this change if we generate provider-components.yaml using the current template the docker version on the node is 1.12 vs 18.06.1-ce on master. 

With older docker version there node is not able to come up properly. I tried with ubuntu 18.04 hosts.

```
Error response from daemon: oci runtime error: rootfs_linux.go:53: mounting "/sys/fs/cgroup" to rootfs "/var/lib/docker/aufs/mnt/" caused "no subsystem for mount"
```
## Host OS
ubuntu 18.04

## Without this change 
### Node gets stuck in NotReady 
As kubelet is not able to start calico and kube-proxy pods. 

```
root@openstack-master-bzzf6:/home/ubuntu# kubectl get nodes
NAME                     STATUS     ROLES    AGE    VERSION
openstack-master-bzzf6   Ready      master   132m   v1.12.1
openstack-node-ptbf6     NotReady   <none>   127m   v1.12.1
```
### Docker info on the node
```
root@openstack-node-zd7qd:/etc/systemd/system# docker info<br/>Containers: 52
 Running: 0
 Paused: 0
 Stopped: 52
Images: 2
Server Version: 1.12.0
Storage Driver: aufs
 Root Dir: /var/lib/docker/aufs
 Backing Filesystem: extfs
 Dirs: 107
 Dirperm1 Supported: true
Logging Driver: json-file
Cgroup Driver: cgroupfs
Plugins:
 Volume: local
 Network: null host bridge overlay
Swarm: inactive
Runtimes: runc
Default Runtime: runc
Security Options: apparmor seccomp
Kernel Version: 4.15.0-34-generic
Operating System: Ubuntu 18.04.1 LTS
OSType: linux
Architecture: x86_64
CPUs: 2
Total Memory: 3.852 GiB
Name: openstack-node-zd7qd
ID: 434Z:SQRU:FOTU:63QH:PIYE:XRXE:LAEM:3PEY:XC7S:V54K:TSVG:C6GX
Docker Root Dir: /var/lib/docker
Debug Mode (client): false
Debug Mode (server): false
Registry: https://index.docker.io/v1/
WARNING: No swap limit support
Insecure Registries:
 127.0.0.0/8
```

## With this change

### All pods are healthy

```
NAMESPACE                   NAME                                             READY     STATUS    RESTARTS   AGE
kube-system                 calico-node-9hcfw                                2/2       Running   0          26m
kube-system                 calico-node-t8x55                                2/2       Running   0          30m
kube-system                 coredns-576cbf47c7-5r7z5                         1/1       Running   0          30m
kube-system                 coredns-576cbf47c7-jprff                         1/1       Running   0          30m
kube-system                 etcd-openstack-master-k2n9q                      1/1       Running   0          29m
kube-system                 kube-apiserver-openstack-master-k2n9q            1/1       Running   0          29m
kube-system                 kube-controller-manager-openstack-master-k2n9q   1/1       Running   0          29m
kube-system                 kube-proxy-6r8x5                                 1/1       Running   0          30m
kube-system                 kube-proxy-zgjz4                                 1/1       Running   0          26m
kube-system                 kube-scheduler-openstack-master-k2n9q            1/1       Running   0          30m
openstack-provider-system   clusterapi-controllers-7f4dd664b6-c87cc          1/1       Running   0          30m
system                      controller-manager-0                             1/1       Running   0          30m
```
### Nodes are ready

```
NAME                     STATUS    ROLES     AGE       VERSION
openstack-master-k2n9q   Ready     master    32m       v1.12.1
openstack-node-d9cdt     Ready     <none>    27m       v1.12.1
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.
This PR doesn't change any image versions

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
