### PR TITLE
Use gopkg.in/yaml.v2 for clientconfig objects

### DIFF
--- a/pkg/cloud/openstack/clients/machineservice.go
+++ b/pkg/cloud/openstack/clients/machineservice.go
@@ -20,8 +20,8 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	"gopkg.in/yaml.v2"
 	"k8s.io/client-go/kubernetes"
-	"sigs.k8s.io/yaml"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"


### PR DESCRIPTION
We ought to use the same yaml package used by clientconfig in order to
marshall/unmarshall Auth structs to/from yaml correctly. Using any other
yaml library will fail to load the auth data from secrets.