### PR TITLE
Drop unnecessary slash in TEMPLATE_PATH.

### DIFF
--- a/cmd/clusterctl/examples/openstack/generate-yaml.sh
+++ b/cmd/clusterctl/examples/openstack/generate-yaml.sh
@@ -105,7 +105,7 @@ fi
 
 # Define global variables
 PWD=$(cd `dirname $0`; pwd)
-TEMPLATES_PATH=${TEMPLATES_PATH:-$PWD/$SUPPORTED_PROVIDER_OS/}
+TEMPLATES_PATH=${TEMPLATES_PATH:-$PWD/$SUPPORTED_PROVIDER_OS}
 HOME_DIR=${PWD%%/cmd/clusterctl/examples/*}
 OUTPUT_DIR="${TEMPLATES_PATH}/out"
 PROVIDER_CRD_DIR="${HOME_DIR}/config/crd"


### PR DESCRIPTION
Issue #166 reported an unnecessary extra slash at the end of the
default value of TEMPLATE_PATH in this script.  This removes it.
