### PR TITLE
Remove unnecessary equal signs

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1,5 +1,4 @@
 # Required Configuration
-========================
 
 ## Floating IP
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Equal signs are unnecessary for header in config.md.