### PR TITLE
Fix cluster nil lead to panic

### DIFF
--- a/pkg/cloud/openstack/cluster/actuator.go
+++ b/pkg/cloud/openstack/cluster/actuator.go
@@ -41,6 +41,10 @@ func NewActuator(params providerv1openstack.ActuatorParams) (*Actuator, error) {
 
 // Reconcile creates or applies updates to the cluster.
 func (a *Actuator) Reconcile(cluster *clusterv1.Cluster) error {
+	if cluster == nil {
+		return fmt.Errorf("The cluster is nil, check your cluster configuration")
+	}
+
 	klog.Infof("Reconciling cluster %v.", cluster.Name)
 	clusterName := fmt.Sprintf("%s-%s", cluster.Namespace, cluster.Name)
 

--- a/pkg/cloud/openstack/machine/actuator.go
+++ b/pkg/cloud/openstack/machine/actuator.go
@@ -82,6 +82,10 @@ func getTimeout(name string, timeout int) time.Duration {
 }
 
 func (oc *OpenstackClient) Create(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
+	if cluster == nil {
+		return fmt.Errorf("The cluster is nil, check your cluster configuration")
+	}
+
 	kubeClient := oc.params.KubeClient
 
 	machineService, err := clients.NewInstanceServiceFromMachine(kubeClient, machine)
@@ -258,6 +262,10 @@ func (oc *OpenstackClient) Delete(ctx context.Context, cluster *clusterv1.Cluste
 }
 
 func (oc *OpenstackClient) Update(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
+	if cluster == nil {
+		return fmt.Errorf("The cluster is nil, check your cluster configuration")
+	}
+
 	status, err := oc.instanceStatus(machine)
 	if err != nil {
 		return err


### PR DESCRIPTION
cluster variable might be be nil due to some configuration error
so this patch adds a check of cluster status before use it



**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #317 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
