### PR TITLE
✨health: add liveness and readiness probes

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -28,6 +28,18 @@ spec:
         image: controller:latest
         imagePullPolicy: Always
         name: manager
+        ports:
+        - containerPort: 9440
+          name: healthz
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
       terminationGracePeriodSeconds: 10
       tolerations:
         - effect: NoSchedule


### PR DESCRIPTION
**What this PR does / why we need it**:
Similar was made here https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/1487 and https://github.com/kubernetes-sigs/cluster-api/pull/2156 and https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/374
Adding the liveness and readiness probes

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
- health: add liveness and readiness probes
```

/cc @vincepri 