### PR TITLE
add CI_VERSION into makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -306,6 +306,7 @@ OPENSTACK_CONTROL_PLANE_MACHINE_FLAVOR ?= "m1.medium"
 CLUSTER_NAME ?= "capi-quickstart"
 OPENSTACK_CLUSTER_TEMPLATE ?= "./templates/cluster-template-without-lb.yaml"
 KUBERNETES_VERSION ?= "v1.17.3"
+CI_VERSION ?= $(KUBERNETES_VERSION)
 CONTROL_PLANE_MACHINE_COUNT ?= "1"
 WORKER_MACHINE_COUNT ?= "3"
 LOAD_IMAGE=$(CONTROLLER_IMG)-$(ARCH):$(TAG)
@@ -386,7 +387,8 @@ create-cluster: $(CLUSTERCTL) $(KUSTOMIZE) $(ENVSUBST) ## Create a development K
 	  sed "s|\$${OPENSTACK_CLOUD_PROVIDER_CONF_B64}|$(OPENSTACK_CLOUD_PROVIDER_CONF_B64)|" | \
 	  sed "s|\$${OPENSTACK_CLOUD_CACERT_B64}|$(OPENSTACK_CLOUD_CACERT_B64)|" | \
 	  sed "s|\$${KUBERNETES_VERSION}|$(KUBERNETES_VERSION)|" | \
-	  sed "s|\$${CLUSTER_NAME}|$(CLUSTER_NAME)|"  \
+	  sed "s|\$${CLUSTER_NAME}|$(CLUSTER_NAME)|"  | \
+	  sed "s|\$${CI_VERSION}|$(CI_VERSION)|" \
 	   > ./hack/ci/e2e-conformance/e2e-conformance_patch.yaml
 	$(KUSTOMIZE) build --reorder=none hack/ci/e2e-conformance  > ./out/cluster.yaml
 

--- a/hack/ci/e2e-conformance/e2e-conformance_patch.yaml.tpl
+++ b/hack/ci/e2e-conformance/e2e-conformance_patch.yaml.tpl
@@ -54,7 +54,6 @@ spec:
         ps aux
         top -b -n 1
 
-        CI_VERSION=${CI_VERSION:-"${KUBERNETES_VERSION}"}
         if [[ "${CI_VERSION}" != "" ]]; then
           CI_DIR=/tmp/k8s-ci
           mkdir -p $CI_DIR


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Add CI_VERSION into Make file

when using `make create-cluster`, I am suffering the controller run CI stuffs which is weird
turn out I need set CI_VERSION , guess that's easier to store in Makefile to turn off this
(still open by default)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
