### PR TITLE
fix docker version issue.

### DIFF
--- a/cmd/clusterctl/examples/openstack/provider-component/user-data/ubuntu/templates/master-user-data.sh
+++ b/cmd/clusterctl/examples/openstack/provider-component/user-data/ubuntu/templates/master-user-data.sh
@@ -55,7 +55,8 @@ function install_configure_docker () {
     echo "exit 101" > /usr/sbin/policy-rc.d
     chmod +x /usr/sbin/policy-rc.d
     trap "rm /usr/sbin/policy-rc.d" RETURN
-    apt-get install -y docker.io
+    docker_version=$(apt-cache policy docker.io | grep 18.06 | awk '{print $1}' | head -n1)
+    apt-get install -y docker.io=${docker_version}
     echo 'DOCKER_OPTS="--iptables=false --ip-masq=false"' > /etc/default/docker
 
     # Reset iptables config

--- a/cmd/clusterctl/examples/openstack/provider-component/user-data/ubuntu/templates/worker-user-data.sh
+++ b/cmd/clusterctl/examples/openstack/provider-component/user-data/ubuntu/templates/worker-user-data.sh
@@ -26,7 +26,8 @@ function install_configure_docker () {
     echo "exit 101" > /usr/sbin/policy-rc.d
     chmod +x /usr/sbin/policy-rc.d
     trap "rm /usr/sbin/policy-rc.d" RETURN
-    apt-get install -y docker.io
+    docker_version=$(apt-cache policy docker.io | grep 18.06 | awk '{print $1}' | head -n1)
+    apt-get install -y docker.io=${docker_version}
     echo 'DOCKER_OPTS="--iptables=false --ip-masq=false"' > /etc/default/docker
 
     # Reset iptables config


### PR DESCRIPTION
**What this PR does / why we need it**:

In ubuntu, the latest docker version(`18.09`) is incompatible with `kubeadm`, resulting `user-data` executing failure. See: https://github.com/kubernetes/minikube/issues/3323

/cc @gyliu513 @xunpan 