### PR TITLE
fix generate-yaml by escaping newlines

### DIFF
--- a/cmd/clusterctl/examples/openstack/provider-component/user-data/coreos/templates/master.yaml
+++ b/cmd/clusterctl/examples/openstack/provider-component/user-data/coreos/templates/master.yaml
@@ -9,8 +9,7 @@ storage:
       id: 0
     mode: 0640
     contents:
-      inline: |
-{{ .CACert | Indent 10}}
+      inline: "{{ .CACert | EscapeNewLines }}"
 
   - path: /etc/kubernetes/pki/ca.key
     filesystem: root
@@ -20,8 +19,7 @@ storage:
       id: 0
     mode: 0600
     contents:
-      inline: |
-{{ .CAKey | Indent 10}}
+      inline: "{{ .CAKey | EscapeNewLines }}"
 
   - path: /etc/kubernetes/pki/etcd/ca.crt
     filesystem: root
@@ -31,8 +29,7 @@ storage:
       id: 0
     mode: 0640
     contents:
-      inline: |
-{{ .EtcdCACert | Indent 10}}
+      inline: "{{ .EtcdCACert | EscapeNewLines }}"
 
   - path: /etc/kubernetes/pki/etcd/ca.key
     filesystem: root
@@ -42,8 +39,7 @@ storage:
       id: 0
     mode: 0600
     contents:
-      inline: |
-{{ .EtcdCAKey | Indent 10}}
+      inline: "{{ .EtcdCAKey | EscapeNewLines }}"
 
   - path: /etc/kubernetes/pki/front-proxy-ca.crt
     filesystem: root
@@ -53,8 +49,7 @@ storage:
       id: 0
     mode: 0640
     contents:
-      inline: |
-{{ .FrontProxyCACert | Indent 10}}
+      inline: "{{ .FrontProxyCACert | EscapeNewLines }}"
 
   - path: /etc/kubernetes/pki/front-proxy-ca.key
     filesystem: root
@@ -64,8 +59,7 @@ storage:
       id: 0
     mode: 0600
     contents:
-      inline: |
-{{ .FrontProxyCAKey | Indent 10}}
+      inline: "{{ .FrontProxyCAKey | EscapeNewLines }}"
 
   - path: /etc/kubernetes/pki/sa.pub
     filesystem: root
@@ -75,8 +69,7 @@ storage:
       id: 0
     mode: 0640
     contents:
-      inline: |
-{{ .SaCert | Indent 10}}
+      inline: "{{ .SaCert | EscapeNewLines }}"
 
   - path: /etc/kubernetes/pki/sa.key
     filesystem: root
@@ -86,8 +79,7 @@ storage:
       id: 0
     mode: 0600
     contents:
-      inline: |
-{{ .SaKey | Indent 10}}
+      inline: "{{ .SaKey | EscapeNewLines }}"
 
 
   - path: /etc/kubernetes/kubeadm_config.yaml

--- a/pkg/cloud/openstack/services/userdata/machinescript.go
+++ b/pkg/cloud/openstack/services/userdata/machinescript.go
@@ -289,7 +289,8 @@ func masterStartupScript(cluster *clusterv1.Cluster, machine *clusterv1.Machine,
 	}
 
 	fMap := map[string]interface{}{
-		"Indent": templateYAMLIndent,
+		"EscapeNewLines": templateEscapeNewLines,
+		"Indent":         templateYAMLIndent,
 	}
 
 	masterStartUpScript := template.Must(template.New("masterStartUp").Funcs(fMap).Parse(script))
@@ -366,6 +367,10 @@ func getSubnet(netRange clusterv1.NetworkRanges) string {
 		return ""
 	}
 	return netRange.CIDRBlocks[0]
+}
+
+func templateEscapeNewLines(s string) string {
+	return strings.ReplaceAll(s, "\n", "\\n")
 }
 
 func templateYAMLIndent(i int, input string) string {


### PR DESCRIPTION
We had a problem with generate-yaml.sh because yq rejected the invalid YAML.
To work around this we have to make sure the master.yaml is also a valid YAML.
So functions like Indent are no option. One option to solve this would have been
base64Encode, but the problem is that Ignition has no property to specify that the
inline content is base64 encoded. The only would have been `inline: !! binary |`, but
then yq complains that {{ .CaCert | Base64Encode }} is not correctly encoded.

So the solution was to just replace the new lines with \n

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #402

