### PR TITLE
Add generated security groups automatically

### DIFF
--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -98,6 +98,14 @@ func (s *Service) InstanceCreate(clusterName string, machine *clusterv1.Machine,
 	if err != nil {
 		return nil, err
 	}
+	if openStackCluster.Spec.ManagedSecurityGroups {
+		if util.IsControlPlaneMachine(machine) {
+			securityGroups = append(securityGroups, openStackCluster.Status.ControlPlaneSecurityGroup.ID)
+		} else {
+			securityGroups = append(securityGroups, openStackCluster.Status.WorkerSecurityGroup.ID)
+		}
+	}
+
 	// Get all network UUIDs
 	var nets []ServerNetwork
 	if len(openStackMachine.Spec.Networks) > 0 {

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -121,8 +121,6 @@ spec:
       cloudsSecret:
         name: ${CLUSTER_NAME}-cloud-config
         namespace: ${NAMESPACE}
-      securityGroups:
-      - name: k8s-cluster-${NAMESPACE}-${CLUSTER_NAME}-secgroup-controlplane
 ---
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
@@ -161,8 +159,6 @@ spec:
         namespace: ${NAMESPACE}
       flavor: ${OPENSTACK_NODE_MACHINE_FLAVOR}
       image: ${OPENSTACK_IMAGE_NAME}
-      securityGroups:
-        - name: k8s-cluster-${NAMESPACE}-${CLUSTER_NAME}-secgroup-worker
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate


### PR DESCRIPTION
Currently generate security groups are not added to the instances.
This commit makes it automatically.

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

Currently generate security groups are not added to the instances if managedSecurityGroups: true.
This PR makes generate security groups to be added automatically.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #556 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Makes generate security groups to be added automatically if managedSecurityGroups: true
```
