### PR TITLE
Register cluster-api/pkg/controller for MachineSet and MachineDeployment

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -467,9 +467,10 @@
   version = "kubernetes-1.11.2"
 
 [[projects]]
-  digest = "1:51747a5c0ff0e54039ee78dcb3c9f2260725747f9a79f92813fb69b84ef07d4a"
+  digest = "1:6a8fca786f4e263fac02cb6cfe8f0decfee526aede3969d301e18fcef167cd38"
   name = "k8s.io/apimachinery"
   packages = [
+    "pkg/api/equality",
     "pkg/api/errors",
     "pkg/api/meta",
     "pkg/api/resource",
@@ -501,6 +502,7 @@
     "pkg/util/json",
     "pkg/util/mergepatch",
     "pkg/util/net",
+    "pkg/util/rand",
     "pkg/util/runtime",
     "pkg/util/sets",
     "pkg/util/strategicpatch",
@@ -655,9 +657,14 @@
     "pkg/client/clientset_generated/clientset",
     "pkg/client/clientset_generated/clientset/scheme",
     "pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1",
+    "pkg/controller",
     "pkg/controller/cluster",
     "pkg/controller/error",
     "pkg/controller/machine",
+    "pkg/controller/machinedeployment",
+    "pkg/controller/machinedeployment/util",
+    "pkg/controller/machineset",
+    "pkg/controller/node",
     "pkg/controller/noderefutil",
     "pkg/errors",
     "pkg/util",
@@ -751,6 +758,7 @@
     "sigs.k8s.io/cluster-api/pkg/apis/cluster/common",
     "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1",
     "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1",
+    "sigs.k8s.io/cluster-api/pkg/controller",
     "sigs.k8s.io/cluster-api/pkg/controller/cluster",
     "sigs.k8s.io/cluster-api/pkg/controller/machine",
     "sigs.k8s.io/cluster-api/pkg/errors",

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/apis"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/controller"
 	clusterapis "sigs.k8s.io/cluster-api/pkg/apis"
+	clusterv1controller "sigs.k8s.io/cluster-api/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
@@ -56,6 +57,11 @@ func main() {
 	}
 
 	if err := clusterapis.AddToScheme(mgr.GetScheme()); err != nil {
+		glog.Fatal(err)
+	}
+
+	// Setup MachineSet and MachineDeployment
+	if err := clusterv1controller.AddToManager(mgr); err != nil {
 		glog.Fatal(err)
 	}
 


### PR DESCRIPTION
Add cluster-api controller for machineSet and machineDeployment #120

**What this PR does / why we need it**:
Add controller for machineSet and machineDeployment/ Openstack controller doesn't include the controller for MachineSet and MachineDeployment any more.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #120 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

