### PR TITLE
change base image to fix security issue

### DIFF
--- a/cmd/manager/Dockerfile
+++ b/cmd/manager/Dockerfile
@@ -23,10 +23,10 @@ COPY vendor/ vendor/
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager sigs.k8s.io/cluster-api-provider-openstack/cmd/manager
 
 # Copy manager into a thin image
-FROM debian:stretch-slim
+FROM alpine:latest
 WORKDIR /
 
-RUN apt-get update && apt-get install -y ca-certificates
+RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 
 COPY --from=builder /go/src/sigs.k8s.io/cluster-api-provider-openstack/manager .
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Change base image to fix security issues.
1) Build image local and docker run works.
2) Push quay.io to do security scan.
3) Same issue has been fixed.
https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/issues/115

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #345

**Special notes for your reviewer**:
Scan result from link below.
https://quay.io/repository/wanghh2000/openstack-cluster-api-controller/manifest/sha256:254ae9a09659f381de4bfb8e988f04a37eb20153657cbf2292fb5a7932148157?tab=vulnerabilities

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.
No version change.

**Release note**:
```release-note
NONE
```
