### PR TITLE
Create floatingip for machines

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -107,7 +107,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:ed964c403c02c6d9c663e84ee6cdf4aba3c7a92a756a4b9a4d054b0ef8daf2d8"
+  digest = "1:46bdb04cf2f7fda51d02b0b0534325cadfd8334b7eb82dfce8647d42b46d3807"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
@@ -121,6 +121,7 @@
     "openstack/identity/v2/tokens",
     "openstack/identity/v3/tokens",
     "openstack/networking/v2/extensions/attributestags",
+    "openstack/networking/v2/extensions/layer3/floatingips",
     "openstack/networking/v2/extensions/layer3/routers",
     "openstack/networking/v2/networks",
     "openstack/networking/v2/ports",
@@ -740,6 +741,7 @@
     "github.com/gophercloud/gophercloud/openstack/compute/v2/servers",
     "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens",
     "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags",
+    "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips",
     "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers",
     "github.com/gophercloud/gophercloud/openstack/networking/v2/networks",
     "github.com/gophercloud/gophercloud/openstack/networking/v2/ports",

--- a/pkg/cloud/openstack/machine/machineScript.go
+++ b/pkg/cloud/openstack/machine/machineScript.go
@@ -41,12 +41,7 @@ type setupParams struct {
 func init() {
 }
 
-func masterStartupScript(cluster *clusterv1.Cluster, machine *clusterv1.Machine, script string) (string, error) {
-	machineSpec, err := openstackconfigv1.MachineSpecFromProviderSpec(machine.Spec.ProviderSpec)
-	if err != nil {
-		return "", err
-	}
-
+func masterStartupScript(cluster *clusterv1.Cluster, machine *clusterv1.Machine, machineSpec *openstackconfigv1.OpenstackProviderSpec, script string) (string, error) {
 	params := setupParams{
 		Cluster:     cluster,
 		Machine:     machine,

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips/doc.go
@@ -1,0 +1,71 @@
+/*
+package floatingips enables management and retrieval of Floating IPs from the
+OpenStack Networking service.
+
+Example to List Floating IPs
+
+	listOpts := floatingips.ListOpts{
+		FloatingNetworkID: "a6917946-38ab-4ffd-a55a-26c0980ce5ee",
+	}
+
+	allPages, err := floatingips.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allFIPs, err := floatingips.ExtractFloatingIPs(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, fip := range allFIPs {
+		fmt.Printf("%+v\n", fip)
+	}
+
+Example to Create a Floating IP
+
+	createOpts := floatingips.CreateOpts{
+		FloatingNetworkID: "a6917946-38ab-4ffd-a55a-26c0980ce5ee",
+	}
+
+	fip, err := floatingips.Create(networkingClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Floating IP
+
+	fipID := "2f245a7b-796b-4f26-9cf9-9e82d248fda7"
+	portID := "76d0a61b-b8e5-490c-9892-4cf674f2bec8"
+
+	updateOpts := floatingips.UpdateOpts{
+		PortID: &portID,
+	}
+
+	fip, err := floatingips.Update(networkingClient, fipID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Disassociate a Floating IP with a Port
+
+	fipID := "2f245a7b-796b-4f26-9cf9-9e82d248fda7"
+
+	updateOpts := floatingips.UpdateOpts{
+		PortID: nil,
+	}
+
+	fip, err := floatingips.Update(networkingClient, fipID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Floating IP
+
+	fipID := "2f245a7b-796b-4f26-9cf9-9e82d248fda7"
+	err := floatingips.Delete(networkClient, fipID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package floatingips

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips/requests.go
@@ -1,0 +1,154 @@
+package floatingips
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the floating IP attributes you want to see returned. SortKey allows you to
+// sort by a particular network attribute. SortDir sets the direction, and is
+// either `asc' or `desc'. Marker and Limit are used for pagination.
+type ListOpts struct {
+	ID                string `q:"id"`
+	FloatingNetworkID string `q:"floating_network_id"`
+	PortID            string `q:"port_id"`
+	FixedIP           string `q:"fixed_ip_address"`
+	FloatingIP        string `q:"floating_ip_address"`
+	TenantID          string `q:"tenant_id"`
+	ProjectID         string `q:"project_id"`
+	Limit             int    `q:"limit"`
+	Marker            string `q:"marker"`
+	SortKey           string `q:"sort_key"`
+	SortDir           string `q:"sort_dir"`
+	RouterID          string `q:"router_id"`
+	Status            string `q:"status"`
+	Tags              string `q:"tags"`
+	TagsAny           string `q:"tags-any"`
+	NotTags           string `q:"not-tags"`
+	NotTagsAny        string `q:"not-tags-any"`
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// floating IP resources. It accepts a ListOpts struct, which allows you to
+// filter and sort the returned collection for greater efficiency.
+func List(c *gophercloud.ServiceClient, opts ListOpts) pagination.Pager {
+	q, err := gophercloud.BuildQueryString(&opts)
+	if err != nil {
+		return pagination.Pager{Err: err}
+	}
+	u := rootURL(c) + q.String()
+	return pagination.NewPager(c, u, func(r pagination.PageResult) pagination.Page {
+		return FloatingIPPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToFloatingIPCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains all the values needed to create a new floating IP
+// resource. The only required fields are FloatingNetworkID and PortID which
+// refer to the external network and internal port respectively.
+type CreateOpts struct {
+	FloatingNetworkID string `json:"floating_network_id" required:"true"`
+	FloatingIP        string `json:"floating_ip_address,omitempty"`
+	PortID            string `json:"port_id,omitempty"`
+	FixedIP           string `json:"fixed_ip_address,omitempty"`
+	SubnetID          string `json:"subnet_id,omitempty"`
+	TenantID          string `json:"tenant_id,omitempty"`
+	ProjectID         string `json:"project_id,omitempty"`
+}
+
+// ToFloatingIPCreateMap allows CreateOpts to satisfy the CreateOptsBuilder
+// interface
+func (opts CreateOpts) ToFloatingIPCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "floatingip")
+}
+
+// Create accepts a CreateOpts struct and uses the values provided to create a
+// new floating IP resource. You can create floating IPs on external networks
+// only. If you provide a FloatingNetworkID which refers to a network that is
+// not external (i.e. its `router:external' attribute is False), the operation
+// will fail and return a 400 error.
+//
+// If you do not specify a FloatingIP address value, the operation will
+// automatically allocate an available address for the new resource. If you do
+// choose to specify one, it must fall within the subnet range for the external
+// network - otherwise the operation returns a 400 error. If the FloatingIP
+// address is already in use, the operation returns a 409 error code.
+//
+// You can associate the new resource with an internal port by using the PortID
+// field. If you specify a PortID that is not valid, the operation will fail and
+// return 404 error code.
+//
+// You must also configure an IP address for the port associated with the PortID
+// you have provided - this is what the FixedIP refers to: an IP fixed to a
+// port. Because a port might be associated with multiple IP addresses, you can
+// use the FixedIP field to associate a particular IP address rather than have
+// the API assume for you. If you specify an IP address that is not valid, the
+// operation will fail and return a 400 error code. If the PortID and FixedIP
+// are already associated with another resource, the operation will fail and
+// returns a 409 error code.
+func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToFloatingIPCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(rootURL(c), b, &r.Body, nil)
+	return
+}
+
+// Get retrieves a particular floating IP resource based on its unique ID.
+func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(resourceURL(c, id), &r.Body, nil)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToFloatingIPUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts contains the values used when updating a floating IP resource. The
+// only value that can be updated is which internal port the floating IP is
+// linked to. To associate the floating IP with a new internal port, provide its
+// ID. To disassociate the floating IP from all ports, provide an empty string.
+type UpdateOpts struct {
+	PortID *string `json:"port_id"`
+}
+
+// ToFloatingIPUpdateMap allows UpdateOpts to satisfy the UpdateOptsBuilder
+// interface
+func (opts UpdateOpts) ToFloatingIPUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "floatingip")
+}
+
+// Update allows floating IP resources to be updated. Currently, the only way to
+// "update" a floating IP is to associate it with a new internal port, or
+// disassociated it from all ports. See UpdateOpts for instructions of how to
+// do this.
+func Update(c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToFloatingIPUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(resourceURL(c, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Delete will permanently delete a particular floating IP resource. Please
+// ensure this is what you want - you can also disassociate the IP from existing
+// internal ports.
+func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = c.Delete(resourceURL(c, id), nil)
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips/results.go
@@ -1,0 +1,122 @@
+package floatingips
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// FloatingIP represents a floating IP resource. A floating IP is an external
+// IP address that is mapped to an internal port and, optionally, a specific
+// IP address on a private network. In other words, it enables access to an
+// instance on a private network from an external network. For this reason,
+// floating IPs can only be defined on networks where the `router:external'
+// attribute (provided by the external network extension) is set to True.
+type FloatingIP struct {
+	// ID is the unique identifier for the floating IP instance.
+	ID string `json:"id"`
+
+	// FloatingNetworkID is the UUID of the external network where the floating
+	// IP is to be created.
+	FloatingNetworkID string `json:"floating_network_id"`
+
+	// FloatingIP is the address of the floating IP on the external network.
+	FloatingIP string `json:"floating_ip_address"`
+
+	// PortID is the UUID of the port on an internal network that is associated
+	// with the floating IP.
+	PortID string `json:"port_id"`
+
+	// FixedIP is the specific IP address of the internal port which should be
+	// associated with the floating IP.
+	FixedIP string `json:"fixed_ip_address"`
+
+	// TenantID is the project owner of the floating IP. Only admin users can
+	// specify a project identifier other than its own.
+	TenantID string `json:"tenant_id"`
+
+	// ProjectID is the project owner of the floating IP.
+	ProjectID string `json:"project_id"`
+
+	// Status is the condition of the API resource.
+	Status string `json:"status"`
+
+	// RouterID is the ID of the router used for this floating IP.
+	RouterID string `json:"router_id"`
+
+	// Tags optionally set via extensions/attributestags
+	Tags []string `json:"tags"`
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract will extract a FloatingIP resource from a result.
+func (r commonResult) Extract() (*FloatingIP, error) {
+	var s struct {
+		FloatingIP *FloatingIP `json:"floatingip"`
+	}
+	err := r.ExtractInto(&s)
+	return s.FloatingIP, err
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a FloatingIP.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a FloatingIP.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a FloatingIP.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of an update operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// FloatingIPPage is the page returned by a pager when traversing over a
+// collection of floating IPs.
+type FloatingIPPage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of floating IPs has
+// reached the end of a page and the pager seeks to traverse over a new one.
+// In order to do this, it needs to construct the next page's URL.
+func (r FloatingIPPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"floatingips_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a FloatingIPPage struct is empty.
+func (r FloatingIPPage) IsEmpty() (bool, error) {
+	is, err := ExtractFloatingIPs(r)
+	return len(is) == 0, err
+}
+
+// ExtractFloatingIPs accepts a Page struct, specifically a FloatingIPPage
+// struct, and extracts the elements into a slice of FloatingIP structs. In
+// other words, a generic collection is mapped into a relevant slice.
+func ExtractFloatingIPs(r pagination.Page) ([]FloatingIP, error) {
+	var s struct {
+		FloatingIPs []FloatingIP `json:"floatingips"`
+	}
+	err := (r.(FloatingIPPage)).ExtractInto(&s)
+	return s.FloatingIPs, err
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips/urls.go
@@ -1,0 +1,13 @@
+package floatingips
+
+import "github.com/gophercloud/gophercloud"
+
+const resourcePath = "floatingips"
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(resourcePath)
+}
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(resourcePath, id)
+}


### PR DESCRIPTION
Automatically create floatingip for machines when externalNetworkId
specified in ClusterProviderSpec and floatingip is not specified in
machine spec

Closes: #219 