### PR TITLE
🐛 Fix cluster-template.yaml

### DIFF
--- a/pkg/cloud/services/networking/securitygroups.go
+++ b/pkg/cloud/services/networking/securitygroups.go
@@ -141,8 +141,8 @@ func generateControlPlaneGroup(clusterName string) infrav1.SecurityGroup {
 				{
 					Direction:      "ingress",
 					EtherType:      "IPv4",
-					PortRangeMin:   443,
-					PortRangeMax:   443,
+					PortRangeMin:   6443,
+					PortRangeMax:   6443,
 					Protocol:       "tcp",
 					RemoteIPPrefix: "0.0.0.0/0",
 				},

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -31,11 +31,12 @@ spec:
   apiServerLoadBalancerPort: 6443
   apiServerLoadBalancerAdditionalPorts:
   - 22
+  managedSecurityGroups: true
   nodeCidr: 10.6.0.0/24
   dnsNameservers:
   - ${OPENSTACK_DNS_NAMESERVERS}
   externalNetworkId: ${OPENSTACK_EXTERNAL_NETWORK_ID}
-  disablePortSecurity: true
+  disablePortSecurity: false
   disableServerTags: true
   useOctavia: true
 ---
@@ -120,6 +121,9 @@ spec:
       cloudsSecret:
         name: ${CLUSTER_NAME}-cloud-config
         namespace: ${NAMESPACE}
+      securityGroups:
+      - name: k8s-cluster-${NAMESPACE}-${CLUSTER_NAME}-secgroup-controlplane
+      - name: k8s-cluster-${NAMESPACE}-${CLUSTER_NAME}-secgroup-all
 ---
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
@@ -158,6 +162,8 @@ spec:
         namespace: ${NAMESPACE}
       flavor: ${OPENSTACK_NODE_MACHINE_FLAVOR}
       image: ${OPENSTACK_IMAGE_NAME}
+      securityGroups:
+        - name: k8s-cluster-${NAMESPACE}-${CLUSTER_NAME}-secgroup-all
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

This PR updates cluster-template.yaml to work.
OpenStack environment needs the followings.

- Port security feature to use OpenStack Octavia with HAProxy Amphora.
- Appropriate security groups to master and worker nodes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
