### PR TITLE
Migrated kubeadm config to v1beta1 for kubeadm 1.14

### DIFF
--- a/cmd/clusterctl/examples/openstack/provider-component/user-data/centos/templates/worker-user-data.sh
+++ b/cmd/clusterctl/examples/openstack/provider-component/user-data/centos/templates/worker-user-data.sh
@@ -45,17 +45,21 @@ echo $OPENSTACK_CLOUD_PROVIDER_CONF | base64 -d > /etc/kubernetes/cloud.conf
 
 # Set up kubeadm config file to pass to kubeadm join.
 cat > /etc/kubernetes/kubeadm_config.yaml <<EOF
-apiVersion: kubeadm.k8s.io/v1alpha3
+apiVersion: kubeadm.k8s.io/v1beta1
 kind: JoinConfiguration
+caCertPath: /etc/kubernetes/pki/ca.crt
+discovery:
+  bootstrapToken:
+    apiServerEndpoint: ${MASTER}
+    token: ${TOKEN}
+    unsafeSkipCAVerification: true
+  timeout: 5m0s
+  tlsBootstrapToken: xp87ac.oaev5jvtje9f0g5h
 nodeRegistration:
-  name: $(hostname -s)
+  criSocket: /var/run/dockershim.sock
   kubeletExtraArgs:
-    cloud-provider: "openstack"
-    cloud-config: "/etc/kubernetes/cloud.conf"
-token: ${TOKEN}
-discoveryTokenAPIServers:
-  - ${MASTER}
-discoveryTokenUnsafeSkipCAVerification: true
+    cloud-config: /etc/kubernetes/cloud.conf
+    cloud-provider: openstack
 EOF
 
 cat <<EOF > /etc/default/kubelet

--- a/cmd/clusterctl/examples/openstack/provider-component/user-data/ubuntu/templates/worker-user-data.sh
+++ b/cmd/clusterctl/examples/openstack/provider-component/user-data/ubuntu/templates/worker-user-data.sh
@@ -79,16 +79,21 @@ echo $OPENSTACK_CLOUD_PROVIDER_CONF | base64 -d > /etc/kubernetes/cloud.conf
 
 # Set up kubeadm config file to pass to kubeadm join.
 cat > /etc/kubernetes/kubeadm_config.yaml <<EOF
-apiVersion: kubeadm.k8s.io/v1alpha3
+apiVersion: kubeadm.k8s.io/v1beta1
 kind: JoinConfiguration
+caCertPath: /etc/kubernetes/pki/ca.crt
+discovery:
+  bootstrapToken:
+    apiServerEndpoint: ${MASTER}
+    token: ${TOKEN}
+    unsafeSkipCAVerification: true
+  timeout: 5m0s
+  tlsBootstrapToken: xp87ac.oaev5jvtje9f0g5h
 nodeRegistration:
+  criSocket: /var/run/dockershim.sock
   kubeletExtraArgs:
-    cloud-provider: "openstack"
-    cloud-config: "/etc/kubernetes/cloud.conf"
-token: ${TOKEN}
-discoveryTokenAPIServers:
-  - ${MASTER}
-discoveryTokenUnsafeSkipCAVerification: true
+    cloud-config: /etc/kubernetes/cloud.conf
+    cloud-provider: openstack
 EOF
 
 # Override network args to use kubenet instead of cni, override Kubelet DNS args and


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Kubeadm 1.14.0 does not support v1alpha3 for anything else than
migrating the config.

See: https://github.com/kubernetes/kubernetes/pull/74025

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

The resulted config is produced by `kubeadm config migrate`.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
