### PR TITLE
✨ Pr v1alpha3 preparations

### DIFF
--- a/examples/cluster/multi-node/cluster.yaml
+++ b/examples/cluster/multi-node/cluster.yaml
@@ -27,9 +27,9 @@ spec:
   cloudsSecret:
     name: cloud-config
     namespace: ${CLUSTER_NAME}
-  nodeCidr: <node-cidr>
+  nodeCidr: ${NODE_CIDR}
   managedAPIServerLoadBalancer: true
-  apiServerLoadBalancerFloatingIP: <loadbalancer floating ip>
+  apiServerLoadBalancerFloatingIP: ${CONTROLPLANE_FLOATING_IP}
   apiServerLoadBalancerPort: 6443
   apiServerLoadBalancerAdditionalPorts:
   - 22
@@ -39,7 +39,7 @@ spec:
   #   * creating routers
   #   * creating floating ips
   #   * creating load balancer
-  externalNetworkId: <external-network-id>
+  externalNetworkId: ${EXTERNAL_NETWORK_ID}
   disablePortSecurity: true
   disableServerTags: true
   useOctavia: true

--- a/examples/cluster/single-node/cluster.yaml
+++ b/examples/cluster/single-node/cluster.yaml
@@ -27,13 +27,13 @@ spec:
   cloudsSecret:
     name: cloud-config
     namespace: ${CLUSTER_NAME}
-  nodeCidr: <node-cidr>
+  nodeCidr: ${NODE_CIDR}
   dnsNameservers: []
   # multi-node control-plane:
   # * externalNetworkId is required for:
   #   * creating routers
   #   * creating floating ips
   #   * creating load balancer
-  externalNetworkId: <external-network-id>
+  externalNetworkId: ${EXTERNAL_NETWORK_ID}
   disablePortSecurity: true
   disableServerTags: true

--- a/examples/controlplane/multi-node/controlplane.yaml
+++ b/examples/controlplane/multi-node/controlplane.yaml
@@ -30,8 +30,8 @@ metadata:
   namespace: ${CLUSTER_NAME}
 spec:
   flavor: m1.medium
-  image: <Image Name>
-  availabilityZone: nova
+  image: ${OS_IMAGE_NAME}
+  availabilityZone: ${AVAILABILITY_ZONE}
   cloudName: $CLOUD
   cloudsSecret:
     name: cloud-config
@@ -130,8 +130,8 @@ metadata:
   namespace: ${CLUSTER_NAME}
 spec:
   flavor: m1.medium
-  image: <Image Name>
-  availabilityZone: nova
+  image: ${OS_IMAGE_NAME}
+  availabilityZone: ${AVAILABILITY_ZONE}
   cloudName: $CLOUD
   cloudsSecret:
     name: cloud-config
@@ -205,8 +205,8 @@ metadata:
   namespace: ${CLUSTER_NAME}
 spec:
   flavor: m1.medium
-  image: <Image Name>
-  availabilityZone: nova
+  image: ${OS_IMAGE_NAME}
+  availabilityZone: ${AVAILABILITY_ZONE}
   cloudName: $CLOUD
   cloudsSecret:
     name: cloud-config

--- a/examples/controlplane/single-node/controlplane.yaml
+++ b/examples/controlplane/single-node/controlplane.yaml
@@ -30,9 +30,9 @@ metadata:
   namespace: ${CLUSTER_NAME}
 spec:
   flavor: m1.medium
-  image: <Image Name>
-  availabilityZone: nova
-  floatingIP: <floating IP>
+  image: ${OS_IMAGE_NAME}
+  availabilityZone: ${AVAILABILITY_ZONE}
+  floatingIP: ${CONTROLPLANE_FLOATING_IP}
   cloudName: $CLOUD
   cloudsSecret:
     name: cloud-config
@@ -75,7 +75,7 @@ spec:
         cloud-provider: openstack
         cloud-config: /etc/kubernetes/cloud.conf
   clusterConfiguration:
-    controlPlaneEndpoint: "<floating ip of control plane node>:6443"
+    controlPlaneEndpoint: "${CONTROLPLANE_FLOATING_IP}:6443"
     imageRepository: k8s.gcr.io
     apiServer:
       extraArgs:

