### PR TITLE
Fix api port

### DIFF
--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -170,10 +170,17 @@ func (r *OpenStackClusterReconciler) reconcileCluster(logger logr.Logger, cluste
 			return reconcile.Result{}, errors.Errorf("failed to get control plane machine: %v", err)
 		}
 		if controlPlaneMachine != nil {
+			var apiPort int
+			if cluster.Spec.ClusterNetwork.APIServerPort == nil {
+				logger.Info("No API endpoint given, default to 6443")
+				apiPort = 6443
+			} else {
+				apiPort = int(*cluster.Spec.ClusterNetwork.APIServerPort)
+			}
 			openStackCluster.Status.APIEndpoints = []infrav1.APIEndpoint{
 				{
 					Host: controlPlaneMachine.Spec.FloatingIP,
-					Port: int(*cluster.Spec.ClusterNetwork.APIServerPort),
+					Port: apiPort,
 				},
 			}
 		} else {

--- a/examples/cluster/cluster.yaml
+++ b/examples/cluster/cluster.yaml
@@ -15,7 +15,7 @@ spec:
     # * Disable the apiServerPort property
     # single-node control-plane:
     # * Enable the apiServerPort property
-    #apiServerPort: 6443
+    apiServerPort: <disable when multi-node control-plane>
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
     kind: OpenStackCluster


### PR DESCRIPTION
The kustomize will remove the # comments ... so no one knows the info provided
and even if we some one failed to set the failure, we should not let container panic ...
so I added a default value here

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
