### PR TITLE
Support keystone with certificate

### DIFF
--- a/cmd/clusterctl/examples/openstack/provider-component/clouds-secrets/kustomization.yaml
+++ b/cmd/clusterctl/examples/openstack/provider-component/clouds-secrets/kustomization.yaml
@@ -7,6 +7,7 @@ secretGenerator:
 - name: cloud-config
   commands:
     clouds.yaml: "cat configs/clouds.yaml"
+    cacert: "cat configs/cacert"
   type: Opaque
 - name: cloud-selector
   commands:

--- a/cmd/clusterctl/examples/openstack/provider-component/user-data/centos/templates/master-user-data.sh
+++ b/cmd/clusterctl/examples/openstack/provider-component/user-data/centos/templates/master-user-data.sh
@@ -86,6 +86,8 @@ echo '1' > /proc/sys/net/bridge/bridge-nf-call-iptables
 echo '1' > /proc/sys/net/ipv4/ip_forward
 
 echo $OPENSTACK_CLOUD_PROVIDER_CONF | base64 -d > /etc/kubernetes/cloud.conf
+mkdir /etc/certs
+echo $OPENSTACK_CLOUD_CACERT_CONFIG | base64 -d > /etc/certs/cacert
 
 # Set up kubeadm config file to pass parameters to kubeadm init.
 cat > /etc/kubernetes/kubeadm_config.yaml <<EOF
@@ -122,6 +124,10 @@ apiServer:
     mountPath: /etc/kubernetes/cloud.conf
     name: cloud
     readOnly: true
+  - hostPath: "/etc/certs/cacert"
+    mountPath: "/etc/certs/cacert"
+    name: cacert
+    readOnly: true
   timeoutForControlPlane: 4m0s
 certificatesDir: /etc/kubernetes/pki
 clusterName: kubernetes
@@ -137,6 +143,10 @@ controllerManager:
   - hostPath: /etc/kubernetes/cloud.conf
     mountPath: /etc/kubernetes/cloud.conf
     name: cloud
+    readOnly: true
+  - hostPath: "/etc/certs/cacert"
+    mountPath: "/etc/certs/cacert"
+    name: cacert
     readOnly: true
 dns:
   type: CoreDNS

--- a/cmd/clusterctl/examples/openstack/provider-component/user-data/centos/templates/worker-user-data.sh
+++ b/cmd/clusterctl/examples/openstack/provider-component/user-data/centos/templates/worker-user-data.sh
@@ -45,6 +45,8 @@ install_configure_docker
 
 # Write the cloud.conf so that the kubelet can use it.
 echo $OPENSTACK_CLOUD_PROVIDER_CONF | base64 -d > /etc/kubernetes/cloud.conf
+mkdir /etc/certs
+echo $OPENSTACK_CLOUD_CACERT_CONFIG | base64 -d > /etc/certs/cacert
 
 # Set up kubeadm config file to pass to kubeadm join.
 cat > /etc/kubernetes/kubeadm_config.yaml <<EOF

--- a/cmd/clusterctl/examples/openstack/provider-component/user-data/coreos/templates/common.yaml
+++ b/cmd/clusterctl/examples/openstack/provider-component/user-data/coreos/templates/common.yaml
@@ -120,6 +120,16 @@ storage:
         id: 0
       group:
         id: 0
+    - path: /etc/certs/cacert
+      filesystem: root
+      contents:
+        inline: !!binary |
+          $OPENSTACK_CLOUD_CACERT_CONFIG
+      mode: 0600
+      user:
+        id: 0
+      group:
+        id: 0
     - path: /etc/modules-load.d/ipvs.conf
       filesystem: root
       contents:

--- a/cmd/clusterctl/examples/openstack/provider-component/user-data/coreos/templates/master.yaml
+++ b/cmd/clusterctl/examples/openstack/provider-component/user-data/coreos/templates/master.yaml
@@ -31,6 +31,9 @@ storage:
           - name: cloud
             hostPath: "/etc/kubernetes/cloud.conf"
             mountPath: "/etc/kubernetes/cloud.conf"
+          - name: cacert
+            hostPath: "/etc/certs/cacert"
+            mountPath: "/etc/certs/cacert"
         controllerManager:
           extraArgs:
             cluster-cidr: {{ .PodCIDR }}
@@ -42,6 +45,9 @@ storage:
           - name: cloud
             hostPath: "/etc/kubernetes/cloud.conf"
             mountPath: "/etc/kubernetes/cloud.conf"
+          - name: cacert
+            hostPath: "/etc/certs/cacert"
+            mountPath: "/etc/certs/cacert"
     user:
       id: 0
     group:

