### PR TITLE
Use apps/v1 for deployment apiVersion

### DIFF
--- a/overlays-config/coreos/manager/deployment.yaml
+++ b/overlays-config/coreos/manager/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: clusterapi-controllers

--- a/overlays-config/generic/manager/deployment.yaml
+++ b/overlays-config/generic/manager/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: clusterapi-controllers


### PR DESCRIPTION
PR 319 fixed the deployment configuration file but failed to add kustomize update..

Error: failed to find an object with gvk.Gvk{Group:"apps", Version:"v1beta1", Kind:"Deployment"} to apply the patch

was caused by kustomize function, this is because the kustomize file didn't updated with the main manager file...
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
