### PR TITLE
🐛  use sec groups from the current project, wait for lb from last reconcile

### DIFF
--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -154,10 +154,11 @@ func (r *OpenStackClusterReconciler) reconcileDelete(ctx context.Context, log lo
 
 	// Cluster is deleted so remove the finalizer.
 	controllerutil.RemoveFinalizer(openStackCluster, infrav1.ClusterFinalizer)
+	log.Info("Reconciled Cluster delete successfully")
 	if err := patchHelper.Patch(ctx, openStackCluster); err != nil {
 		return ctrl.Result{}, err
 	}
-	return reconcile.Result{}, nil
+	return ctrl.Result{}, nil
 }
 
 func (r *OpenStackClusterReconciler) reconcileNormal(ctx context.Context, log logr.Logger, patchHelper *patch.Helper, cluster *clusterv1.Cluster, openStackCluster *infrav1.OpenStackCluster) (ctrl.Result, error) {

--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -245,6 +245,7 @@ func (r *OpenStackMachineReconciler) reconcileDelete(ctx context.Context, logger
 
 	// Instance is deleted so remove the finalizer.
 	controllerutil.RemoveFinalizer(openStackMachine, infrav1.MachineFinalizer)
+	logger.Info("Reconciled Machine delete successfully")
 	if err := patchHelper.Patch(ctx, openStackMachine); err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -281,6 +281,9 @@ func getSecurityGroups(is *Service, securityGroupParams []infrav1.SecurityGroupP
 	var sgIDs []string
 	for _, sg := range securityGroupParams {
 		listOpts := groups.ListOpts(sg.Filter)
+		if listOpts.ProjectID == "" {
+			listOpts.ProjectID = is.projectID
+		}
 		listOpts.Name = sg.Name
 		listOpts.ID = sg.UUID
 		pages, err := groups.List(is.networkClient, listOpts).AllPages()

--- a/pkg/cloud/services/loadbalancer/loadbalancer.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer.go
@@ -68,10 +68,9 @@ func (s *Service) ReconcileLoadBalancer(clusterName string, openStackCluster *in
 		if err != nil {
 			return fmt.Errorf("error creating loadbalancer: %s", err)
 		}
-		err = waitForLoadBalancerActive(s.logger, s.loadbalancerClient, lb.ID)
-		if err != nil {
-			return err
-		}
+	}
+	if err := waitForLoadBalancerActive(s.logger, s.loadbalancerClient, lb.ID); err != nil {
+		return err
 	}
 
 	// floating ip
@@ -127,14 +126,13 @@ func (s *Service) ReconcileLoadBalancer(clusterName string, openStackCluster *in
 			if err != nil {
 				return fmt.Errorf("error creating listener: %s", err)
 			}
-			err = waitForLoadBalancerActive(s.logger, s.loadbalancerClient, lb.ID)
-			if err != nil {
-				return err
-			}
-			err = waitForListener(s.logger, s.loadbalancerClient, listener.ID, "ACTIVE")
-			if err != nil {
-				return err
-			}
+		}
+		if err := waitForLoadBalancerActive(s.logger, s.loadbalancerClient, lb.ID); err != nil {
+			return err
+		}
+
+		if err := waitForListener(s.logger, s.loadbalancerClient, listener.ID, "ACTIVE"); err != nil {
+			return err
 		}
 
 		// lb pool
@@ -154,10 +152,9 @@ func (s *Service) ReconcileLoadBalancer(clusterName string, openStackCluster *in
 			if err != nil {
 				return fmt.Errorf("error creating pool: %s", err)
 			}
-			err = waitForLoadBalancerActive(s.logger, s.loadbalancerClient, lb.ID)
-			if err != nil {
-				return err
-			}
+		}
+		if err := waitForLoadBalancerActive(s.logger, s.loadbalancerClient, lb.ID); err != nil {
+			return err
 		}
 
 		// lb monitor
@@ -179,10 +176,9 @@ func (s *Service) ReconcileLoadBalancer(clusterName string, openStackCluster *in
 			if err != nil {
 				return fmt.Errorf("error creating monitor: %s", err)
 			}
-			err = waitForLoadBalancerActive(s.logger, s.loadbalancerClient, lb.ID)
-			if err != nil {
-				return err
-			}
+		}
+		if err = waitForLoadBalancerActive(s.logger, s.loadbalancerClient, lb.ID); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION

**What this PR does / why we need it**:

This PR fixes to issues:
* When using an admin user it wasn't possible to assign security groups to machines because the security group list call returned sec groups from all projects, now it's filtered to the current one
* When reconciling load balancer there was an issue when the lb was still "pending create" from the last reconcile. Now the controller also waits even when the lb already exists from before.

