### PR TITLE
Remove MasterEndpoint string in favour of a function

### DIFF
--- a/cmd/clusterctl/examples/openstack/centos/provider-components.yaml.template
+++ b/cmd/clusterctl/examples/openstack/centos/provider-components.yaml.template
@@ -149,7 +149,7 @@ data:
         (
         KUBELET_VERSION={{ .Machine.Spec.Versions.Kubelet }}
         TOKEN={{ .Token }}
-        MASTER={{ .MasterEndpoint }}
+        MASTER={{ call .GetMasterEndpoint }}
         NAMESPACE={{ .Machine.ObjectMeta.Namespace }}
         MACHINE=$NAMESPACE
         MACHINE+="/"

--- a/cmd/clusterctl/examples/openstack/ubuntu/provider-components.yaml.template
+++ b/cmd/clusterctl/examples/openstack/ubuntu/provider-components.yaml.template
@@ -164,7 +164,7 @@ data:
         (
         KUBELET_VERSION={{ .Machine.Spec.Versions.Kubelet }}
         TOKEN={{ .Token }}
-        MASTER={{ .MasterEndpoint }}
+        MASTER={{ call .GetMasterEndpoint }}
         NAMESPACE={{ .Machine.ObjectMeta.Namespace }}
         MACHINE=$NAMESPACE
         MACHINE+="/"

--- a/pkg/cloud/openstack/machine/machineScript.go
+++ b/pkg/cloud/openstack/machine/machineScript.go
@@ -33,9 +33,9 @@ type setupParams struct {
 	Machine     *clusterv1.Machine
 	MachineSpec *openstackconfigv1.OpenstackProviderSpec
 
-	PodCIDR        string
-	ServiceCIDR    string
-	MasterEndpoint string
+	PodCIDR           string
+	ServiceCIDR       string
+	GetMasterEndpoint func() (string, error)
 }
 
 func init() {
@@ -65,23 +65,26 @@ func masterStartupScript(cluster *clusterv1.Cluster, machine *clusterv1.Machine,
 }
 
 func nodeStartupScript(cluster *clusterv1.Cluster, machine *clusterv1.Machine, token, script string) (string, error) {
-	if len(cluster.Status.APIEndpoints) == 0 {
-		return "", errors.New("no cluster status found")
-	}
-
 	machineSpec, err := openstackconfigv1.MachineSpecFromProviderSpec(machine.Spec.ProviderSpec)
 	if err != nil {
 		return "", err
 	}
 
+	GetMasterEndpoint := func() (string, error) {
+		if len(cluster.Status.APIEndpoints) == 0 {
+			return "", errors.New("no cluster status found")
+		}
+		return getEndpoint(cluster.Status.APIEndpoints[0]), nil
+	}
+
 	params := setupParams{
-		Token:          token,
-		Cluster:        cluster,
-		Machine:        machine,
-		MachineSpec:    machineSpec,
-		PodCIDR:        getSubnet(cluster.Spec.ClusterNetwork.Pods),
-		ServiceCIDR:    getSubnet(cluster.Spec.ClusterNetwork.Services),
-		MasterEndpoint: getEndpoint(cluster.Status.APIEndpoints[0]),
+		Token:             token,
+		Cluster:           cluster,
+		Machine:           machine,
+		MachineSpec:       machineSpec,
+		PodCIDR:           getSubnet(cluster.Spec.ClusterNetwork.Pods),
+		ServiceCIDR:       getSubnet(cluster.Spec.ClusterNetwork.Services),
+		GetMasterEndpoint: GetMasterEndpoint,
 	}
 
 	nodeStartUpScript := template.Must(template.New("nodeStartUp").Parse(script))

--- a/pkg/cloud/openstack/machine/machineScript_test.go
+++ b/pkg/cloud/openstack/machine/machineScript_test.go
@@ -1,0 +1,88 @@
+package machine
+
+import (
+	"testing"
+
+	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	"sigs.k8s.io/yaml"
+)
+
+const providerSpecYAML = `
+value:
+  apiVersion: "openstackproviderconfig/v1alpha1"
+  kind: "OpenstackProviderSpec"
+`
+
+func TestNodeStartupScriptEmpty(t *testing.T) {
+	cluster := &clusterv1.Cluster{}
+	machine := &clusterv1.Machine{}
+	err := yaml.Unmarshal([]byte(providerSpecYAML), &machine.Spec.ProviderSpec)
+	if err != nil {
+		t.Errorf("%v", err)
+		return
+	}
+
+	token := ""
+	script_template := ""
+
+	// `machine` has no endpoint specified so having `call
+	// .GetMasterEndpoint` in the script template would fail. But we
+	// don't, so this should succeed.
+	script, err := nodeStartupScript(cluster, machine, token, script_template)
+	if err != nil {
+		t.Errorf("%v", err)
+		return
+	}
+
+	if script != "" {
+		t.Errorf("Expected script, found %q instead", script)
+	}
+}
+
+func TestNodeStartupScriptEndpointError(t *testing.T) {
+	cluster := &clusterv1.Cluster{}
+	machine := &clusterv1.Machine{}
+	err := yaml.Unmarshal([]byte(providerSpecYAML), &machine.Spec.ProviderSpec)
+	if err != nil {
+		t.Errorf("%v", err)
+		return
+	}
+
+	token := ""
+	script_template := "{{ call .GetMasterEndpoint }}"
+	// `machine` has no endpoint specified so having `call
+	// .GetMasterEndpoint` in the template should fail.
+	script, err := nodeStartupScript(cluster, machine, token, script_template)
+	if err == nil {
+		t.Errorf("Expected GetMasterEndpoint to fail, but it succeeded. Startup script %q", script)
+	}
+}
+
+func TestNodeStartupScriptWithEndpoint(t *testing.T) {
+	cluster := clusterv1.Cluster{}
+	cluster.Status.APIEndpoints = make([]clusterv1.APIEndpoint, 1)
+	cluster.Status.APIEndpoints[0] = clusterv1.APIEndpoint{
+		Host: "example.com",
+		Port: 8080,
+	}
+
+	machine := &clusterv1.Machine{}
+	err := yaml.Unmarshal([]byte(providerSpecYAML), &machine.Spec.ProviderSpec)
+	if err != nil {
+		t.Errorf("%v", err)
+		return
+	}
+
+	token := ""
+	script_template := "{{ call .GetMasterEndpoint }}"
+	script, err := nodeStartupScript(&cluster, machine, token, script_template)
+	if err != nil {
+		t.Errorf("%v", err)
+		return
+	}
+
+	expected := "example.com:8080"
+	if script != expected {
+		t.Errorf("Expected %q master endpoint, found %q instead", expected, script)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Some startup scripts do not require the endpoint to be available (because they've got other means of bootstrapping for example) and calling it right now would fail unconditionally.
    
Instead, this introduces a `GetMasterEndpoint` function that can be called from the template via `"{{ call .GetMasterEndpoint }}` to query the endpoint. Scripts that don't need it will not call this function.

**Which issue(s) this PR fixes**

Fixes #163

**Release note**:

```release-note
The node startup script will now need to `{{ call .GetMasterEndpoint }}` in the template
to get the value, rather than querying it with `{{ .MasterEndpoint }}`. This lets the scripts
that don't need it be robust against it failing.
```
