### PR TITLE
Delete SecurityGroups from cluster

### DIFF
--- a/pkg/cloud/openstack/cluster/actuator.go
+++ b/pkg/cloud/openstack/cluster/actuator.go
@@ -100,6 +100,11 @@ func (a *Actuator) Delete(cluster *clusterv1.Cluster) error {
 		return err
 	}
 
+	secGroupService, err := clients.NewSecGroupService(client)
+	if err != nil {
+		return err
+	}
+
 	// Load provider config.
 	_, err = providerv1.ClusterSpecFromProviderSpec(cluster.Spec.ProviderSpec)
 	if err != nil {
@@ -107,12 +112,28 @@ func (a *Actuator) Delete(cluster *clusterv1.Cluster) error {
 	}
 
 	// Load provider status.
-	_, err = providerv1.ClusterStatusFromProviderStatus(cluster.Status.ProviderStatus)
+	providerStatus, err := providerv1.ClusterStatusFromProviderStatus(cluster.Status.ProviderStatus)
 	if err != nil {
 		return errors.Errorf("failed to load cluster provider status: %v", err)
 	}
 
 	// Delete other things
+
+	if providerStatus.GlobalSecurityGroup != nil {
+		klog.Infof("Deleting global security group %q", providerStatus.GlobalSecurityGroup.Name)
+		err := secGroupService.Delete(providerStatus.GlobalSecurityGroup)
+		if err != nil {
+			return errors.Errorf("failed to delete security group: %v", err)
+		}
+	}
+
+	if providerStatus.ControlPlaneSecurityGroup != nil {
+		klog.Infof("Deleting control plane security group %q", providerStatus.ControlPlaneSecurityGroup.Name)
+		err := secGroupService.Delete(providerStatus.ControlPlaneSecurityGroup)
+		if err != nil {
+			return errors.Errorf("failed to delete security group: %v", err)
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
This changes provide security groups removal
during cluster deletion if managedSecurityGroups
is true in clusterSpec.providerSpec

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

Fixes #227 
