### PR TITLE
WIP Configure Calico default ippool to POD_CIDR

### DIFF
--- a/cmd/clusterctl/examples/openstack/centos/provider-components.yaml.template
+++ b/cmd/clusterctl/examples/openstack/centos/provider-components.yaml.template
@@ -133,6 +133,11 @@ data:
         # By default, use calico for container network plugin, should make this configurable.
         kubectl --kubeconfig /etc/kubernetes/admin.conf apply -f https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml
         kubectl --kubeconfig /etc/kubernetes/admin.conf apply -f https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml
+        # Fixing default ipv4 pool of calico to configured POD_CIDR
+        for tries in $(seq 1 60); do
+            kubectl --kubeconfig /etc/kubernetes/admin.conf patch ippools.crd.projectcalico.org/default-ipv4-ippool --type='json' -p="[{\"op\": \"replace\", \"path\": \"/spec/cidr\", \"value\":\"$POD_CIDR\"}]" && break
+            sleep 5
+        done
 
         mkdir -p /root/.kube
         cp -i /etc/kubernetes/admin.conf /root/.kube/config

--- a/cmd/clusterctl/examples/openstack/ubuntu/provider-components.yaml.template
+++ b/cmd/clusterctl/examples/openstack/ubuntu/provider-components.yaml.template
@@ -153,6 +153,11 @@ data:
         # By default, use calico for container network plugin, should make this configurable.
         kubectl --kubeconfig /etc/kubernetes/admin.conf apply -f https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml
         kubectl --kubeconfig /etc/kubernetes/admin.conf apply -f https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml
+        # Fixing default ipv4 pool of calico to configured POD_CIDR
+        for tries in $(seq 1 60); do
+            kubectl --kubeconfig /etc/kubernetes/admin.conf patch ippools.crd.projectcalico.org/default-ipv4-ippool --type='json' -p="[{\"op\": \"replace\", \"path\": \"/spec/cidr\", \"value\":\"$POD_CIDR\"}]" && break
+            sleep 5
+        done
         echo done.
         ) 2>&1 | tee /var/log/startup.log
     - versions:


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

When changing the PodCIDR in the cluster spec, kubernetes will happily
use this, but networking won't work. This is because the default calico
deployment hard coded 192.168.0.0/24 in the default ip pool.

Decided to patch the created ippool over using sed on calico.yaml,
because of sed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
