### PR TITLE
✨ Add ServerGroupID to OpenStackMachineSpec

### DIFF
--- a/api/v1alpha3/openstackmachine_types.go
+++ b/api/v1alpha3/openstackmachine_types.go
@@ -79,6 +79,9 @@ type OpenStackMachineSpec struct {
 
 	// The volume metadata to boot from
 	RootVolume *RootVolume `json:"rootVolume,omitempty"`
+
+	// The server group to assign the machine to
+	ServerGroupID string `json:"serverGroupID,omitempty"`
 }
 
 // OpenStackMachineStatus defines the observed state of OpenStackMachine

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
@@ -256,6 +256,9 @@ spec:
                       type: string
                   type: object
                 type: array
+              serverGroupID:
+                description: The server group to assign the machine to
+                type: string
               serverMetadata:
                 additionalProperties:
                   type: string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
@@ -250,6 +250,9 @@ spec:
                               type: string
                           type: object
                         type: array
+                      serverGroupID:
+                        description: The server group to assign the machine to
+                        type: string
                       serverMetadata:
                         additionalProperties:
                           type: string


### PR DESCRIPTION
With this change, it is possible to assign a machine to an [OpenStack
Server group][1]. By passing a server group ID to the Machine Spec, it
is possible to leverage affinity policies and control how machines are
distributed across physical hosts.

[1]: https://docs.openstack.org/python-openstackclient/latest/cli/command-objects/server-group.html

```release-note
OpenStackMachineSpec: add ServerGroupID property for assigning a Nova Server Group
```
