### PR TITLE
:bug: deduplicate machine tags prior to openstack API apply call

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,3 +19,5 @@ linters:
 issue:
   max-same-issues: 0
   max-per-linter: 0
+run:
+  deadline: 4m

--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -18,8 +18,9 @@ package compute
 
 import (
 	"fmt"
-	"sigs.k8s.io/cluster-api-provider-openstack/pkg/record"
 	"time"
+
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/record"
 
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/networking"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha2"
@@ -89,6 +90,9 @@ func (s *Service) InstanceCreate(clusterName string, machine *clusterv1.Machine,
 
 	// Append cluster scope tags
 	machineTags = append(machineTags, openStackCluster.Spec.Tags...)
+
+	// tags need to be unique or the "apply tags" call will fail.
+	machineTags = deduplicate(machineTags)
 
 	// Get security groups
 	securityGroups, err := getSecurityGroups(s, openStackMachine.Spec.SecurityGroups)
@@ -536,4 +540,21 @@ func (s *Service) InstanceExists(openStackMachine *infrav1.OpenStackMachine) (in
 		return nil, nil
 	}
 	return instanceList[0], nil
+}
+
+// deduplicate takes a slice of input strings and filters out any duplicate
+// string occurences, for example making ["a", "b", "a", "c"] become ["a", "b",
+// "c"].
+func deduplicate(sequence []string) []string {
+	var filtered []string
+	set := make(map[string]bool)
+
+	for _, s := range sequence {
+		if _, ok := set[s]; !ok {
+			filtered = append(filtered, s)
+			set[s] = true
+		}
+	}
+
+	return filtered
 }

--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -543,7 +543,7 @@ func (s *Service) InstanceExists(openStackMachine *infrav1.OpenStackMachine) (in
 }
 
 // deduplicate takes a slice of input strings and filters out any duplicate
-// string occurences, for example making ["a", "b", "a", "c"] become ["a", "b",
+// string occurrences, for example making ["a", "b", "a", "c"] become ["a", "b",
 // "c"].
 func deduplicate(sequence []string) []string {
 	var unique []string

--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -546,15 +546,15 @@ func (s *Service) InstanceExists(openStackMachine *infrav1.OpenStackMachine) (in
 // string occurences, for example making ["a", "b", "a", "c"] become ["a", "b",
 // "c"].
 func deduplicate(sequence []string) []string {
-	var filtered []string
+	var unique []string
 	set := make(map[string]bool)
 
 	for _, s := range sequence {
 		if _, ok := set[s]; !ok {
-			filtered = append(filtered, s)
+			unique = append(unique, s)
 			set[s] = true
 		}
 	}
 
-	return filtered
+	return unique
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The set of machine tags needs to be de-duplicated prior to applying tags on a machine or the Openstack API call will fail.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #501
