### PR TITLE
Fix default cloud usage when cloudsSecret is absent

### DIFF
--- a/pkg/cloud/openstack/clients/machineservice.go
+++ b/pkg/cloud/openstack/clients/machineservice.go
@@ -101,13 +101,16 @@ func NewInstanceServiceFromMachine(kubeClient kubernetes.Interface, machine *clu
 	if err != nil {
 		return nil, err
 	}
-	namespace := machineSpec.CloudsSecret.Namespace
-	if namespace == "" {
-		namespace = machine.Namespace
-	}
-	cloud, err := GetCloudFromSecret(kubeClient, namespace, machineSpec.CloudsSecret.Name, machineSpec.CloudName)
-	if err != nil {
-		return nil, err
+	cloud := clientconfig.Cloud{}
+	if machineSpec.CloudsSecret != nil && machineSpec.CloudsSecret.Name != "" {
+		namespace := machineSpec.CloudsSecret.Namespace
+		if namespace == "" {
+			namespace = machine.Namespace
+		}
+		cloud, err = GetCloudFromSecret(kubeClient, namespace, machineSpec.CloudsSecret.Name, machineSpec.CloudName)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return NewInstanceServiceFromCloud(cloud)
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

When cloudsSecret is not specified in machine's provider config,currently provider segfaults because CloudsSecret is nil and we try to access Namespace field from it. Add a guard to ignore secret if it is nil or name is empty.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
