### PR TITLE
Move OS_CLOUD environment variable to ConfigMap.

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -20,6 +20,17 @@ spec:
     control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+  name: cloud-selector
+  namespace: openstack-provider-system
+data:
+  OS_CLOUD: {OS_CLOUD}
+---
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
@@ -70,7 +81,10 @@ spec:
           - name: USER
             value: root
           - name: OS_CLOUD
-            value: {OS_CLOUD}
+            valueFrom:
+              configMapKeyRef:
+                name: cloud-selector
+                key: OS_CLOUD
       volumes:
       - name: config
         hostPath:


### PR DESCRIPTION
**What this PR does / why we need it**:
This moves the OS_CLOUD data to a ConfigMap and then references that in
the environment of the controller, instead of injecting OS_CLOUD
directly into the environment variables. 

**Which issue(s) this PR fixes**:
Fixes #161