### PR TITLE
Fix incorrect debug info after generate-yaml

### DIFF
--- a/cmd/clusterctl/examples/openstack/generate-yaml.sh
+++ b/cmd/clusterctl/examples/openstack/generate-yaml.sh
@@ -105,7 +105,7 @@ fi
 
 # Define global variables
 PWD=$(cd `dirname $0`; pwd)
-TEMPLATES_PATH=${TEMPLATES_PATH:-$PWD/$SUPPORTED_PROVIDER_OS/}
+TEMPLATES_PATH=${TEMPLATES_PATH:-$PWD/$SUPPORTED_PROVIDER_OS}
 HOME_DIR=${PWD%%/cmd/clusterctl/examples/*}
 OUTPUT_DIR="${TEMPLATES_PATH}/out"
 PROVIDER_CRD_DIR="${HOME_DIR}/config/crd"


### PR DESCRIPTION
**What this PR does / why we need it**:
fix incorrect path description, in future it may corrupt scripting arch.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #166 

