### PR TITLE
Fixed bootstrapping of CentOS machine

### DIFF
--- a/cmd/clusterctl/examples/openstack/centos/worker-user-data.sh
+++ b/cmd/clusterctl/examples/openstack/centos/worker-user-data.sh
@@ -32,7 +32,7 @@ function install_configure_docker () {
     chmod +x /usr/sbin/policy-rc.d
     trap "rm /usr/sbin/policy-rc.d" RETURN
     yum install -y docker
-    echo 'DOCKER_OPTS="--iptables=false --ip-masq=false"' > /etc/default/docker
+    echo 'OPTIONS="--selinux-enabled --log-driver=journald --signature-verification=false --iptables=false --ip-masq=false"' >> /etc/sysconfig/docker
     systemctl daemon-reload
     systemctl enable docker
     systemctl start docker
@@ -48,6 +48,7 @@ cat > /etc/kubernetes/kubeadm_config.yaml <<EOF
 apiVersion: kubeadm.k8s.io/v1alpha3
 kind: JoinConfiguration
 nodeRegistration:
+  name: $(hostname -s)
   kubeletExtraArgs:
     cloud-provider: "openstack"
     cloud-config: "/etc/kubernetes/cloud.conf"
@@ -68,7 +69,7 @@ echo '1' > /proc/sys/net/ipv4/ip_forward
 
 kubeadm join --ignore-preflight-errors=all --config /etc/kubernetes/kubeadm_config.yaml
 for tries in $(seq 1 60); do
-	kubectl --kubeconfig /etc/kubernetes/kubelet.conf annotate --overwrite node $(hostname) machine=${MACHINE} && break
+	kubectl --kubeconfig /etc/kubernetes/kubelet.conf annotate --overwrite node $(hostname -s) machine=${MACHINE} && break
 	sleep 1
 done
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -53,8 +53,6 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /etc/kubernetes
-        - name: certs
-          mountPath: /etc/ssl/certs
         - name: sshkeys
           mountPath: /etc/sshkeys
         - name: cloud-config
@@ -77,9 +75,6 @@ spec:
       - name: config
         hostPath:
           path: /etc/kubernetes
-      - name: certs
-        hostPath:
-          path: /etc/ssl/certs
       - name: sshkeys
         secret:
           secretName: machine-controller-sshkeys


### PR DESCRIPTION
docker disabled iptables and ip-masq.
only deploy calico.
used hostname -s to avoid .novalocal confusion.
removed ssl cert host mount into manager container, because the manager
container already includes a sane set of certs. And on centos
/etc/ssl/certs only contains a symlink which was not mounted in. So TLS
to openstack api was broken with the host mount.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #185 

**Special notes for your reviewer**:



**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
