### PR TITLE
Fix IngexOutOfRange error if managedSecurityGroups:true

### DIFF
--- a/pkg/cloud/openstack/clients/secgroupservice.go
+++ b/pkg/cloud/openstack/clients/secgroupservice.go
@@ -321,7 +321,7 @@ func (s *SecGroupService) createRule(r openstackconfigv1.SecurityGroupRule) (ope
 }
 
 func (s *SecGroupService) convertOSSecGroupToConfigSecGroup(osSecGroup groups.SecGroup) *openstackconfigv1.SecurityGroup {
-	rules := make([]openstackconfigv1.SecurityGroupRule, 0, len(osSecGroup.Rules))
+	rules := make([]openstackconfigv1.SecurityGroupRule, len(osSecGroup.Rules))
 	for i, rule := range osSecGroup.Rules {
 		rules[i] = s.convertOSSecGroupRuleToConfigSecGroupRule(rule)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR fixes index out of range error if managedSecurityGroups is set to true.

**Which issue(s) this PR fixes** 
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/225

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note 
NONE
```
