### PR TITLE
✨Add external network discovery

### DIFF
--- a/api/v1alpha3/openstackcluster_types.go
+++ b/api/v1alpha3/openstackcluster_types.go
@@ -59,6 +59,7 @@ type OpenStackClusterSpec struct {
 	ExternalRouterIPs []ExternalRouterIPParam `json:"externalRouterIPs,omitempty"`
 	// ExternalNetworkID is the ID of an external OpenStack Network. This is necessary
 	// to get public internet to the VMs.
+	// +optional
 	ExternalNetworkID string `json:"externalNetworkId,omitempty"`
 
 	// UseOctavia is weather LoadBalancer Service is Octavia or not
@@ -128,6 +129,9 @@ type OpenStackClusterStatus struct {
 	// Network contains all information about the created OpenStack Network.
 	// It includes Subnets and Router.
 	Network *Network `json:"network,omitempty"`
+
+	// External Network contains information about the created OpenStack external network.
+	ExternalNetwork *Network `json:"externalNetwork,omitempty"`
 
 	// FailureDomains represent OpenStack availability zones
 	FailureDomains clusterv1.FailureDomains `json:"failureDomains,omitempty"`

--- a/api/v1alpha3/zz_generated.deepcopy.go
+++ b/api/v1alpha3/zz_generated.deepcopy.go
@@ -297,6 +297,11 @@ func (in *OpenStackClusterStatus) DeepCopyInto(out *OpenStackClusterStatus) {
 		*out = new(Network)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ExternalNetwork != nil {
+		in, out := &in.ExternalNetwork, &out.ExternalNetwork
+		*out = new(Network)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.FailureDomains != nil {
 		in, out := &in.FailureDomains, &out.FailureDomains
 		*out = make(apiv1alpha3.FailureDomains, len(*in))

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -412,6 +412,63 @@ spec:
                 - name
                 - rules
                 type: object
+              externalNetwork:
+                description: External Network contains information about the created
+                  OpenStack external network.
+                properties:
+                  apiServerLoadBalancer:
+                    description: Be careful when using APIServerLoadBalancer, because
+                      this field is optional and therefore not set in all cases
+                    properties:
+                      id:
+                        type: string
+                      internalIP:
+                        type: string
+                      ip:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - id
+                    - internalIP
+                    - ip
+                    - name
+                    type: object
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  router:
+                    description: Router represents basic information about the associated
+                      OpenStack Neutron Router
+                    properties:
+                      id:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - id
+                    - name
+                    type: object
+                  subnet:
+                    description: Subnet represents basic information about the associated
+                      OpenStack Neutron Subnet
+                    properties:
+                      cidr:
+                        type: string
+                      id:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - cidr
+                    - id
+                    - name
+                    type: object
+                required:
+                - id
+                - name
+                type: object
               failureDomains:
                 additionalProperties:
                   description: FailureDomainSpec is the Schema for Cluster API failure

--- a/pkg/cloud/services/networking/network.go
+++ b/pkg/cloud/services/networking/network.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 	"github.com/pkg/errors"
@@ -37,6 +38,53 @@ type createOpts struct {
 
 func (c createOpts) ToNetworkCreateMap() (map[string]interface{}, error) {
 	return gophercloud.BuildRequestBody(c, "network")
+}
+
+func (s *Service) ReconcileExternalNetwork(openStackCluster *infrav1.OpenStackCluster) error {
+
+	if openStackCluster.Spec.ExternalNetworkID != "" {
+		externalNetwork, err := s.getNetworkByID(openStackCluster.Spec.ExternalNetworkID)
+		if err != nil {
+			return err
+		}
+		if externalNetwork.ID != "" {
+			openStackCluster.Status.ExternalNetwork = &infrav1.Network{
+				ID:   externalNetwork.ID,
+				Name: externalNetwork.Name,
+			}
+			return nil
+		}
+	}
+
+	// ExternalNetworkID is not given
+	iTrue := true
+	networkListOpts := networks.ListOpts{}
+	listOpts := external.ListOptsExt{
+		ListOptsBuilder: networkListOpts,
+		External:        &iTrue,
+	}
+
+	allPages, err := networks.List(s.client, listOpts).AllPages()
+	if err != nil {
+		return err
+	}
+	allNetworks, err := networks.ExtractNetworks(allPages)
+	if err != nil {
+		return err
+	}
+
+	switch len(allNetworks) {
+	case 0:
+		return fmt.Errorf("external network not found")
+	case 1:
+		openStackCluster.Status.ExternalNetwork = &infrav1.Network{
+			ID:   allNetworks[0].ID,
+			Name: allNetworks[0].Name,
+		}
+		s.logger.Info("External network found:", "network id", allNetworks[0].ID)
+		return nil
+	}
+	return errors.New("too many resources")
 }
 
 func (s *Service) ReconcileNetwork(clusterName string, openStackCluster *infrav1.OpenStackCluster) error {
@@ -182,6 +230,30 @@ func (s *Service) ReconcileSubnet(clusterName string, openStackCluster *infrav1.
 
 	openStackCluster.Status.Network.Subnet = &observedSubnet
 	return nil
+}
+
+func (s *Service) getNetworkByID(networkID string) (networks.Network, error) {
+	opts := networks.ListOpts{
+		ID: networkID,
+	}
+
+	allPages, err := networks.List(s.client, opts).AllPages()
+	if err != nil {
+		return networks.Network{}, err
+	}
+
+	allNetworks, err := networks.ExtractNetworks(allPages)
+	if err != nil {
+		return networks.Network{}, err
+	}
+
+	switch len(allNetworks) {
+	case 0:
+		return networks.Network{}, nil
+	case 1:
+		return allNetworks[0], nil
+	}
+	return networks.Network{}, errors.New("multiple external network found")
 }
 
 func (s *Service) getNetworkByName(networkName string) (networks.Network, error) {

--- a/pkg/cloud/services/networking/router.go
+++ b/pkg/cloud/services/networking/router.go
@@ -41,7 +41,7 @@ func (s *Service) ReconcileRouter(clusterName string, openStackCluster *infrav1.
 		s.logger.V(4).Info("No need to reconcile router since no subnet exists.")
 		return nil
 	}
-	if openStackCluster.Spec.ExternalNetworkID == "" {
+	if openStackCluster.Status.ExternalNetwork == nil || openStackCluster.Status.ExternalNetwork.ID == "" {
 		s.logger.V(3).Info("No need to create router, due to missing ExternalNetworkID.")
 		return nil
 	}
@@ -71,7 +71,7 @@ func (s *Service) ReconcileRouter(clusterName string, openStackCluster *infrav1.
 		// That's also the same way terraform provider OpenStack does it
 		if len(openStackCluster.Spec.ExternalRouterIPs) == 0 {
 			opts.GatewayInfo = &routers.GatewayInfo{
-				NetworkID: openStackCluster.Spec.ExternalNetworkID,
+				NetworkID: openStackCluster.Status.ExternalNetwork.ID,
 			}
 		}
 		newRouter, err := routers.Create(s.client, opts).Extract()
@@ -88,7 +88,7 @@ func (s *Service) ReconcileRouter(clusterName string, openStackCluster *infrav1.
 	if len(openStackCluster.Spec.ExternalRouterIPs) > 0 {
 		var updateOpts routers.UpdateOpts
 		updateOpts.GatewayInfo = &routers.GatewayInfo{
-			NetworkID: openStackCluster.Spec.ExternalNetworkID,
+			NetworkID: openStackCluster.Status.ExternalNetwork.ID,
 		}
 		for _, externalRouterIP := range openStackCluster.Spec.ExternalRouterIPs {
 			subnetID := externalRouterIP.Subnet.UUID

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -27,13 +27,10 @@ spec:
     name: ${CLUSTER_NAME}-cloud-config
     namespace: ${NAMESPACE}
   managedAPIServerLoadBalancer: true
-  apiServerLoadBalancerFloatingIP: ${OPENSTACK_CONTROLPLANE_IP}
-  apiServerLoadBalancerPort: 6443
   managedSecurityGroups: true
   nodeCidr: 10.6.0.0/24
   dnsNameservers:
   - ${OPENSTACK_DNS_NAMESERVERS}
-  externalNetworkId: ${OPENSTACK_EXTERNAL_NETWORK_ID}
   disablePortSecurity: false
   disableServerTags: true
   useOctavia: true
@@ -56,7 +53,6 @@ spec:
           cloud-provider: openstack
           cloud-config: /etc/kubernetes/cloud.conf
     clusterConfiguration:
-      controlPlaneEndpoint: "${OPENSTACK_CONTROLPLANE_IP}:6443"
       imageRepository: k8s.gcr.io
       apiServer:
         extraArgs:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR finds external network and create floating ip if `externalNetworkId`, `apiServerLoadBalancerFloatingIP`, and
`apiServerLoadBalancerPort` are not given when `managedAPIServerLoadBalancer: true`.

When `managedAPIServerLoadBalancer: false`, this PR also works without `controlPlaneEndpoint` and `floatingIP` in the manifest.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #566 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add external network discovery
```