--- a/cmd/clusterctl/examples/openstack/provider-component/user-data/ubuntu/templates/master-user-data.sh
+++ b/cmd/clusterctl/examples/openstack/provider-component/user-data/ubuntu/templates/master-user-data.sh
@@ -107,6 +107,8 @@ EOF
 
 echo $OPENSTACK_CLOUD_PROVIDER_CONF | base64 -d > /etc/kubernetes/cloud.conf
 chmod 600 /etc/kubernetes/cloud.conf
+mkdir /etc/certs
+echo $OPENSTACK_CLOUD_CACERT_CONFIG | base64 -d > /etc/certs/cacert
 
 systemctl daemon-reload
 systemctl restart kubelet.service
@@ -150,6 +152,10 @@ apiServer:
     mountPath: /etc/kubernetes/cloud.conf
     name: cloud
     readOnly: true
+  - hostPath: "/etc/certs/cacert"
+    mountPath: "/etc/certs/cacert"
+    name: cacert
+    readOnly: true
   timeoutForControlPlane: 4m0s
 certificatesDir: /etc/kubernetes/pki
 clusterName: kubernetes
@@ -165,6 +171,10 @@ controllerManager:
   - hostPath: /etc/kubernetes/cloud.conf
     mountPath: /etc/kubernetes/cloud.conf
     name: cloud
+    readOnly: true
+  - hostPath: "/etc/certs/cacert"
+    mountPath: "/etc/certs/cacert"
+    name: cacert
     readOnly: true
 dns:
   type: CoreDNS

--- a/cmd/clusterctl/examples/openstack/provider-component/user-data/ubuntu/templates/worker-user-data.sh
+++ b/cmd/clusterctl/examples/openstack/provider-component/user-data/ubuntu/templates/worker-user-data.sh
@@ -79,6 +79,8 @@ CLUSTER_DNS_SERVER=$(prips ${SERVICE_CIDR} | head -n 11 | tail -n 1)
 
 # Write the cloud.conf so that the kubelet can use it.
 echo $OPENSTACK_CLOUD_PROVIDER_CONF | base64 -d > /etc/kubernetes/cloud.conf
+mkdir /etc/certs
+echo $OPENSTACK_CLOUD_CACERT_CONFIG | base64 -d > /etc/certs/cacert
 
 # Set up kubeadm config file to pass to kubeadm join.
 cat > /etc/kubernetes/kubeadm_config.yaml <<EOF

--- a/config/crds/openstackproviderconfig_v1alpha1_openstackclusterproviderspec.yaml
+++ b/config/crds/openstackproviderconfig_v1alpha1_openstackclusterproviderspec.yaml
@@ -16,6 +16,10 @@ spec:
       properties:
         apiVersion:
           type: string
+        cloudName:
+          type: string
+        cloudsSecret:
+          type: object
         disableServerTags:
           type: boolean
         dnsNameservers:
@@ -37,6 +41,8 @@ spec:
             type: string
           type: array
       required:
+      - cloudsSecret
+      - cloudName
       - managedSecurityGroups
   version: v1alpha1
 status:

--- a/pkg/apis/openstackproviderconfig/v1alpha1/types.go
+++ b/pkg/apis/openstackproviderconfig/v1alpha1/types.go
@@ -187,6 +187,12 @@ type OpenstackClusterProviderSpec struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// The name of the secret containing the openstack credentials
+	CloudsSecret *corev1.SecretReference `json:"cloudsSecret"`
+
+	// The name of the cloud to use from the clouds secret
+	CloudName string `json:"cloudName"`
+
 	// NodeCIDR is the OpenStack Subnet to be created. Cluster actuator will create a
 	// network, a subnet with NodeCIDR, and a router connected to this subnet.
 	// If you leave this empty, no network will be created.

