### PR TITLE
Use corev1.SecretReference for CloudsSecrets too

### DIFF
--- a/pkg/apis/openstackproviderconfig/v1alpha1/types.go
+++ b/pkg/apis/openstackproviderconfig/v1alpha1/types.go
@@ -31,7 +31,7 @@ type OpenstackProviderSpec struct {
 	metav1.TypeMeta `json:",inline"`
 
 	// The name of the secret containing the openstack credentials
-	CloudsSecret string `json:"cloudsSecret"`
+	CloudsSecret *corev1.SecretReference `json:"cloudsSecret"`
 
 	// The name of the cloud to use from the clouds secret
 	CloudName string `json:"cloudName"`

--- a/pkg/cloud/openstack/clients/machineservice.go
+++ b/pkg/cloud/openstack/clients/machineservice.go
@@ -101,7 +101,11 @@ func NewInstanceServiceFromMachine(kubeClient kubernetes.Interface, machine *clu
 	if err != nil {
 		return nil, err
 	}
-	cloud, err := GetCloudFromSecret(kubeClient, machine.Namespace, machineSpec.CloudsSecret, machineSpec.CloudName)
+	namespace := machineSpec.CloudsSecret.Namespace
+	if namespace == "" {
+		namespace = machine.Namespace
+	}
+	cloud, err := GetCloudFromSecret(kubeClient, namespace, machineSpec.CloudsSecret.Name, machineSpec.CloudName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
For the sake of consistency, let's use `corev1.SecretReference` for `CloudsSecrets` too