### PR TITLE
add UserDataSecret into deepcopy file

### DIFF
--- a/pkg/apis/openstackproviderconfig/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/openstackproviderconfig/v1alpha1/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -175,6 +176,11 @@ func (in *OpenstackProviderSpec) DeepCopyInto(out *OpenstackProviderSpec) {
 		in, out := &in.SecurityGroups, &out.SecurityGroups
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.UserDataSecret != nil {
+		in, out := &in.UserDataSecret, &out.UserDataSecret
+		*out = new(v1.SecretReference)
+		**out = **in
 	}
 	out.RootVolume = in.RootVolume
 	return


### PR DESCRIPTION
complete the deepcopy functions

Signed-off-by: Alex Yang <yangyang1@zte.com.cn>

**What this PR does / why we need it**:
Run the following commands in pkg/apis/openstackproviderconfig/v1alpha1 directory:

```bash
$ go run ../../../../vendor/k8s.io/code-generator/cmd/deepcopy-gen/main.go -O zz_generated.deepcopy -i ./... -h ../../../../hack/boilerplate.go.txt
$ git diff
diff --git a/pkg/apis/openstackproviderconfig/v1alpha1/zz_generated.deepcopy.go b/pkg/apis/openstackproviderconfig/v1alpha1/zz_generated.deepcopy.go
index a95e10d..f9cb99f 100644
--- a/pkg/apis/openstackproviderconfig/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/openstackproviderconfig/v1alpha1/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1alpha1

 import (
+       v1 "k8s.io/api/core/v1"
        runtime "k8s.io/apimachinery/pkg/runtime"
 )

@@ -176,6 +177,11 @@ func (in *OpenstackProviderSpec) DeepCopyInto(out *OpenstackProviderSpec) {
                *out = make([]string, len(*in))
                copy(*out, *in)
        }
+       if in.UserDataSecret != nil {
+               in, out := &in.UserDataSecret, &out.UserDataSecret
+               *out = new(v1.SecretReference)
+               **out = **in
+       }
        out.RootVolume = in.RootVolume
        return
 }
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:

```release-note
NONE
```
