### PR TITLE
🐛  e2e test: switch to -bazel folder because bin folder has been removed

### DIFF
--- a/hack/ci/e2e-conformance/e2e-conformance_patch.yaml.tpl
+++ b/hack/ci/e2e-conformance/e2e-conformance_patch.yaml.tpl
@@ -59,7 +59,7 @@ spec:
           CI_DIR=/tmp/k8s-ci
           mkdir -p $CI_DIR
           # replace + with %2B for the URL
-          CI_URL="https://storage.googleapis.com/kubernetes-release-dev/ci/${CI_VERSION//+/%2B}/bin/linux/amd64"
+          CI_URL="https://storage.googleapis.com/kubernetes-release-dev/ci/${CI_VERSION//+/%2B}-bazel/bin/linux/amd64"
           declare -a BINARIES_TO_TEST=("kubectl" "kubelet" "kubeadm")
           declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-scheduler" "kube-proxy")
           CONTAINER_EXT="tar"
@@ -148,7 +148,7 @@ spec:
               CI_DIR=/tmp/k8s-ci
               mkdir -p $CI_DIR
               # replace + with %2B for the URL
-              CI_URL="https://storage.googleapis.com/kubernetes-release-dev/ci/${CI_VERSION//+/%2B}/bin/linux/amd64"
+              CI_URL="https://storage.googleapis.com/kubernetes-release-dev/ci/${CI_VERSION//+/%2B}-bazel/bin/linux/amd64"
               declare -a BINARIES_TO_TEST=("kubectl" "kubelet" "kubeadm")
               declare -a CONTAINERS_TO_TEST=("kube-proxy")
               CONTAINER_EXT="tar"


### PR DESCRIPTION
Not sure why but looks like they removed the bin folder in the build output. So we're using the -bazel folder for now:
https://console.cloud.google.com/storage/browser/kubernetes-release-dev/ci/v1.19.0-alpha.1.254+4a897137b6b6dc-bazel/

(our periodic job is failing because of that: http://status.openlabtesting.org/builds?project=kubernetes-sigs%2Fcluster-api-provider-openstack)
