### PR TITLE
Hostname missing in /etc/hosts file in openstack instance

### DIFF
--- a/cmd/clusterctl/examples/openstack/provider-component/user-data/ubuntu/templates/master-user-data.sh
+++ b/cmd/clusterctl/examples/openstack/provider-component/user-data/ubuntu/templates/master-user-data.sh
@@ -10,6 +10,7 @@ MACHINE+="/"
 MACHINE+={{ .Machine.ObjectMeta.Name }}
 ARCH=amd64
 swapoff -a
+echo "127.0.0.1 $(hostname)"  >> /etc/hosts
 # disable swap in fstab
 sed -i.bak -r 's/(.+ swap .+)/#\1/' /etc/fstab
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -

--- a/cmd/clusterctl/examples/openstack/provider-component/user-data/ubuntu/templates/worker-user-data.sh
+++ b/cmd/clusterctl/examples/openstack/provider-component/user-data/ubuntu/templates/worker-user-data.sh
@@ -9,6 +9,7 @@ MACHINE+="/"
 MACHINE+={{ .Machine.ObjectMeta.Name }}
 
 swapoff -a
+echo "127.0.0.1 $(hostname)"  >> /etc/hosts
 # disable swap in fstab
 sed -i.bak -r 's/(.+ swap .+)/#\1/' /etc/fstab
 apt-get update


### PR DESCRIPTION
#436 

> What I felt is when any sudo commands run from master-user-data.sh, it hangs for a bit and then proceeds. If we can map loopback-ip to the hostname in /etc/hosts (can add command in master-user-data file), it would not get stuck.