### PR TITLE
[WIP] Overhaul to the way cloud.conf and clouds.yaml are handled

### DIFF
--- a/cmd/clusterctl/examples/openstack/ubuntu/provider-components.yaml.template
+++ b/cmd/clusterctl/examples/openstack/ubuntu/provider-components.yaml.template
@@ -16,8 +16,18 @@ metadata:
   name: cloud-config
   namespace: openstack-provider-system
 data:
-  clouds.yaml: $OPENSTACK_CLOUD_CONFIG
+  cloud.conf: $OPENSTACK_CLOUD_PROVIDER_CONF
 ---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: clouds
+  namespace: openstack-provider-system
+data:
+  clouds.yaml: $OPENSTACK_CLOUDS
+---
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -93,8 +103,6 @@ data:
         [Service]
         Environment="KUBELET_DNS_ARGS=--cluster-dns=${CLUSTER_DNS_SERVER} --cluster-domain=${CLUSTER_DNS_DOMAIN}"
         EOF
-
-        echo $OPENSTACK_CLOUD_PROVIDER_CONF | base64 -d > /etc/kubernetes/cloud.conf
 
         systemctl daemon-reload
         systemctl restart kubelet.service

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -51,7 +51,9 @@ spec:
       - name: openstack-machine-controller
         image: k8scloudprovider/openstack-cluster-api-controller:latest
         volumeMounts:
-        - name: config
+        - name: clouds
+          mountPath: /etc/openstack
+        - name: cloud-config
           mountPath: /etc/kubernetes
         - name: certs
           mountPath: /etc/ssl/certs
@@ -59,8 +61,6 @@ spec:
           mountPath: /etc/sshkeys
         - name: machine-setup
           mountPath: /etc/machinesetup
-        - name: cloud-config
-          mountPath: /etc/openstack
         - name: kubeadm
           mountPath: /usr/bin/kubeadm
         resources:
@@ -76,9 +76,12 @@ spec:
           - name: OS_CLOUD
             value: {OS_CLOUD}
       volumes:
-      - name: config
-        hostPath:
-          path: /etc/kubernetes
+      - name: clouds
+        secret:
+          secretName: clouds
+      - name: cloud-config
+        secret:
+          secretName: cloud-config
       - name: certs
         hostPath:
           path: /etc/ssl/certs
@@ -86,9 +89,6 @@ spec:
         secret:
           secretName: machine-controller-sshkeys
           defaultMode: 256
-      - name: cloud-config
-        secret:
-          secretName: cloud-config
       - name: machine-setup
         configMap:
           name: machine-setup


### PR DESCRIPTION
**What this PR does / why we need it**: makes a number of changes to how clouds.yaml and cloud.conf are handled
1. moves cloud.conf into a secret to keep user credentials secure
2. allows for passing of custom cloud.conf in generate-yaml.sh script
3. Aligns usage of cloud.conf and clouds.yaml with https://github.com/kubernetes/cloud-provider-openstack/pull/350

**Requires** cloud-provider-openstack to be implemented, and for pull #350 in cloud-provider-openstack to go through.

**Which issue(s) this PR fixes** #125 #85

**Special notes for your reviewer**: 

**Release note**:
```release-note
```
