### PR TITLE
no need to check the cgroup driver in user data

### DIFF
--- a/cmd/clusterctl/examples/openstack/provider-component/user-data/centos/templates/master-user-data.sh
+++ b/cmd/clusterctl/examples/openstack/provider-component/user-data/centos/templates/master-user-data.sh
@@ -77,13 +77,6 @@ function install_configure_docker () {
 
 install_configure_docker
 
-# Get docker cgroup driver for kubelet configuration
-CG_DRIVER=$(docker info --format '{{.CgroupDriver}}')
-
-cat <<EOF > /etc/default/kubelet
-KUBELET_KUBEADM_EXTRA_ARGS=--cgroup-driver=$CG_DRIVER
-EOF
-
 systemctl enable kubelet.service
 
 modprobe br_netfilter

--- a/cmd/clusterctl/examples/openstack/provider-component/user-data/centos/templates/worker-user-data.sh
+++ b/cmd/clusterctl/examples/openstack/provider-component/user-data/centos/templates/worker-user-data.sh
@@ -47,9 +47,6 @@ function install_configure_docker () {
 
 install_configure_docker
 
-# Get docker cgroup driver for kubelet configuration
-CG_DRIVER=$(docker info --format '{{.CgroupDriver}}')
-
 # Write the cloud.conf so that the kubelet can use it.
 echo $OPENSTACK_CLOUD_PROVIDER_CONF | base64 -d > /etc/kubernetes/cloud.conf
 mkdir /etc/certs
@@ -74,9 +71,6 @@ nodeRegistration:
     cloud-provider: openstack
 EOF
 
-cat <<EOF > /etc/default/kubelet
-KUBELET_KUBEADM_EXTRA_ARGS=--cgroup-driver=$CG_DRIVER
-EOF
 systemctl enable kubelet.service
 
 modprobe br_netfilter


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

without this PR, the test template can not parse the {{.CgrouDriver}} and throws below errors:
```
E0505 13:41:20.202163       1 machineScript.go:67] the erro was: template: masterStartUp:81:36: executing "masterStartUp" at <.CgroupDriver>: can't evaluate field CgroupDriver in type machine.setupParams
E0505 13:41:20.208434       1 actuator.go:385] Machine error hchenxa-master-tx6nn: error creating Openstack instance: template: masterStartUp:81:36: executing "masterStartUp" at <.CgroupDriver>: can't evaluate field CgroupDriver in type machine.setupParams
```

and looks like we do not need to check the cgroup driver as kubeadm will help to do this check, refer https://github.com/kubernetes/kubernetes/pull/64347/files

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
