### PR TITLE
Fix generation issue

### DIFF
--- a/examples/provider-components/manager_tolerations_patch.yaml
+++ b/examples/provider-components/manager_tolerations_patch.yaml
@@ -42,8 +42,8 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: cluster-api-controller-manager
-  namespace: cluster-api-system
+  name: capi-controller-manager
+  namespace: capi-system
 spec:
   template:
     spec:


### PR DESCRIPTION
fix following error:

when 
./generate.sh clouds.yaml openstack output1

Error: no matches for OriginalId apps_v1_Deployment|cluster-api-system|cluster-api-controller-manager; no matches for CurrentId apps_v1_Deployment|cluster-api-system|cluster-api-controller-manager; failed to find unique target for patch apps_v1_Deployment|cluster-api-controller-manager

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
