### PR TITLE
Check jq first

### DIFF
--- a/cmd/clusterctl/examples/openstack/generate-yaml.sh
+++ b/cmd/clusterctl/examples/openstack/generate-yaml.sh
@@ -91,6 +91,12 @@ if ! hash yq 2>/dev/null; then
   exit 1
 fi
 
+if ! hash jq 2>/dev/null; then
+  echo "'jq' is not available, please install it. for example, `pip install jq`"
+  print_help
+  exit 1
+fi
+
 yq_type=$(file $(which yq))
 if [[ $yq_type == *"Python script"* ]]; then
   echo "Wrong version of 'yq' installed, please install the one from https://github.com/mikefarah/yq"


### PR DESCRIPTION
if jq not exist, it will complain after all cloud param input complete
this is not efficient, so check before generate cloud configuration files.

**What this PR does / why we need it**:
avoid find issue after input all param

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
```release-note
NONE
```
