### PR TITLE
Disabled auto generation of rbac ClusterRoles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,6 @@ generate: manifests
 	go generate ./pkg/... ./cmd/...
 
 manifests:
-	go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go --name openstack-provider-manager rbac
 	go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go crd
 
 images: openstack-cluster-api-controller manifests

--- a/config/rbac/rbac_role_binding.yaml
+++ b/config/rbac/rbac_role_binding.yaml
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: system
+  namespace: openstack-provider-system

--- a/pkg/cloud/openstack/cluster/actuator.go
+++ b/pkg/cloud/openstack/cluster/actuator.go
@@ -27,11 +27,6 @@ func NewActuator(params providerv1openstack.ActuatorParams) (*Actuator, error) {
 }
 
 // Reconcile creates or applies updates to the cluster.
-// TODO: those are copied from original rbac_role.yaml, need remove them if not needed later
-// +kubebuilder:rbac:groups=openstackproviderconfig.k8s.io,resources=openstackmachineproviderconfigs,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=cluster.k8s.io,resources=clusters;clusters/status;machinedeployments;machinesets;machines,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=,resources=nodes,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=,resources=secrets,verbs=get;list;watch
 func (a *Actuator) Reconcile(cluster *clusterv1.Cluster) error {
 	klog.Infof("Reconciling cluster %v.", cluster.Name)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Because currently, controller-tools only support this for controllers
that in in namespace "system", I disabled the auto generation in order
to get the controller back into a running state.

Maybe we need to discuss this further, but in a different ticket!?

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #213 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
