### PR TITLE
⚠️ fixup namespace handling in 0.3.0

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -35,7 +35,7 @@
 9.  Perform the [image promotion process](https://github.com/kubernetes/k8s.io/tree/master/k8s.gcr.io#image-promoter).
     The staging repository is at https://console.cloud.google.com/gcr/images/k8s-staging-capi-openstack/GLOBAL. Be
     sure to choose the top level `capi-openstack-controller`, which will provide the multi-arch manifest, rather than one for a specific architecture.
-    Add the new sha=>tag mapping to the [images.yaml](https://github.com/kubernetes/k8s.io/edit/master/k8s.gcr.io/images/k8s-staging-capi-openstack/images.yaml)
+    Add the new sha=>tag mapping to the [images.yaml](https://github.com/kubernetes/k8s.io/edit/master/k8s.gcr.io/images/k8s-staging-capi-openstack/images.yaml) (use the sha of the image with the corresponding tag)
 10.  Finalise the release notes
 11.  Publish release. Use the pre-release option for release
     candidate versions of Cluster API Provider OpenStack.

--- a/templates/cluster-template-without-lb.yaml
+++ b/templates/cluster-template-without-lb.yaml
@@ -25,7 +25,7 @@ spec:
   cloudName: ${OPENSTACK_CLOUD}
   cloudsSecret:
     name: ${CLUSTER_NAME}-cloud-config
-    namespace: ${CLUSTER_NAME}
+    namespace: ${NAMESPACE}
   controlPlaneEndpoint:
     host: ${OPENSTACK_CONTROLPLANE_IP}
     port: 6443
@@ -118,7 +118,7 @@ spec:
       cloudName: ${OPENSTACK_CLOUD}
       cloudsSecret:
         name: ${CLUSTER_NAME}-cloud-config
-        namespace: ${CLUSTER_NAME}
+        namespace: ${NAMESPACE}
 ---
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
@@ -154,7 +154,7 @@ spec:
       cloudName: ${OPENSTACK_CLOUD}
       cloudsSecret:
         name: ${CLUSTER_NAME}-cloud-config
-        namespace: ${CLUSTER_NAME}
+        namespace: ${NAMESPACE}
       flavor: ${OPENSTACK_NODE_MACHINE_FLAVOR}
       image: ${OPENSTACK_IMAGE_NAME}
 ---

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -25,7 +25,7 @@ spec:
   cloudName: ${OPENSTACK_CLOUD}
   cloudsSecret:
     name: ${CLUSTER_NAME}-cloud-config
-    namespace: ${CLUSTER_NAME}
+    namespace: ${NAMESPACE}
   managedAPIServerLoadBalancer: true
   apiServerLoadBalancerFloatingIP: ${OPENSTACK_CONTROLPLANE_IP}
   apiServerLoadBalancerPort: 6443
@@ -119,7 +119,7 @@ spec:
       cloudName: ${OPENSTACK_CLOUD}
       cloudsSecret:
         name: ${CLUSTER_NAME}-cloud-config
-        namespace: ${CLUSTER_NAME}
+        namespace: ${NAMESPACE}
 ---
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
@@ -155,7 +155,7 @@ spec:
       cloudName: ${OPENSTACK_CLOUD}
       cloudsSecret:
         name: ${CLUSTER_NAME}-cloud-config
-        namespace: ${CLUSTER_NAME}
+        namespace: ${NAMESPACE}
       flavor: ${OPENSTACK_NODE_MACHINE_FLAVOR}
       image: ${OPENSTACK_IMAGE_NAME}
 ---


### PR DESCRIPTION
I just did a final manual test and saw that the quickstart with 0.3.0 only worked when --target-namespace was equal to the cluster-name. This PRs fixes our templates so that the namespace where all resources are deployed is equal to our secret references in the CAPO resources

P.S. I already replaced the uploaded cluster-templates in the published 0.3.0 release to avoid that somebody who is trying CAPO out right now directly fails with this error, which would be bad :)