### PR TITLE
Make auto generate crds generate openstackproviderspec

### DIFF
--- a/config/crds/openstackproviderconfig_v1alpha1_openstackproviderspec.yaml
+++ b/config/crds/openstackproviderconfig_v1alpha1_openstackproviderspec.yaml
@@ -1,0 +1,81 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: openstackproviderspecs.openstackproviderconfig.k8s.io
+spec:
+  group: openstackproviderconfig.k8s.io
+  names:
+    kind: OpenstackProviderSpec
+    plural: openstackproviderspecs
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        availabilityZone:
+          type: string
+        cloudName:
+          type: string
+        cloudsSecret:
+          type: object
+        flavor:
+          type: string
+        floatingIP:
+          type: string
+        image:
+          type: string
+        keyName:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        networks:
+          items:
+            properties:
+              filter:
+                properties:
+                  id:
+                    type: string
+                  limit:
+                    format: int64
+                    type: integer
+                  marker:
+                    type: string
+                  name:
+                    type: string
+                  shared:
+                    type: boolean
+                  status:
+                    type: string
+                  tags:
+                    type: string
+                type: object
+              uuid:
+                type: string
+            type: object
+          type: array
+        securityGroups:
+          items:
+            type: string
+          type: array
+        sshUserName:
+          type: string
+        userDataSecret:
+          type: object
+      required:
+      - cloudsSecret
+      - cloudName
+      - flavor
+      - image
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/apis/openstackproviderconfig/v1alpha1/types.go
+++ b/pkg/apis/openstackproviderconfig/v1alpha1/types.go
@@ -27,8 +27,10 @@ import (
 // OpenstackProviderSpec is the type that will be embedded in a Machine.Spec.ProviderSpec field
 // for an OpenStack Instance. It is used by the Openstack machine actuator to create a single machine instance.
 // TODO(cglaubitz): We might consider to change this to OpenstackMachineProviderSpec
+// +k8s:openapi-gen=true
 type OpenstackProviderSpec struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// The name of the secret containing the openstack credentials
 	CloudsSecret *corev1.SecretReference `json:"cloudsSecret"`


### PR DESCRIPTION
the openstackproviderspec removed in #193 and
because of missing 'metav1.ObjectMeta' so it failed to
generate the CRD file.

Fixes #217


**What this PR does / why we need it**:
Fix bug 217
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
related to #193, not create the crds files correctly at that PR
1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
```release-note

```
