### PR TITLE
Add the filter key to the network's CRD entry

### DIFF
--- a/config/crd/openstackproviderconfig_v1alpha1.yaml
+++ b/config/crd/openstackproviderconfig_v1alpha1.yaml
@@ -29,6 +29,8 @@ spec:
               type: string
             fixed_ip:
               type: string
+            filter:
+              type: object
           type: array
         floatingIP:
           type: string

--- a/config/crd/openstackproviderconfig_v1alpha1.yaml
+++ b/config/crd/openstackproviderconfig_v1alpha1.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -40,16 +41,16 @@ spec:
         root_volume:
           properties:
             volumeType:
-             type: string
+              type: string
             diskSize:
               type: string
           type: object
         metadata:
           type: object
       required:
-      - name
-      - flavor
-      - image
+        - name
+        - flavor
+        - image
   version: v1alpha1
 status:
   acceptedNames:


### PR DESCRIPTION
We support filtering networks by tags and other attributes but we're missing the filter object for networks in the actuator's CRD. This commit fixes that.