### PR TITLE
Make DisablePortSecurity compatible with platforms not using the port…

### DIFF
--- a/pkg/cloud/services/networking/network.go
+++ b/pkg/cloud/services/networking/network.go
@@ -58,15 +58,19 @@ func (s *Service) ReconcileNetwork(clusterName string, openStackCluster *infrav1
 	}
 
 	var portSecurityEnabled gophercloud.EnabledState
+	var opts createOpts
 	if openStackCluster.Spec.DisablePortSecurity {
 		portSecurityEnabled = gophercloud.Disabled
+		opts = createOpts{
+			AdminStateUp:        gophercloud.Enabled,
+			Name:                networkName,
+			PortSecurityEnabled: portSecurityEnabled,
+		}
 	} else {
-		portSecurityEnabled = gophercloud.Enabled
-	}
-	opts := createOpts{
-		AdminStateUp:        gophercloud.Enabled,
-		Name:                networkName,
-		PortSecurityEnabled: portSecurityEnabled,
+		opts = createOpts{
+			AdminStateUp: gophercloud.Enabled,
+			Name:         networkName,
+		}
 	}
 	network, err := networks.Create(s.client, opts).Extract()
 	if err != nil {

--- a/pkg/cloud/services/networking/network.go
+++ b/pkg/cloud/services/networking/network.go
@@ -57,7 +57,6 @@ func (s *Service) ReconcileNetwork(clusterName string, openStackCluster *infrav1
 		return nil
 	}
 
-	var portSecurityEnabled gophercloud.EnabledState
 	var opts createOpts
 	if openStackCluster.Spec.DisablePortSecurity {
 		opts = createOpts{

--- a/pkg/cloud/services/networking/network.go
+++ b/pkg/cloud/services/networking/network.go
@@ -60,11 +60,10 @@ func (s *Service) ReconcileNetwork(clusterName string, openStackCluster *infrav1
 	var portSecurityEnabled gophercloud.EnabledState
 	var opts createOpts
 	if openStackCluster.Spec.DisablePortSecurity {
-		portSecurityEnabled = gophercloud.Disabled
 		opts = createOpts{
 			AdminStateUp:        gophercloud.Enabled,
 			Name:                networkName,
-			PortSecurityEnabled: portSecurityEnabled,
+			PortSecurityEnabled: gophercloud.Disabled,
 		}
 	} else {
 		opts = createOpts{


### PR DESCRIPTION
… security extension

🐛 (:bug:, patch and bugfixes)

**What this PR does / why we need it**:
Improves compatibility with OpenStack without the port security extension
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #559 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
