### PR TITLE
Configure DNS Nameservers for created network

### DIFF
--- a/config/crds/openstackproviderconfig_v1alpha1_openstackclusterproviderspec.yaml
+++ b/config/crds/openstackproviderconfig_v1alpha1_openstackclusterproviderspec.yaml
@@ -16,6 +16,10 @@ spec:
       properties:
         apiVersion:
           type: string
+        dnsNameservers:
+          items:
+            type: string
+          type: array
         externalNetworkId:
           type: string
         kind:

--- a/pkg/apis/openstackproviderconfig/v1alpha1/types.go
+++ b/pkg/apis/openstackproviderconfig/v1alpha1/types.go
@@ -111,6 +111,8 @@ type OpenstackClusterProviderSpec struct {
 	// network, a subnet with NodeCIDR, and a router connected to this subnet.
 	// If you leave this empty, no network will be created.
 	NodeCIDR string `json:"nodeCidr,omitempty"`
+	// DNSNameservers is the list of nameservers for OpenStack Subnet being created.
+	DNSNameservers []string `json:"dnsNameservers,omitempty"`
 	// ExternalNetworkID is the ID of an external OpenStack Network. This is necessary
 	// to get public internet to the VMs.
 	ExternalNetworkID string `json:"externalNetworkId,omitempty"`

--- a/pkg/cloud/openstack/clients/networkservice.go
+++ b/pkg/cloud/openstack/clients/networkservice.go
@@ -157,7 +157,8 @@ func (s *NetworkService) reconcileSubnets(clusterName, name string, desired open
 			Name:      name,
 			IPVersion: 4,
 
-			CIDR: desired.NodeCIDR,
+			CIDR:           desired.NodeCIDR,
+			DNSNameservers: desired.DNSNameservers,
 		}
 
 		newSubnet, err := subnets.Create(s.client, opts).Extract()


### PR DESCRIPTION
Use dnsNameservers option to configure nameserver for created subnets.

Fixes #215 