--- a/pkg/apis/openstackproviderconfig/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/openstackproviderconfig/v1alpha1/zz_generated.deepcopy.go
@@ -106,6 +106,11 @@ func (in *OpenstackClusterProviderSpec) DeepCopyInto(out *OpenstackClusterProvid
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	if in.CloudsSecret != nil {
+		in, out := &in.CloudsSecret, &out.CloudsSecret
+		*out = new(v1.SecretReference)
+		**out = **in
+	}
 	if in.DNSNameservers != nil {
 		in, out := &in.DNSNameservers, &out.DNSNameservers
 		*out = make([]string, len(*in))

--- a/pkg/cloud/openstack/cluster/actuator.go
+++ b/pkg/cloud/openstack/cluster/actuator.go
@@ -2,17 +2,30 @@ package cluster
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
+	"net/http"
+
+	"gopkg.in/yaml.v2"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/utils/openstack/clientconfig"
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
 	"k8s.io/klog"
 	providerv1 "sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1"
 	providerv1openstack "sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/openstack"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/openstack/clients"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+)
+
+const (
+	CloudsSecretKey = "clouds.yaml"
+	CaSecretKey     = "cacert"
 )
 
 // Actuator controls cluster related infrastructure.
@@ -119,20 +132,103 @@ func (a *Actuator) storeClusterStatus(cluster *clusterv1.Cluster, status *provid
 	return nil
 }
 
+func GetCloudFromSecret(kubeClient kubernetes.Interface, namespace string, secretName string, cloudName string) (clientconfig.Cloud, []byte, error) {
+	emptyCloud := clientconfig.Cloud{}
+
+	if secretName == "" {
+		return emptyCloud, nil, nil
+	}
+
+	if secretName != "" && cloudName == "" {
+		return emptyCloud, nil, fmt.Errorf("Secret name set to %v but no cloud was specified. Please set cloud_name in your machine spec.", secretName)
+	}
+
+	secret, err := kubeClient.CoreV1().Secrets(namespace).Get(secretName, metav1.GetOptions{})
+	if err != nil {
+		return emptyCloud, nil, err
+	}
+
+	content, ok := secret.Data[CloudsSecretKey]
+	if !ok {
+		return emptyCloud, nil, fmt.Errorf("OpenStack credentials secret %v did not contain key %v",
+			secretName, CloudsSecretKey)
+	}
+	var clouds clientconfig.Clouds
+	err = yaml.Unmarshal(content, &clouds)
+	if err != nil {
+		return emptyCloud, nil, fmt.Errorf("failed to unmarshal clouds credentials stored in secret %v: %v", secretName, err)
+	}
+
+	// get cacert
+	cacert, ok := secret.Data[CaSecretKey]
+	if !ok {
+		return emptyCloud, nil, err
+	}
+
+	return clouds.Clouds[cloudName], cacert, nil
+}
+
 // getNetworkClient returns an gophercloud.ServiceClient provided by openstack.NewNetworkV2
 // TODO(chrigl) currently ignoring cluster, but in the future we might store OS-Credentials
 // as secrets referenced by the cluster.
 // See https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/136
 func (a *Actuator) getNetworkClient(cluster *clusterv1.Cluster) (*gophercloud.ServiceClient, error) {
+	kubeClient := a.params.KubeClient
+	clusterSpec, err := providerv1.ClusterSpecFromProviderSpec(cluster.Spec.ProviderSpec)
+	if err != nil {
+		return nil, errors.Errorf("failed to load cluster provider spec: %v", err)
+	}
+	cloud := clientconfig.Cloud{}
+	var cacert []byte
+
+	if clusterSpec.CloudsSecret != nil && clusterSpec.CloudsSecret.Name != "" {
+		namespace := clusterSpec.CloudsSecret.Namespace
+		if namespace == "" {
+			namespace = cluster.Namespace
+		}
+		cloud, cacert, err = GetCloudFromSecret(kubeClient, namespace, clusterSpec.CloudsSecret.Name, clusterSpec.CloudName)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	clientOpts := new(clientconfig.ClientOpts)
-	opts, err := clientconfig.AuthOptions(clientOpts)
+	var opts *gophercloud.AuthOptions
+
+	if cloud.AuthInfo != nil {
+		clientOpts.AuthInfo = cloud.AuthInfo
+		clientOpts.AuthType = cloud.AuthType
+		clientOpts.Cloud = cloud.Cloud
+		clientOpts.RegionName = cloud.RegionName
+	}
+
+	opts, err = clientconfig.AuthOptions(clientOpts)
 	if err != nil {
 		return nil, err
 	}
 
-	provider, err := openstack.AuthenticatedClient(*opts)
+	opts.AllowReauth = true
+
+	provider, err := openstack.NewClient(opts.IdentityEndpoint)
 	if err != nil {
 		return nil, fmt.Errorf("create providerClient err: %v", err)
+	}
+
+	config := &tls.Config{}
+	cloudFromYaml, err := clientconfig.GetCloudFromYAML(clientOpts)
+	if cloudFromYaml.CACertFile != "" {
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(cacert)
+		config.RootCAs = caCertPool
+	}
+
+	config.InsecureSkipVerify = *cloudFromYaml.Verify
+	transport := &http.Transport{Proxy: http.ProxyFromEnvironment, TLSClientConfig: config}
+	provider.HTTPClient.Transport = transport
+
+	err = openstack.Authenticate(provider, *opts)
+	if err != nil {
+		return nil, fmt.Errorf("providerClient authentication err: %v", err)
 	}
 
 	client, err := openstack.NewNetworkV2(provider, gophercloud.EndpointOpts{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This PR supports keystone endpoint with certificate by the following clouds.yaml with cacert key.

```yaml
clouds:
  openstack:
    auth:
      auth_url: https://yourauthurl:5000/v3
      username: foo
      password: bar
      project_id: foobar123
      project_name: foobar
      user_domain_name: "Default"
    cacert: /path/to/cacertfile
    region_name: "Region_1"
    interface: "public"
    identity_api_version: 3
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #209 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
