### PR TITLE
Fix clustercli CLI in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 2. Create a cluster:
 
    ```bash
-   ./clusterctl create cluster --minikube kubernetes-version=v1.12.3 --provider openstack -c examples/openstack/[os name]/out/cluster.yaml -m examples/openstack/[os name]/out/machines.yaml -p examples/openstack/[os name]/out/provider-components.yaml
+   ./clusterctl create cluster --bootstrap-type minikube --bootstrap-flags kubernetes-version=v1.12.3 --provider openstack -c examples/openstack/[os name]/out/cluster.yaml -m examples/openstack/[os name]/out/machines.yaml -p examples/openstack/[os name]/out/provider-components.yaml
    ```
 
 To choose a specific minikube driver, please use the `--vm-driver` command line parameter. For example to use the kvm2 driver with clusterctl you woud add `--vm-driver kvm2`, for linux, if you haven't installed any driver, you can add `--vm-driver none`.


### PR DESCRIPTION
**What this PR does / why we need it**:

Options for bootstrap provisioner changed in clustercli. Adjust README accordingly.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
