### PR TITLE
Add alternative to OS image

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,7 +9,9 @@
    - If you want to use VM, install [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/), version 0.30.0 or greater. Also install a [driver](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md). For Linux, we recommend `kvm2`. For MacOS, we recommend `VirtualBox`.
    - If you want to use a container, install [Kind](https://github.com/kubernetes-sigs/kind#installation-and-usage).
    - If you want to use an existing Kubernetes cluster, prepare a kubeconfig which for this cluster.
-1. The CAPO provider requires an OS image (available in OpenStack), which is build like the ones in [image-builder](https://github.com/kubernetes-sigs/image-builder/tree/master/images/capi) 
+1. The CAPO provider requires an OS image (available in OpenStack), you have several ways to provide one:
+   - Build image via [image-builder](https://github.com/kubernetes-sigs/image-builder/tree/master/images/capi)
+   - Or as a test env, you can deploy a VM through OpenStack, log on to the VM and follow the steps in [install kubeadm](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/) to install container runtime and download kubectl, kubelet and kubeadm but *don't* execute kubeadm, then capture the image in OpenStack cloud and use it as OS image.
 
 ## Cluster Creation
 


### PR DESCRIPTION
image builder is good but we may tip folks to use other potential
easier way (learning curve perspective) to build an image.

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
