### PR TITLE
✨ Delete router/network/subnet

### DIFF
--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -150,7 +150,23 @@ func (r *OpenStackClusterReconciler) reconcileDelete(ctx context.Context, log lo
 		}
 	}
 
-	// TODO(sbueringer) Delete network/subnet/router/... if created by CAPO
+	if openStackCluster.Status.Network.Router != nil {
+		log.Info("Deleting router", "name", openStackCluster.Status.Network.Router.Name)
+		if err := networkingService.DeleteRouter(openStackCluster.Status.Network); err != nil {
+			return ctrl.Result{}, errors.Errorf("failed to delete router: %v", err)
+		}
+		log.Info("OpenStack router deleted successfully")
+	}
+
+	if openStackCluster.Status.Network != nil {
+		log.Info("Deleting network", "name", openStackCluster.Status.Network.Name)
+		if err := networkingService.DeleteNetwork(openStackCluster.Status.Network); err != nil {
+			return ctrl.Result{}, errors.Errorf("failed to delete network: %v", err)
+		}
+		log.Info("OpenStack network deleted successfully")
+	}
+
+	log.Info("OpenStack cluster deleted successfully")
 
 	// Cluster is deleted so remove the finalizer.
 	controllerutil.RemoveFinalizer(openStackCluster, infrav1.ClusterFinalizer)
@@ -297,6 +313,7 @@ func (r *OpenStackClusterReconciler) reconcileNormal(ctx context.Context, log lo
 	}
 
 	openStackCluster.Status.Ready = true
+	log.Info("Reconciled Cluster create successfully")
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

This PR adds to delete router, network, and subnet feature. Currently how to delete cluster is not provided explicitly in my understanding, but we need to delete OpenStack resources easily even for testing. By this PR, we can delete OpenStack resources created with `cluster-template-without-lb.yaml` by the following.

```
kubectl delete machinedeployment capi-quickstart-md-0 -n capi-quickstart
kubectl delete kubeadmcontrolplane capi-quickstart-control-plane -n capi-quickstart
kubectl delete cluster capi-quickstart -n capi-quickstart
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
