### PR TITLE
workaround master and node failed to start

### DIFF
--- a/cmd/clusterctl/examples/openstack/provider-component/user-data/centos/templates/master-user-data.sh
+++ b/cmd/clusterctl/examples/openstack/provider-component/user-data/centos/templates/master-user-data.sh
@@ -105,7 +105,6 @@ nodeRegistration:
   criSocket: /var/run/dockershim.sock
   kubeletExtraArgs:
     cloud-config: /etc/kubernetes/cloud.conf
-    cloud-provider: openstack
   taints:
   - effect: NoSchedule
     key: node-role.kubernetes.io/master
@@ -116,7 +115,6 @@ kubernetesVersion: v${CONTROL_PLANE_VERSION}
 apiServer:
   extraArgs:
     cloud-config: /etc/kubernetes/cloud.conf
-    cloud-provider: openstack
   extraVolumes:
   - hostPath: /etc/kubernetes/cloud.conf
     mountPath: /etc/kubernetes/cloud.conf
@@ -134,7 +132,6 @@ controllerManager:
   extraArgs:
     allocate-node-cidrs: "true"
     cloud-config: /etc/kubernetes/cloud.conf
-    cloud-provider: openstack
     cluster-cidr: ${POD_CIDR}
     service-cluster-ip-range: ${SERVICE_CIDR}
   extraVolumes:

--- a/cmd/clusterctl/examples/openstack/provider-component/user-data/centos/templates/worker-user-data.sh
+++ b/cmd/clusterctl/examples/openstack/provider-component/user-data/centos/templates/worker-user-data.sh
@@ -68,7 +68,6 @@ nodeRegistration:
   criSocket: /var/run/dockershim.sock
   kubeletExtraArgs:
     cloud-config: /etc/kubernetes/cloud.conf
-    cloud-provider: openstack
 EOF
 
 systemctl enable kubelet.service

--- a/cmd/clusterctl/examples/openstack/provider-component/user-data/coreos/templates/master.yaml
+++ b/cmd/clusterctl/examples/openstack/provider-component/user-data/coreos/templates/master.yaml
@@ -10,7 +10,6 @@ storage:
           bindPort: 443
         nodeRegistration:
           kubeletExtraArgs:
-            cloud-provider: "openstack"
             cloud-config: "/etc/kubernetes/cloud.conf"
         ---
         apiVersion: kubeadm.k8s.io/v1beta1
@@ -25,7 +24,6 @@ storage:
         controlPlaneEndpoint: ${MASTER}
         apiServer:
           extraArgs:
-            cloud-provider: "openstack"
             cloud-config: "/etc/kubernetes/cloud.conf"
           extraVolumes:
           - name: cloud
@@ -39,7 +37,6 @@ storage:
             cluster-cidr: {{ .PodCIDR }}
             service-cluster-ip-range: {{ .ServiceCIDR }}
             allocate-node-cidrs: "true"
-            cloud-provider: "openstack"
             cloud-config: "/etc/kubernetes/cloud.conf"
           extraVolumes:
           - name: cloud

--- a/cmd/clusterctl/examples/openstack/provider-component/user-data/coreos/templates/worker.yaml
+++ b/cmd/clusterctl/examples/openstack/provider-component/user-data/coreos/templates/worker.yaml
@@ -8,7 +8,6 @@ storage:
         kind: JoinConfiguration
         nodeRegistration:
           kubeletExtraArgs:
-            cloud-provider: "openstack"
             cloud-config: "/etc/kubernetes/cloud.conf"
         discovery:
           bootstrapToken:

--- a/cmd/clusterctl/examples/openstack/provider-component/user-data/ubuntu/templates/master-user-data.sh
+++ b/cmd/clusterctl/examples/openstack/provider-component/user-data/ubuntu/templates/master-user-data.sh
@@ -138,7 +138,6 @@ nodeRegistration:
   criSocket: /var/run/dockershim.sock
   kubeletExtraArgs:
     cloud-config: /etc/kubernetes/cloud.conf
-    cloud-provider: openstack
   taints:
   - effect: NoSchedule
     key: node-role.kubernetes.io/master
@@ -149,7 +148,6 @@ kubernetesVersion: v${CONTROL_PLANE_VERSION}
 apiServer:
   extraArgs:
     cloud-config: /etc/kubernetes/cloud.conf
-    cloud-provider: openstack
   extraVolumes:
   - hostPath: /etc/kubernetes/cloud.conf
     mountPath: /etc/kubernetes/cloud.conf
@@ -167,7 +165,6 @@ controllerManager:
   extraArgs:
     allocate-node-cidrs: "true"
     cloud-config: /etc/kubernetes/cloud.conf
-    cloud-provider: openstack
     cluster-cidr: ${POD_CIDR}
     service-cluster-ip-range: ${SERVICE_CIDR}
   extraVolumes:

--- a/cmd/clusterctl/examples/openstack/provider-component/user-data/ubuntu/templates/worker-user-data.sh
+++ b/cmd/clusterctl/examples/openstack/provider-component/user-data/ubuntu/templates/worker-user-data.sh
@@ -98,7 +98,6 @@ nodeRegistration:
   criSocket: /var/run/dockershim.sock
   kubeletExtraArgs:
     cloud-config: /etc/kubernetes/cloud.conf
-    cloud-provider: openstack
 EOF
 
 # Override network args to use kubenet instead of cni, override Kubelet DNS args and


### PR DESCRIPTION
cloud-provider flag has some indication to k8s itself
on cloud provider, this PR makes workaround to clear
the cloud-provider settings and we can add it back later.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #391 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
