### PR TITLE
Don't require kubelet version to be set

### DIFF
--- a/pkg/cloud/openstack/machine/actuator.go
+++ b/pkg/cloud/openstack/machine/actuator.go
@@ -424,9 +424,6 @@ func (oc *OpenstackClient) createBootstrapToken() (string, error) {
 }
 
 func (oc *OpenstackClient) validateMachine(machine *clusterv1.Machine, config *openstackconfigv1.OpenstackProviderSpec) *apierrors.MachineError {
-	if machine.Spec.Versions.Kubelet == "" {
-		return apierrors.InvalidMachineConfiguration("spec.versions.kubelet can't be empty")
-	}
 	// TODO: other validate of openstackCloud
 	return nil
 }


### PR DESCRIPTION
In an isolated scenario where only the actuator is being used (no clusterctl or any of the CAPO scripts) the kubelet version may not be required. Pre-built images may come with a pre-installed kubelet or versions could be provided through different means.

This PR removes the check in favor of letting the templates manage/verify they have all the data they need.