### PR TITLE
fix for pr590 wrong parameter for a user provider network

### DIFF
--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -297,7 +297,10 @@ func (r *OpenStackClusterReconciler) reconcileNetworkComponents(log logr.Logger,
 
 		netOpts := networks.ListOpts(openStackCluster.Spec.Network)
 		networkList, err := networkingService.GetNetworksByFilter(&netOpts)
-		if err != nil && len(networkList) == 0 {
+		if len(networkList) == 0 {
+			return errors.Errorf("failed to find any network: %v", err)
+		}
+		if err != nil {
 			return errors.Errorf("failed to find network: %v", err)
 		}
 		if len(networkList) > 1 {

--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -297,11 +297,17 @@ func (r *OpenStackClusterReconciler) reconcileNetworkComponents(log logr.Logger,
 
 		netOpts := networks.ListOpts(openStackCluster.Spec.Network)
 		networkList, err := networkingService.GetNetworksByFilter(&netOpts)
+<<<<<<< Updated upstream
 		if len(networkList) == 0 {
 			return errors.Errorf("failed to find any network: %v", err)
 		}
+=======
+>>>>>>> Stashed changes
 		if err != nil {
 			return errors.Errorf("failed to find network: %v", err)
+		}
+		if len(networkList) <= 0 {
+			return errors.Errorf("failed to find any network: %v", err)
 		}
 		if len(networkList) > 1 {
 			return errors.Errorf("failed to find only one network (result: %v): %v", networkList, err)

--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -306,7 +306,7 @@ func (r *OpenStackClusterReconciler) reconcileNetworkComponents(log logr.Logger,
 		if err != nil {
 			return errors.Errorf("failed to find network: %v", err)
 		}
-		if len(networkList) <= 0 {
+		if len(networkList) == 0 {
 			return errors.Errorf("failed to find any network: %v", err)
 		}
 		if len(networkList) > 1 {

--- a/pkg/cloud/services/networking/securitygroups.go
+++ b/pkg/cloud/services/networking/securitygroups.go
@@ -35,6 +35,7 @@ const (
 var defaultRules = []infrav1.SecurityGroupRule{
 	{
 		Direction:      "egress",
+		Description:    "Full open",
 		EtherType:      "IPv4",
 		PortRangeMin:   0,
 		PortRangeMax:   0,
@@ -43,6 +44,7 @@ var defaultRules = []infrav1.SecurityGroupRule{
 	},
 	{
 		Direction:      "egress",
+		Description:    "Full open",
 		EtherType:      "IPv6",
 		PortRangeMin:   0,
 		PortRangeMax:   0,


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
