### PR TITLE
Update how generate-yaml.sh handles inplace sed for replacing image

### DIFF
--- a/cmd/clusterctl/examples/openstack/generate-yaml.sh
+++ b/cmd/clusterctl/examples/openstack/generate-yaml.sh
@@ -222,10 +222,8 @@ cat "$PROVIDERCOMPONENT_TEMPLATE_FILE" \
   | sed -e "s/\$MACHINE_CONTROLLER_SSH_PRIVATE/$MACHINE_CONTROLLER_SSH_PRIVATE/" \
   >> "$PROVIDERCOMPONENT_GENERATED_FILE"
 
-if [[ "$OS" =~ "Linux" ]]; then
+if [[ "$OS" =~ "Linux" || "$OS" =~ "Darwin" ]]; then
   sed -i "s#image: controller:latest#image: gcr.io/k8s-cluster-api/cluster-api-controller:latest#" "$PROVIDERCOMPONENT_GENERATED_FILE"
-elif [[ "$OS" =~ "Darwin" ]]; then
-  sed -i '' -e "s#image: controller:latest#image: gcr.io/k8s-cluster-api/cluster-api-controller:latest#" "$PROVIDERCOMPONENT_GENERATED_FILE"
 else
   echo "Unrecognized OS : $OS"
   exit 1


### PR DESCRIPTION
**What this PR does / why we need it**:

On OSX when I attempted to generate the files, the `sed` piece was failing with error but the file did exist on disk. I think the normal `sed -i` workflow should work fine on both Linux & Darwin. 

```
sed: can't read : No such file or directory
```

Signed-off-by: Steve Sloka <steves@heptio.com>
