### PR TITLE
Stop Instance creation on invalid Network spec

### DIFF
--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -130,6 +130,10 @@ func (s *Service) InstanceCreate(clusterName string, machine *clusterv1.Machine,
 			}
 		}
 	}
+	if len(nets) == 0 {
+		return nil, fmt.Errorf("no network was found or provided. Please check your machine configuration and try again")
+	}
+
 	portsList := []servers.Network{}
 	for _, net := range nets {
 		if net.networkID == "" {


### PR DESCRIPTION
Before triggering the creation of a new Instance in OpenStack, Network
filters are used to fetch actual NetworkIDs from OpenStack.

Before this change, if no OpenShift network was found based on the
filters, the Instance spec was sent to OpenStack with an empty Network
segment, resulting in an error.

With this change, Create returns an error to the caller if no matching
networks are found in Openstack.

**What this PR does / why we need it**:

A Machine definition with an invalid Network section is currently converted for OpenStack to an Instance definition with an empty Network section, resulting in a `Bad Request` with error message `'networks' is a required property`.

```
spec:
  providerSpec:
    value:
      networks:
      - filter: {}
        subnets:
        - filter:
            name: cluster-nodes
            tags: openshiftClusterID=i-do-not-exist
```