### PR TITLE
🐛 don't require cacert in cloud.yaml

### DIFF
--- a/pkg/cloud/services/provider/provider.go
+++ b/pkg/cloud/services/provider/provider.go
@@ -84,7 +84,9 @@ func newClient(cloud clientconfig.Cloud, caCert []byte) (*gophercloud.ProviderCl
 	if cloud.Verify != nil {
 		config.InsecureSkipVerify = !*cloud.Verify
 	}
-	config.RootCAs.AppendCertsFromPEM(caCert)
+	if caCert != nil {
+		config.RootCAs.AppendCertsFromPEM(caCert)
+	}
 
 	provider.HTTPClient.Transport = &http.Transport{Proxy: http.ProxyFromEnvironment, TLSClientConfig: config}
 	err = openstack.Authenticate(provider, *opts)
@@ -130,7 +132,7 @@ func getCloudFromSecret(ctrlClient client.Client, secretNamespace string, secret
 	// get caCert
 	caCert, ok := secret.Data[CaSecretKey]
 	if !ok {
-		return emptyCloud, nil, err
+		return clouds.Clouds[cloudName], nil, nil
 	}
 
 	return clouds.Clouds[cloudName], caCert, nil


### PR DESCRIPTION

**What this PR does / why we need it**:

Before this PR it was mandatory to set a cacert. Without it the cloud.yaml was not parsed correctly.

Bug was identified here: https://kubernetes.slack.com/archives/CFKJB65G9/p1579624001004800?thread_ts=1579502983.003200&cid=CFKJB65G9
