### PR TITLE
Pr create floating ip on demand

### DIFF
--- a/pkg/cloud/openstack/machine/actuator.go
+++ b/pkg/cloud/openstack/machine/actuator.go
@@ -155,7 +155,7 @@ func (a *Actuator) Create(ctx context.Context, cluster *clusterv1.Cluster, machi
 	}
 
 	if machineProviderSpec.FloatingIP != "" {
-		err := networkingService.CreateFloatingIP(clusterProviderSpec, machineProviderSpec.FloatingIP)
+		err := networkingService.GetOrCreateFloatingIP(clusterProviderSpec, machineProviderSpec.FloatingIP)
 		if err != nil {
 			return a.handleMachineError(machine, apierrors.CreateMachine(
 				"Create floatingIP err: %v", err))

--- a/pkg/cloud/openstack/machine/actuator.go
+++ b/pkg/cloud/openstack/machine/actuator.go
@@ -27,6 +27,7 @@ import (
 	constants "sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/openstack/contants"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/openstack/services/compute"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/openstack/services/loadbalancer"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/openstack/services/networking"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/openstack/services/provider"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/openstack/services/userdata"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/deployer"
@@ -96,6 +97,11 @@ func (a *Actuator) Create(ctx context.Context, cluster *clusterv1.Cluster, machi
 		return err
 	}
 
+	networkingService, err := networking.NewService(osProviderClient, clientOpts)
+	if err != nil {
+		return err
+	}
+
 	clusterProviderSpec, clusterProviderStatus, err := providerv1.ClusterSpecAndStatusFromProviderSpec(cluster)
 	if err != nil {
 		return a.handleMachineError(machine, apierrors.CreateMachine(
@@ -149,7 +155,13 @@ func (a *Actuator) Create(ctx context.Context, cluster *clusterv1.Cluster, machi
 	}
 
 	if machineProviderSpec.FloatingIP != "" {
-		err := computeService.AssociateFloatingIP(instance.ID, machineProviderSpec.FloatingIP)
+		err := networkingService.CreateFloatingIP(clusterProviderSpec, machineProviderSpec.FloatingIP)
+		if err != nil {
+			return a.handleMachineError(machine, apierrors.CreateMachine(
+				"Create floatingIP err: %v", err))
+		}
+
+		err = computeService.AssociateFloatingIP(instance.ID, machineProviderSpec.FloatingIP)
 		if err != nil {
 			return a.handleMachineError(machine, apierrors.CreateMachine(
 				"Associate floatingIP err: %v", err))

--- a/pkg/cloud/openstack/services/networking/floatingip.go
+++ b/pkg/cloud/openstack/services/networking/floatingip.go
@@ -1,0 +1,66 @@
+package networking
+
+import (
+	"fmt"
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog"
+	providerv1 "sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1"
+	"time"
+)
+
+func (s *Service) CreateFloatingIP(clusterProviderSpec *providerv1.OpenstackClusterProviderSpec, ip string) error {
+	fp, err := checkIfFloatingIPExists(s.client, ip)
+	if err != nil {
+		return err
+	}
+	if fp == nil {
+		klog.Infof("Creating floating ip %s", ip)
+		fpCreateOpts := &floatingips.CreateOpts{
+			FloatingIP:        ip,
+			FloatingNetworkID: clusterProviderSpec.ExternalNetworkID,
+		}
+		fp, err = floatingips.Create(s.client, fpCreateOpts).Extract()
+		if err != nil {
+			return fmt.Errorf("error allocating floating IP: %s", err)
+		}
+		err = waitForFloatingIP(s.client, fp.ID, "ACTIVE")
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func checkIfFloatingIPExists(client *gophercloud.ServiceClient, ip string) (*floatingips.FloatingIP, error) {
+	allPages, err := floatingips.List(client, floatingips.ListOpts{FloatingIP: ip}).AllPages()
+	if err != nil {
+		return nil, err
+	}
+	fpList, err := floatingips.ExtractFloatingIPs(allPages)
+	if err != nil {
+		return nil, err
+	}
+	if len(fpList) == 0 {
+		return nil, nil
+	}
+	return &fpList[0], nil
+}
+
+var backoff = wait.Backoff{
+	Steps:    10,
+	Duration: 30 * time.Second,
+	Factor:   1.0,
+	Jitter:   0.1,
+}
+
+func waitForFloatingIP(client *gophercloud.ServiceClient, id, target string) error {
+	klog.Infof("Waiting for floatingip %s to become %s.", id, target)
+	return wait.ExponentialBackoff(backoff, func() (bool, error) {
+		fp, err := floatingips.Get(client, id).Extract()
+		if err != nil {
+			return false, err
+		}
+		return fp.Status == target, nil
+	})
+}

--- a/pkg/cloud/openstack/services/networking/floatingip.go
+++ b/pkg/cloud/openstack/services/networking/floatingip.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-func (s *Service) CreateFloatingIP(clusterProviderSpec *providerv1.OpenstackClusterProviderSpec, ip string) error {
+func (s *Service) GetOrCreateFloatingIP(clusterProviderSpec *providerv1.OpenstackClusterProviderSpec, ip string) error {
 	fp, err := checkIfFloatingIPExists(s.client, ip)
 	if err != nil {
 		return err
@@ -25,11 +25,8 @@ func (s *Service) CreateFloatingIP(clusterProviderSpec *providerv1.OpenstackClus
 		if err != nil {
 			return fmt.Errorf("error allocating floating IP: %s", err)
 		}
-		err = waitForFloatingIP(s.client, fp.ID, "ACTIVE")
-		if err != nil {
-			return err
-		}
 	}
+	return nil
 }
 
 func checkIfFloatingIPExists(client *gophercloud.ServiceClient, ip string) (*floatingips.FloatingIP, error) {


### PR DESCRIPTION
This PR creates machine floating ips if they don't exist. Depending on the interpretation fixes https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/427 :)

**What this PR does / why we need it**:
Floating IP handling is now consistent. LoadBalancer & machine floating ip's are both created if they don't already exist. If they already exist they are just associated.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #427
