### PR TITLE
🐛 remove docker-build from build test

### DIFF
--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -22,4 +22,4 @@ REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 # shellcheck source=../hack/ensure-go.sh
 source "${REPO_ROOT}/hack/ensure-go.sh"
 
-cd "${REPO_ROOT}" && make binaries docker-build
+cd "${REPO_ROOT}" && make binaries


### PR DESCRIPTION
I would suggest removing the docker-build from the test target so we don't need docker-in-docker in Prow. We're testing the docker build in OpenLab anyway in our e2e test