### PR TITLE
Explicitly require OS_CLOUD to be set

### DIFF
--- a/cmd/clusterctl/examples/openstack/generate-yaml.sh
+++ b/cmd/clusterctl/examples/openstack/generate-yaml.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-# Function that prints out the help message, describing the script 
+# Function that prints out the help message, describing the script
 print_help()
 {
   echo "$SCRIPT - generates input yaml files for Cluster API on openstack"
@@ -85,6 +85,11 @@ if test -z "$SUPPORTED_PROVIDER_OS"; then
   exit 1
 fi
 
+if [ -z "$OS_CLOUD" ]; then
+  echo "OS_CLOUD environment variable is not set. Please set OS_CLOUD before running this script."
+  exit 1
+fi
+
 if ! hash yq 2>/dev/null; then
   echo "'yq' is not available, please install it. (https://github.com/kislyuk/yq)"
   print_help
@@ -118,7 +123,7 @@ MACHINE_CONTROLLER_SSH_HOME=${HOME}/.ssh/
 
 OVERWRITE=${OVERWRITE:-0}
 CLOUDS_PATH=${CLOUDS_PATH:-""}
-CLOUD="${OS_CLOUD}" 
+
 
 if [ $OVERWRITE -ne 1 ] && [ -f "$MACHINE_GENERATED_FILE" ]; then
   echo "File $MACHINE_GENERATED_FILE already exists. Delete it manually before running this script."
@@ -135,14 +140,10 @@ if [ $OVERWRITE -ne 1 ] && [ -f "$PROVIDERCOMPONENT_GENERATED_FILE" ]; then
   exit 1
 fi
 
-if [ -z "$CLOUD" ]; then
-  CLOUD=openstack
-fi
-
 mkdir -p "${OUTPUT_DIR}"
 
 if [ -n "$CLOUDS_PATH" ]; then
-  # Read clouds.yaml from file if a path is provided 
+  # Read clouds.yaml from file if a path is provided
   OPENSTACK_CLOUD_CONFIG_PLAIN=$(cat "$CLOUDS_PATH")
 else
   # Collect user input to generate a clouds.yaml file
@@ -166,12 +167,12 @@ else
 fi
 
 # Just blindly parse the cloud.conf here, overwriting old vars.
-AUTH_URL=$(echo "$OPENSTACK_CLOUD_CONFIG_PLAIN" | yq -r .clouds.$CLOUD.auth.auth_url)
-USERNAME=$(echo "$OPENSTACK_CLOUD_CONFIG_PLAIN" | yq -r .clouds.$CLOUD.auth.username)
-PASSWORD=$(echo "$OPENSTACK_CLOUD_CONFIG_PLAIN" | yq -r .clouds.$CLOUD.auth.password)
-REGION=$(echo "$OPENSTACK_CLOUD_CONFIG_PLAIN" | yq -r .clouds.$CLOUD.region_name)
-PROJECT_ID=$(echo "$OPENSTACK_CLOUD_CONFIG_PLAIN" | yq -r .clouds.$CLOUD.auth.project_id)
-DOMAIN_NAME=$(echo "$OPENSTACK_CLOUD_CONFIG_PLAIN" | yq -r .clouds.$CLOUD.auth.user_domain_name)
+AUTH_URL=$(echo "$OPENSTACK_CLOUD_CONFIG_PLAIN" | yq -r .clouds.$OS_CLOUD.auth.auth_url)
+USERNAME=$(echo "$OPENSTACK_CLOUD_CONFIG_PLAIN" | yq -r .clouds.$OS_CLOUD.auth.username)
+PASSWORD=$(echo "$OPENSTACK_CLOUD_CONFIG_PLAIN" | yq -r .clouds.$OS_CLOUD.auth.password)
+REGION=$(echo "$OPENSTACK_CLOUD_CONFIG_PLAIN" | yq -r .clouds.$OS_CLOUD.region_name)
+PROJECT_ID=$(echo "$OPENSTACK_CLOUD_CONFIG_PLAIN" | yq -r .clouds.$OS_CLOUD.auth.project_id)
+DOMAIN_NAME=$(echo "$OPENSTACK_CLOUD_CONFIG_PLAIN" | yq -r .clouds.$OS_CLOUD.auth.user_domain_name)
 
 
 # Basic cloud.conf, no LB configuration as that data is not known yet.
@@ -223,7 +224,7 @@ do
 done
 for file in `ls "${PROVIDER_MANAGER_DIR}"`
 do
-    sed "s/{OS_CLOUD}/$CLOUD/g" "${PROVIDER_MANAGER_DIR}/${file}" >> "$PROVIDERCOMPONENT_GENERATED_FILE"
+    sed "s/{OS_CLOUD}/$OS_CLOUD/g" "${PROVIDER_MANAGER_DIR}/${file}" >> "$PROVIDERCOMPONENT_GENERATED_FILE"
     echo "---" >> "$PROVIDERCOMPONENT_GENERATED_FILE"
 done
 for file in `ls "${CLUSTER_MANAGER_DIR}"`
@@ -268,4 +269,3 @@ cat "$CLUSTER_TEMPLATE_FILE" \
 
 echo "Done generating $PROVIDERCOMPONENT_GENERATED_FILE $MACHINE_GENERATED_FILE $CLUSTER_GENERATED_FILE"
 echo "You should now manually change your cluster configuration by editing the generated files."
-


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Enforces `OS_CLOUD` being set to ensure the correct cloud.conf is extracted
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
