### PR TITLE
Add additional info when error occur

### DIFF
--- a/pkg/cloud/services/provider/provider.go
+++ b/pkg/cloud/services/provider/provider.go
@@ -85,7 +85,7 @@ func newClient(cloud clientconfig.Cloud, caCert []byte) (*gophercloud.ProviderCl
 
 	opts, err := clientconfig.AuthOptions(clientOpts)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("auth option failed for cloud %v: %v", cloud.Cloud, err)
 	}
 	opts.AllowReauth = true
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
it took me long time to find when I define the wrong cloud different to clouds.yaml 
in make file... I got err like `'auth_url' input can't be empty` which is really confusing
add this will be much helpful ..
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
