### PR TITLE
update calico version to v3.8 (#481)

### DIFF
--- a/cmd/clusterctl/examples/openstack/provider-component/user-data/centos/templates/master-user-data.sh
+++ b/cmd/clusterctl/examples/openstack/provider-component/user-data/centos/templates/master-user-data.sh
@@ -113,7 +113,7 @@ for tries in $(seq 1 60); do
     sleep 1
 done
 # By default, use calico for container network plugin, should make this configurable.
-kubectl --kubeconfig /etc/kubernetes/admin.conf apply -f https://docs.projectcalico.org/v3.5/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml
+kubectl --kubeconfig /etc/kubernetes/admin.conf apply -f https://docs.projectcalico.org/v3.8/manifests/calico.yaml
 
 mkdir -p /root/.kube
 cp -i /etc/kubernetes/admin.conf /root/.kube/config

--- a/cmd/clusterctl/examples/openstack/provider-component/user-data/coreos/templates/master.yaml
+++ b/cmd/clusterctl/examples/openstack/provider-component/user-data/coreos/templates/master.yaml
@@ -121,7 +121,7 @@ systemd:
       ExecStartPre=/opt/bin/prepare.sh
       ExecStart=/opt/bin/kubeadm init --config /etc/kubernetes/kubeadm_config.yaml
       ExecStartPost=/opt/bin/kubectl --kubeconfig /etc/kubernetes/kubelet.conf annotate --overwrite node %H machine={{ .Machine.ObjectMeta.Namespace }}/{{ .Machine.ObjectMeta.Name }}
-      ExecStartPost=/opt/bin/kubectl --kubeconfig /etc/kubernetes/admin.conf apply -f https://docs.projectcalico.org/v3.6/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml
+      ExecStartPost=/opt/bin/kubectl --kubeconfig /etc/kubernetes/admin.conf apply -f https://docs.projectcalico.org/v3.8/manifests/calico.yaml
       ExecStartPost=/usr/bin/systemctl disable kubeadm.service
 
       [Install]

--- a/cmd/clusterctl/examples/openstack/provider-component/user-data/ubuntu/templates/master-user-data.sh
+++ b/cmd/clusterctl/examples/openstack/provider-component/user-data/ubuntu/templates/master-user-data.sh
@@ -143,6 +143,6 @@ for tries in $(seq 1 60); do
     sleep 1
 done
 # By default, use calico for container network plugin, should make this configurable.
-kubectl --kubeconfig /etc/kubernetes/admin.conf apply -f https://docs.projectcalico.org/v3.5/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml
+kubectl --kubeconfig /etc/kubernetes/admin.conf apply -f https://docs.projectcalico.org/v3.8/manifests/calico.yaml
 echo done.
 ) 2>&1 | tee /var/log/startup.log


### PR DESCRIPTION
**What this PR does / why we need it**:
The version of existing calico is incompatible
with kubenetes 1.13.x, 1.14.x and 1.15.x.
So it needs to be updated.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #481

**Special notes for your reviewer**:

**Release note**:
NONE