### PR TITLE
use existing networks, fallback to network/subnet defined in cluster …

### DIFF
--- a/api/v1alpha2/openstackcluster_types.go
+++ b/api/v1alpha2/openstackcluster_types.go
@@ -42,6 +42,13 @@ type OpenStackClusterSpec struct {
 	// network, a subnet with NodeCIDR, and a router connected to this subnet.
 	// If you leave this empty, no network will be created.
 	NodeCIDR string `json:"nodeCidr,omitempty"`
+
+	// If NodeCIDR cannot be set this can be used to detect an existing network.
+	Network Filter `json:"networks,omitempty"`
+
+	// If NodeCIDR cannot be set this can be used to detect an existing subnet.
+	Subnet SubnetFilter `json:"networks,omitempty"`
+
 	// DNSNameservers is the list of nameservers for OpenStack Subnet being created.
 	DNSNameservers []string `json:"dnsNameservers,omitempty"`
 	// ExternalRouterIPs is an array of externalIPs on the respective subnets.

--- a/api/v1alpha2/openstackcluster_types.go
+++ b/api/v1alpha2/openstackcluster_types.go
@@ -44,10 +44,10 @@ type OpenStackClusterSpec struct {
 	NodeCIDR string `json:"nodeCidr,omitempty"`
 
 	// If NodeCIDR cannot be set this can be used to detect an existing network.
-	Network Filter `json:"networks,omitempty"`
+	Network Filter `json:"network,omitempty"`
 
 	// If NodeCIDR cannot be set this can be used to detect an existing subnet.
-	Subnet SubnetFilter `json:"networks,omitempty"`
+	Subnet SubnetFilter `json:"subnet,omitempty"`
 
 	// DNSNameservers is the list of nameservers for OpenStack Subnet being created.
 	DNSNameservers []string `json:"dnsNameservers,omitempty"`

--- a/api/v1alpha2/zz_generated.deepcopy.go
+++ b/api/v1alpha2/zz_generated.deepcopy.go
@@ -242,6 +242,8 @@ func (in *OpenStackClusterSpec) DeepCopyInto(out *OpenStackClusterSpec) {
 		*out = new(v1.SecretReference)
 		**out = **in
 	}
+	in.Network.DeepCopyInto(&out.Network)
+	in.Subnet.DeepCopyInto(&out.Subnet)
 	if in.DNSNameservers != nil {
 		in, out := &in.DNSNameservers, &out.DNSNameservers
 		*out = make([]string, len(*in))

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -192,6 +192,43 @@ spec:
                 and another one that allows all traffic to/from machines belonging
                 to that group. In the future, we could make this more flexible.
               type: boolean
+            network:
+              description: If NodeCIDR cannot be set this can be used to detect an
+                existing network.
+              properties:
+                adminStateUp:
+                  type: boolean
+                description:
+                  type: string
+                id:
+                  type: string
+                limit:
+                  type: integer
+                marker:
+                  type: string
+                name:
+                  type: string
+                notTags:
+                  type: string
+                notTagsAny:
+                  type: string
+                projectId:
+                  type: string
+                shared:
+                  type: boolean
+                sortDir:
+                  type: string
+                sortKey:
+                  type: string
+                status:
+                  type: string
+                tags:
+                  type: string
+                tagsAny:
+                  type: string
+                tenantId:
+                  type: string
+              type: object
             nodeCidr:
               description: NodeCIDR is the OpenStack Subnet to be created. Cluster
                 actuator will create a network, a subnet with NodeCIDR, and a router
@@ -207,6 +244,53 @@ spec:
                   type: string
                 key:
                   format: byte
+                  type: string
+              type: object
+            subnet:
+              description: If NodeCIDR cannot be set this can be used to detect an
+                existing subnet.
+              properties:
+                cidr:
+                  type: string
+                description:
+                  type: string
+                enableDhcp:
+                  type: boolean
+                gateway_ip:
+                  type: string
+                id:
+                  type: string
+                ipVersion:
+                  type: integer
+                ipv6AddressMode:
+                  type: string
+                ipv6RaMode:
+                  type: string
+                limit:
+                  type: integer
+                marker:
+                  type: string
+                name:
+                  type: string
+                networkId:
+                  type: string
+                notTags:
+                  type: string
+                notTagsAny:
+                  type: string
+                projectId:
+                  type: string
+                sortDir:
+                  type: string
+                sortKey:
+                  type: string
+                subnetpoolId:
+                  type: string
+                tags:
+                  type: string
+                tagsAny:
+                  type: string
+                tenantId:
                   type: string
               type: object
             tags:

--- a/examples/controlplane/controlplane.yaml
+++ b/examples/controlplane/controlplane.yaml
@@ -33,12 +33,6 @@ spec:
   image: <Image Name>
   sshKeyName: cluster-api-provider-openstack
   availabilityZone: nova
-  networks:
-  - filter:
-      name: k8s-clusterapi-cluster-${CLUSTER_NAME}-${CLUSTER_NAME}
-    subnets:
-    - filter:
-        name: k8s-clusterapi-cluster-${CLUSTER_NAME}-${CLUSTER_NAME}
   # multi-node control-plane:
   # * Disable the floatingIP property
   # single-node control-plane:
@@ -148,12 +142,6 @@ spec:
   image: <Image Name>
   sshKeyName: cluster-api-provider-openstack
   availabilityZone: nova
-  networks:
-  - filter:
-      name: k8s-clusterapi-cluster-${CLUSTER_NAME}-${CLUSTER_NAME}
-    subnets:
-    - filter:
-        name: k8s-clusterapi-cluster-${CLUSTER_NAME}-${CLUSTER_NAME}
   cloudName: $CLOUD
   cloudsSecret:
     name: cloud-config
@@ -229,12 +217,6 @@ spec:
   image: <Image Name>
   sshKeyName: cluster-api-provider-openstack
   availabilityZone: nova
-  networks:
-  - filter:
-      name: k8s-clusterapi-cluster-${CLUSTER_NAME}-${CLUSTER_NAME}
-    subnets:
-    - filter:
-        name: k8s-clusterapi-cluster-${CLUSTER_NAME}-${CLUSTER_NAME}
   cloudName: $CLOUD
   cloudsSecret:
     name: cloud-config

--- a/examples/machinedeployment/machinedeployment.yaml
+++ b/examples/machinedeployment/machinedeployment.yaml
@@ -49,12 +49,6 @@ spec:
         namespace: ${CLUSTER_NAME}
       flavor: m1.medium
       image: <Image Name>
-      networks:
-      - filter:
-          name: k8s-clusterapi-cluster-${CLUSTER_NAME}-${CLUSTER_NAME}
-        subnets:
-        - filter:
-            name: k8s-clusterapi-cluster-${CLUSTER_NAME}-${CLUSTER_NAME}
       sshKeyName: cluster-api-provider-openstack
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2

--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
 
-	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/common/extensions"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume"
@@ -41,7 +40,6 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
-	"github.com/gophercloud/gophercloud/pagination"
 	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha2"
 	"sigs.k8s.io/cluster-api/util"
 )
@@ -99,36 +97,51 @@ func (s *Service) InstanceCreate(clusterName string, machine *clusterv1.Machine,
 	}
 	// Get all network UUIDs
 	var nets []ServerNetwork
-	for _, net := range openStackMachine.Spec.Networks {
-		opts := networks.ListOpts(net.Filter)
-		opts.ID = net.UUID
-		ids, err := getNetworkIDsByFilter(s.networkClient, &opts)
-		if err != nil {
-			return nil, err
-		}
-		for _, netID := range ids {
-			if net.Subnets == nil {
-				nets = append(nets, ServerNetwork{
-					networkID: netID,
-				})
+	if len(openStackMachine.Spec.Networks) > 0 {
+		for _, net := range openStackMachine.Spec.Networks {
+			opts := networks.ListOpts(net.Filter)
+			opts.ID = net.UUID
+			ids, err := networking.GetNetworkIDsByFilter(s.networkClient, &opts)
+			if err != nil {
+				return nil, err
 			}
-
-			for _, subnet := range net.Subnets {
-				subnetOpts := subnets.ListOpts(subnet.Filter)
-				subnetOpts.ID = subnet.UUID
-				subnetOpts.NetworkID = netID
-				subnetsByFilter, err := networking.GetSubnetsByFilter(s.networkClient, &subnetOpts)
-				if err != nil {
-					return nil, err
-				}
-				for _, subnetByFilter := range subnetsByFilter {
+			for _, netID := range ids {
+				if net.Subnets == nil {
 					nets = append(nets, ServerNetwork{
-						networkID: subnetByFilter.NetworkID,
-						subnetID:  subnetByFilter.ID,
+						networkID: netID,
 					})
+					continue
+				}
+
+				for _, subnet := range net.Subnets {
+					subnetOpts := subnets.ListOpts(subnet.Filter)
+					subnetOpts.ID = subnet.UUID
+					subnetOpts.NetworkID = netID
+					subnetsByFilter, err := networking.GetSubnetsByFilter(s.networkClient, &subnetOpts)
+					if err != nil {
+						return nil, err
+					}
+					for _, subnetByFilter := range subnetsByFilter {
+						nets = append(nets, ServerNetwork{
+							networkID: subnetByFilter.NetworkID,
+							subnetID:  subnetByFilter.ID,
+						})
+					}
 				}
 			}
 		}
+	} else {
+		if openStackCluster.Status.Network == nil {
+			return nil, fmt.Errorf("no network was found in OpenStackCluster.Status.Network")
+		}
+		if openStackCluster.Status.Network.Subnet == nil {
+			return nil, fmt.Errorf("no subnet was found in OpenStackCluster.Status.Network")
+		}
+
+		nets = []ServerNetwork{{
+			networkID: openStackCluster.Status.Network.ID,
+			subnetID: openStackCluster.Status.Network.Subnet.ID,
+		}}
 	}
 	if len(nets) == 0 {
 		return nil, fmt.Errorf("no network was found or provided. Please check your machine configuration and try again")
@@ -322,31 +335,6 @@ func isDuplicate(list []string, name string) bool {
 		}
 	}
 	return false
-}
-
-// A function for getting the id of a network by querying openstack with filters
-func getNetworkIDsByFilter(networkClient *gophercloud.ServiceClient, opts networks.ListOptsBuilder) ([]string, error) {
-	if opts == nil {
-		return []string{}, fmt.Errorf("no Filters were passed")
-	}
-	pager := networks.List(networkClient, opts)
-	var uuids []string
-	err := pager.EachPage(func(page pagination.Page) (bool, error) {
-		networkList, err := networks.ExtractNetworks(page)
-		if err != nil {
-			return false, err
-		} else if len(networkList) == 0 {
-			return false, fmt.Errorf("no networks could be found with the filters provided")
-		}
-		for _, network := range networkList {
-			uuids = append(uuids, network.ID)
-		}
-		return true, nil
-	})
-	if err != nil {
-		return []string{}, err
-	}
-	return uuids, nil
 }
 
 func createPort(is *Service, name string, net ServerNetwork, securityGroups *[]string) (ports.Port, error) {

--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -140,7 +140,7 @@ func (s *Service) InstanceCreate(clusterName string, machine *clusterv1.Machine,
 
 		nets = []ServerNetwork{{
 			networkID: openStackCluster.Status.Network.ID,
-			subnetID: openStackCluster.Status.Network.Subnet.ID,
+			subnetID:  openStackCluster.Status.Network.Subnet.ID,
 		}}
 	}
 	if len(nets) == 0 {

--- a/pkg/cloud/services/networking/router.go
+++ b/pkg/cloud/services/networking/router.go
@@ -18,6 +18,7 @@ package networking
 
 import (
 	"fmt"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/record"
 
 	"github.com/gophercloud/gophercloud"
@@ -178,6 +179,50 @@ func (s *Service) getRouterInterfaces(routerID string) ([]ports.Port, error) {
 	}
 
 	return portList, nil
+}
+
+func (s *Service) GetNetworksByFilter(opts networks.ListOptsBuilder) ([]networks.Network, error) {
+	return GetNetworksByFilter(s.client, opts)
+}
+
+// getNetworkIDsByFilter retrieves network ids by querying openstack with filters
+func GetNetworkIDsByFilter(networkClient *gophercloud.ServiceClient, opts networks.ListOptsBuilder) ([]string, error) {
+	nets, err := GetNetworksByFilter(networkClient, opts)
+	if err != nil {
+		return nil, err
+	}
+	var ids []string
+	for _, network := range nets {
+		ids = append(ids, network.ID)
+	}
+	return ids, nil
+}
+
+// GetNetworksByFilter retrieves networks by querying openstack with filters
+func GetNetworksByFilter(networkClient *gophercloud.ServiceClient, opts networks.ListOptsBuilder) ([]networks.Network, error) {
+	if opts == nil {
+		return nil, fmt.Errorf("no Filters were passed")
+	}
+	pager := networks.List(networkClient, opts)
+	var nets []networks.Network
+	err := pager.EachPage(func(page pagination.Page) (bool, error) {
+		networkList, err := networks.ExtractNetworks(page)
+		if err != nil {
+			return false, err
+		} else if len(networkList) == 0 {
+			return false, fmt.Errorf("no networks could be found with the filters provided")
+		}
+		nets = networkList
+		return true, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return nets, nil
+}
+
+func (s *Service) GetSubnetsByFilter(opts subnets.ListOptsBuilder) ([]subnets.Subnet, error) {
+	return GetSubnetsByFilter(s.client, opts)
 }
 
 // A function for getting the id of a subnet by querying openstack with filters

--- a/pkg/cloud/services/networking/router.go
+++ b/pkg/cloud/services/networking/router.go
@@ -191,7 +191,7 @@ func GetNetworkIDsByFilter(networkClient *gophercloud.ServiceClient, opts networ
 	if err != nil {
 		return nil, err
 	}
-	var ids []string
+	ids := []string{}
 	for _, network := range nets {
 		ids = append(ids, network.ID)
 	}


### PR DESCRIPTION
This PR enables the following:
* reuse existing networks/subnet if they cannot be created (by defining NodeCIDR in the OpenStackCluster)
* define network/subnet on the cluster level so it doesn't has to be defined in every Machine (only works for one net/subnet not multiple)

Fixes #428