### PR TITLE
the generate.sh exited when the cluster.yaml exists

### DIFF
--- a/cmd/clusterctl/examples/openstack/generate-yaml.sh
+++ b/cmd/clusterctl/examples/openstack/generate-yaml.sh
@@ -140,8 +140,8 @@ CACERT="/etc/certs/cacert"
 
 # Set up the output dir if it does not yet exist
 mkdir -p $PWD/$OUTPUT
-cp -n $PWD/cluster.yaml $PWD/$OUTPUT/cluster.yaml
-cp -n $PWD/machines.yaml.template $PWD/$OUTPUT/machines.yaml
+cp -n $PWD/cluster.yaml $PWD/$OUTPUT/cluster.yaml || true
+cp -n $PWD/machines.yaml.template $PWD/$OUTPUT/machines.yaml || true
 
 # Make the config directory
 mkdir -p $CONFIG_DIR


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

below code will exited when the cluster.yaml exists.
```
# Set up the output dir if it does not yet exist
mkdir -p $PWD/$OUTPUT
cp -n $PWD/cluster.yaml.template $PWD/$OUTPUT/cluster.yaml  >>>>>>>> The return code was 1
cp -n $PWD/machines.yaml.template $PWD/$OUTPUT/machines.yaml 
```

so in order to avoid the file overwrite and keep the updated file of cluster.yaml and machines.yaml, create this PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