--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -159,6 +159,10 @@ DOMAIN_NAME=$(echo "$OPENSTACK_CLOUD_CONFIG_PLAIN" | yq r - clouds.${CLOUD}.auth
 if [[ "$DOMAIN_NAME" = "null" ]]; then
   DOMAIN_NAME=$(echo "$OPENSTACK_CLOUD_CONFIG_PLAIN" | yq r - clouds.${CLOUD}.auth.domain_name)
 fi
+DOMAIN_ID=$(echo "$OPENSTACK_CLOUD_CONFIG_PLAIN" | yq r - clouds.${CLOUD}.auth.user_domain_id)
+if [[ "$DOMAIN_ID" = "null" ]]; then
+  DOMAIN_ID=$(echo "$OPENSTACK_CLOUD_CONFIG_PLAIN" | yq r - clouds.${CLOUD}.auth.domain_id)
+fi
 CACERT_ORIGINAL=$(echo "$OPENSTACK_CLOUD_CONFIG_PLAIN" | yq r - clouds.${CLOUD}.cacert)
 
 # use only the selected cloud not the whole clouds.yaml
@@ -171,8 +175,19 @@ auth-url=$AUTH_URL
 username=\"$USERNAME\"
 password=\"$PASSWORD\"
 tenant-id=\"$PROJECT_ID\"
-domain-name=\"$DOMAIN_NAME\"
 "
+
+if [[ "$DOMAIN_NAME" != "null" ]]; then
+  OPENSTACK_CLOUD_PROVIDER_CONF="$OPENSTACK_CLOUD_PROVIDER_CONF
+domain-name=\"${DOMAIN_NAME}\"
+  "
+fi
+if [[ "$DOMAIN_ID" != "null" ]]; then
+  OPENSTACK_CLOUD_PROVIDER_CONF="$OPENSTACK_CLOUD_PROVIDER_CONF
+domain-id=\"${DOMAIN_ID}\"
+  "
+fi
+
 if [[ "$CACERT_ORIGINAL" != "null" ]]; then
   OPENSTACK_CLOUD_PROVIDER_CONF="$OPENSTACK_CLOUD_PROVIDER_CONF
 ca-file=\"${CACERT_ORIGINAL}\"

--- a/examples/machinedeployment/machinedeployment.yaml
+++ b/examples/machinedeployment/machinedeployment.yaml
@@ -42,13 +42,13 @@ metadata:
 spec:
   template:
     spec:
-      availabilityZone: nova
+      availabilityZone: ${AVAILABILITY_ZONE}
       cloudName: $CLOUD
       cloudsSecret:
         name: cloud-config
         namespace: ${CLUSTER_NAME}
       flavor: m1.medium
-      image: <Image Name>
+      image: ${OS_IMAGE_NAME}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
 kind: KubeadmConfigTemplate

--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -46,4 +46,3 @@ verify_go_version
 
 # Explicitly opt into go modules, even though we're inside a GOPATH directory
 export GO111MODULE=on
-export GOFLAGS="-mod=vendor"

--- a/hack/ensure-kind.sh
+++ b/hack/ensure-kind.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+GOPATH_BIN="$(go env GOPATH)/bin/"
+MINIMUM_KIND_VERSION=v0.7.0
+
+# Ensure the kind tool exists and is a viable version, or installs it
+verify_kind_version() {
+
+  # If kind is not available on the path, get it
+  if ! [ -x "$(command -v kind)" ]; then
+    if [[ "${OSTYPE}" == "linux-gnu" ]]; then
+      echo 'kind not found, installing'
+      if ! [ -d "${GOPATH_BIN}" ]; then
+        mkdir -p "${GOPATH_BIN}"
+      fi
+      curl -sLo "${GOPATH_BIN}/kind" https://github.com/kubernetes-sigs/kind/releases/download/${MINIMUM_KIND_VERSION}/kind-linux-amd64
+      chmod +x "${GOPATH_BIN}/kind"
+    else
+      echo "Missing required binary in path: kind"
+      return 2
+    fi
+  fi
+
+  local kind_version
+  # Format is 'kind v0.6.1 go1.13.4 darwin/amd64'
+  kind_version=$(kind version | grep -E -o 'v[0-9]+\.[0-9]+\.[0-9]+')
+  if [[ "${MINIMUM_KIND_VERSION}" != $(echo -e "${MINIMUM_KIND_VERSION}\n${kind_version}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) ]]; then
+    cat <<EOF
+Detected kind version: ${kind_version}.
+Requires ${MINIMUM_KIND_VERSION} or greater.
+Please install ${MINIMUM_KIND_VERSION} or later.
+EOF
+    return 2
+  fi
+}
+
+verify_kind_version

--- a/hack/ensure-kubectl.sh
+++ b/hack/ensure-kubectl.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+GOPATH_BIN="$(go env GOPATH)/bin/"
+MINIMUM_KUBECTL_VERSION=v1.15.0
+
+# Ensure the kubectl tool exists and is a viable version, or installs it
+verify_kubectl_version() {
+
+  # If kubectl is not available on the path, get it
+  if ! [ -x "$(command -v kubectl)" ]; then
+    if [[ "${OSTYPE}" == "linux-gnu" ]]; then
+      if ! [ -d "${GOPATH_BIN}" ]; then
+        mkdir -p "${GOPATH_BIN}"
+      fi
+      echo 'kubectl not found, installing'
+      curl -sLo "${GOPATH_BIN}/kubectl" https://storage.googleapis.com/kubernetes-release/release/${MINIMUM_KUBECTL_VERSION}/bin/linux/amd64/kubectl
+      chmod +x "${GOPATH_BIN}/kubectl"
+    else
+      echo "Missing required binary in path: kubectl"
+      return 2
+    fi
+  fi
+
+  local kubectl_version
+  IFS=" " read -ra kubectl_version <<< "$(kubectl version --client --short)"
+  if [[ "${MINIMUM_KUBECTL_VERSION}" != $(echo -e "${MINIMUM_KUBECTL_VERSION}\n${kubectl_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) ]]; then
+    cat <<EOF
+Detected kubectl version: ${kubectl_version[2]}.
+Requires ${MINIMUM_KUBECTL_VERSION} or greater.
+Please install ${MINIMUM_KUBECTL_VERSION} or later.
+EOF
+    return 2
+  fi
+}
+
+verify_kubectl_version

--- a/hack/ensure-kustomize.sh
+++ b/hack/ensure-kustomize.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+GOPATH_BIN="$(go env GOPATH)/bin/"
+MINIMUM_KUSTOMIZE_VERSION=3.1.0
+
+# Ensure the kustomize tool exists and is a viable version, or installs it
+verify_kustomize_version() {
+
+  # If kustomize is not available on the path, get it
+  if ! [ -x "$(command -v kustomize)" ]; then
+    if [[ "${OSTYPE}" == "linux-gnu" ]]; then
+      echo 'kustomize not found, installing'
+      if ! [ -d "${GOPATH_BIN}" ]; then
+        mkdir -p "${GOPATH_BIN}"
+      fi
+      curl -sLo "${GOPATH_BIN}/kustomize" https://github.com/kubernetes-sigs/kustomize/releases/download/v${MINIMUM_KUSTOMIZE_VERSION}/kustomize_${MINIMUM_KUSTOMIZE_VERSION}_linux_amd64
+      chmod +x "${GOPATH_BIN}/kustomize"
+    else
+      echo "Missing required binary in path: kustomize"
+      return 2
+    fi
+  fi
+
+  local kustomize_version
+  kustomize_version=$(kustomize version)
+  if [[ "${MINIMUM_KUSTOMIZE_VERSION}" != $(echo -e "${MINIMUM_KUSTOMIZE_VERSION}\n${kustomize_version}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) ]]; then
+    cat <<EOF
+Detected kustomize version: ${kustomize_version}.
+Requires ${MINIMUM_KUSTOMIZE_VERSION} or greater.
+Please install ${MINIMUM_KUSTOMIZE_VERSION} or later.
+EOF
+    return 2
+  fi
+}
+
+verify_kustomize_version


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Some minor fixes I discoverd when building the e2e tests for Zuul. Some of these changes are
also required for v1alpha3 (the variables in our example).

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

Fyi: the e2e tests are mostly working on Zuul. Only the master does not come up. I guess that's due to limited resources. But I'm currently also using the e2e conformance script to test locally against a devstack. I'll start rebasing the Zuul Job onto the v1alpha3 branch