### PR TITLE
Conf from secret

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -745,6 +745,8 @@
     "k8s.io/apimachinery/pkg/runtime/serializer/json",
     "k8s.io/apimachinery/pkg/util/json",
     "k8s.io/apimachinery/pkg/util/wait",
+    "k8s.io/client-go/kubernetes",
+    "k8s.io/client-go/tools/record",
     "k8s.io/cluster-bootstrap/token/api",
     "k8s.io/cluster-bootstrap/token/util",
     "k8s.io/code-generator/cmd/deepcopy-gen",

--- a/config/rbac/rbac_role.yaml
+++ b/config/rbac/rbac_role.yaml
@@ -42,3 +42,11 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch

--- a/pkg/apis/openstackproviderconfig/v1alpha1/types.go
+++ b/pkg/apis/openstackproviderconfig/v1alpha1/types.go
@@ -28,10 +28,20 @@ import (
 // TODO(cglaubitz): We might consider to change this to OpenstackMachineProviderSpec
 type OpenstackProviderSpec struct {
 	metav1.TypeMeta `json:",inline"`
+
+	// The name of the secret containing the openstack credentials
+	CloudsSecret string `json:"cloudsSecret"`
+
+	// The name of the cloud to use from the clouds secret
+	CloudName string `json:"cloudName"`
+
 	// The flavor reference for the flavor for your server instance.
 	Flavor string `json:"flavor"`
 	// The name of the image to use for your server instance.
 	Image string `json:"image"`
+
+	// The ssh key to inject in the instance
+	KeyName string `json:"keyName,omitempty"`
 
 	// The machine ssh username
 	SshUserName string `json:"sshUserName,omitempty"`

--- a/pkg/cloud/openstack/clients/machineservice.go
+++ b/pkg/cloud/openstack/clients/machineservice.go
@@ -20,6 +20,9 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/yaml"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/floatingips"
@@ -29,9 +32,13 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/pagination"
 	"github.com/gophercloud/utils/openstack/clientconfig"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
 	openstackconfigv1 "sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1"
+	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
+
+const CloudsSecretKey = "clouds.yaml"
 
 type InstanceService struct {
 	provider       *gophercloud.ProviderClient
@@ -71,12 +78,71 @@ type InstanceListOpts struct {
 	Name string `q:"name"`
 }
 
-func NewInstanceService() (*InstanceService, error) {
-	clientOpts := new(clientconfig.ClientOpts)
-	opts, err := clientconfig.AuthOptions(clientOpts)
+func GetCloudFromSecret(kubeClient kubernetes.Interface, namespace string, secretName string, cloudName string) (clientconfig.Cloud, error) {
+	emptyCloud := clientconfig.Cloud{}
+
+	if secretName == "" {
+		return emptyCloud, nil
+	}
+
+	if secretName != "" && cloudName == "" {
+		return emptyCloud, fmt.Errorf("Secret name set to %v but no cloud was specified. Please set cloud_name in your machine spec.", secretName)
+	}
+
+	secret, err := kubeClient.CoreV1().Secrets(namespace).Get(secretName, metav1.GetOptions{})
+	if err != nil {
+		return emptyCloud, err
+	}
+
+	content, ok := secret.Data[CloudsSecretKey]
+	if !ok {
+		return emptyCloud, fmt.Errorf("OpenStack credentials secret %v did not contain key %v",
+			secretName, CloudsSecretKey)
+	}
+	var clouds clientconfig.Clouds
+	err = yaml.Unmarshal(content, &clouds)
+	if err != nil {
+		return emptyCloud, fmt.Errorf("failed to unmarshal clouds credentials stored in secret %v: %v", secretName, err)
+	}
+
+	return clouds.Clouds[cloudName], nil
+}
+
+// TODO: Eventually we'll have a NewInstanceServiceFromCluster too
+func NewInstanceServiceFromMachine(kubeClient kubernetes.Interface, machine *clusterv1.Machine) (*InstanceService, error) {
+	machineSpec, err := openstackconfigv1.MachineSpecFromProviderSpec(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, err
 	}
+	cloud, err := GetCloudFromSecret(kubeClient, machine.Namespace, machineSpec.CloudsSecret, machineSpec.CloudName)
+	if err != nil {
+		return nil, err
+	}
+	return NewInstanceServiceFromCloud(cloud)
+}
+
+func NewInstanceService() (*InstanceService, error) {
+	cloud := clientconfig.Cloud{}
+	return NewInstanceServiceFromCloud(cloud)
+}
+
+func NewInstanceServiceFromCloud(cloud clientconfig.Cloud) (*InstanceService, error) {
+	clientOpts := new(clientconfig.ClientOpts)
+	var opts *gophercloud.AuthOptions
+
+	if cloud.AuthInfo != nil {
+		clientOpts.AuthInfo = cloud.AuthInfo
+		clientOpts.AuthType = cloud.AuthType
+		clientOpts.Cloud = cloud.Cloud
+		clientOpts.RegionName = cloud.RegionName
+	}
+
+	opts, err := clientconfig.AuthOptions(clientOpts)
+
+	if err != nil {
+		return nil, err
+	}
+
 	provider, err := openstack.AuthenticatedClient(*opts)
 	if err != nil {
 		return nil, fmt.Errorf("Create providerClient err: %v", err)

--- a/pkg/cloud/openstack/cluster/actuator.go
+++ b/pkg/cloud/openstack/cluster/actuator.go
@@ -6,25 +6,19 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/klog"
 	providerv1 "sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/openstack"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	client "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1"
 )
 
 type Actuator struct {
+	params         openstack.ActuatorParams
 	clustersGetter client.ClustersGetter
 }
 
-// ActuatorParams holds parameter information for Actuator
-type ActuatorParams struct {
-	ClustersGetter client.ClustersGetter
-}
-
 // NewActuator creates a new Actuator
-func NewActuator(params ActuatorParams) (*Actuator, error) {
-	res := &Actuator{
-		clustersGetter: params.ClustersGetter,
-	}
-
+func NewActuator(params openstack.ActuatorParams) (*Actuator, error) {
+	res := &Actuator{params: params}
 	return res, nil
 }
 

--- a/pkg/cloud/openstack/types.go
+++ b/pkg/cloud/openstack/types.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// ActuatorParams holds parameter information for Actuator
+type ActuatorParams struct {
+	KubeClient       kubernetes.Interface
+	Client           client.Client
+	EventRecorder    record.EventRecorder
+    Scheme           *runtime.Scheme
+}

--- a/pkg/cloud/openstack/types.go
+++ b/pkg/cloud/openstack/types.go
@@ -17,16 +17,16 @@ limitations under the License.
 package openstack
 
 import (
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // ActuatorParams holds parameter information for Actuator
 type ActuatorParams struct {
-	KubeClient       kubernetes.Interface
-	Client           client.Client
-	EventRecorder    record.EventRecorder
-    Scheme           *runtime.Scheme
+	KubeClient    kubernetes.Interface
+	Client        client.Client
+	EventRecorder record.EventRecorder
+	Scheme        *runtime.Scheme
 }

--- a/pkg/controller/add_cluster.go
+++ b/pkg/controller/add_cluster.go
@@ -25,7 +25,8 @@ import (
 func init() {
 	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
 	AddToManagerFuncs = append(AddToManagerFuncs, func(m manager.Manager) error {
-		clusterActuator, err := occ.NewActuator(occ.ActuatorParams{})
+		params := getActuatorParams(m)
+		clusterActuator, err := occ.NewActuator(params)
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/add_machine.go
+++ b/pkg/controller/add_machine.go
@@ -25,7 +25,8 @@ import (
 func init() {
 	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
 	AddToManagerFuncs = append(AddToManagerFuncs, func(m manager.Manager) error {
-		machineActuator, err := ocm.NewActuator(m.GetClient(), m.GetScheme())
+		params := getActuatorParams(m)
+		machineActuator, err := ocm.NewActuator(params)
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -17,6 +17,10 @@ limitations under the License.
 package controller
 
 import (
+	"k8s.io/klog"
+
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/openstack"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
@@ -32,4 +36,21 @@ func AddToManager(m manager.Manager) error {
 	}
 
 	return nil
+}
+
+func getActuatorParams(mgr manager.Manager) openstack.ActuatorParams {
+	config := mgr.GetConfig()
+
+	kubeClient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		klog.Fatalf("Could not create kubernetes client to talk to the apiserver: %v", err)
+	}
+
+	return openstack.ActuatorParams{
+		Client:        mgr.GetClient(),
+		KubeClient:    kubeClient,
+		Scheme:        mgr.GetScheme(),
+		EventRecorder: mgr.GetRecorder("openstack-controller"),
+	}
+
 }


### PR DESCRIPTION
Allow for the actuator to gather its configs from a secret.

The config parsing logic is as follows:

- Check if the machine has `CloudsSecret` set. If yes, get the secret, load the cloud from it using the value of `CloudName` (default is "openstack"), and use the credentials of this cloud.
- If `CloudSecret` is not set, check for `clouds.yaml` files in the container and proceed using the standard flow.

Some things to note:
- As of now, if the `OS_CLOUD` env variable is set, and there's a `clouds.yaml` file in the container with a cloud corresponding to `OS_CLOUD`, it'll overwrite the one loaded from the secret.
- The current implementation requires setting `CloudsSecret` on every machine definition. Future patches PRs will allow for setting `CloudsSecret` in the cluster spec too.

Fixes #130 

Note to reviewers:

I'm sure there are lots of things that could be improved, changed, etc in this patch. Unfortunately, we're still cleaning up the actuator code and there's only so much I could implement without having to refactor most of it. More patches to come to improve this implementation and the rest of the actuator.
