### PR TITLE
Disable ufw on ubuntu #149

### DIFF
--- a/cmd/clusterctl/examples/openstack/ubuntu/provider-components.yaml.template
+++ b/cmd/clusterctl/examples/openstack/ubuntu/provider-components.yaml.template
@@ -253,7 +253,6 @@ data:
         # Reset iptables config  
         cat > /etc/systemd/system/docker.service.d/10-iptables.conf <<EOF
         [Service]
-        # Yes, we need to clear it, because otherwise it is addative!
         ExecStart=
         ExecStart=/usr/bin/dockerd -H fd:// --iptables=false --ip-masq=false
         EOF

--- a/cmd/clusterctl/examples/openstack/ubuntu/provider-components.yaml.template
+++ b/cmd/clusterctl/examples/openstack/ubuntu/provider-components.yaml.template
@@ -257,6 +257,7 @@ data:
         ExecStart=
         ExecStart=/usr/bin/dockerd -H fd:// $DOCKER_OPTS
         EOF
+
         systemctl daemon-reload
         systemctl disable ufw 
 

--- a/cmd/clusterctl/examples/openstack/ubuntu/provider-components.yaml.template
+++ b/cmd/clusterctl/examples/openstack/ubuntu/provider-components.yaml.template
@@ -253,6 +253,7 @@ data:
         # Reset iptables config  
         cat > /etc/systemd/system/docker.service.d/10-iptables.conf <<EOF
         [Service]
+        EnvironmentFile=/etc/default/docker
         ExecStart=
         ExecStart=/usr/bin/dockerd -H fd:// --iptables=false --ip-masq=false
         EOF

--- a/cmd/clusterctl/examples/openstack/ubuntu/provider-components.yaml.template
+++ b/cmd/clusterctl/examples/openstack/ubuntu/provider-components.yaml.template
@@ -255,7 +255,7 @@ data:
         [Service]
         EnvironmentFile=/etc/default/docker
         ExecStart=
-        ExecStart=/usr/bin/dockerd -H fd:// --iptables=false --ip-masq=false
+        ExecStart=/usr/bin/dockerd -H fd:// $DOCKER_OPTS
         EOF
         systemctl daemon-reload
         systemctl disable ufw 

--- a/cmd/clusterctl/examples/openstack/ubuntu/provider-components.yaml.template
+++ b/cmd/clusterctl/examples/openstack/ubuntu/provider-components.yaml.template
@@ -251,7 +251,7 @@ data:
         systemctl restart kubelet.service
         
         # Reset iptables config  
-        cat > /etc/systemd/system/docker.service.d/iptables.conf <<EOF
+        cat > /etc/systemd/system/docker.service.d/10-iptables.conf <<EOF
         [Service]
         # Yes, we need to clear it, because otherwise it is addative!
         ExecStart=

--- a/cmd/clusterctl/examples/openstack/ubuntu/provider-components.yaml.template
+++ b/cmd/clusterctl/examples/openstack/ubuntu/provider-components.yaml.template
@@ -249,6 +249,17 @@ data:
         EOF
         systemctl daemon-reload
         systemctl restart kubelet.service
+        
+        # Reset iptables config  
+        cat > /etc/systemd/system/docker.service.d/iptables.conf <<EOF
+        [Service]
+        # Yes, we need to clear it, because otherwise it is addative!
+        ExecStart=
+        ExecStart=/usr/bin/dockerd -H fd:// --iptables=false --ip-masq=false
+        EOF
+        systemctl daemon-reload
+        systemctl disable ufw 
+
         kubeadm join --ignore-preflight-errors=all --config /etc/kubernetes/kubeadm_config.yaml
         for tries in $(seq 1 60); do
         	kubectl --kubeconfig /etc/kubernetes/kubelet.conf annotate --overwrite node $(hostname) machine=${MACHINE} && break


### PR DESCRIPTION
**What this PR does / why we need it**:  Disable ufw on ubuntu 

We don't have access from inside the pod because ufw block the traffic. 

We need to allow external clients such as kubectl and kubelet to access the Kubernets API, so we should disable the firewall or create new iptables rules. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #149 


