### PR TITLE
 ✨ My594 revised #590 #594 wrong parameter for a user provider network

### DIFF
--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -297,7 +297,10 @@ func (r *OpenStackClusterReconciler) reconcileNetworkComponents(log logr.Logger,
 
 		netOpts := networks.ListOpts(openStackCluster.Spec.Network)
 		networkList, err := networkingService.GetNetworksByFilter(&netOpts)
-		if err != nil && len(networkList) == 0 {
+		if len(networkList) == 0 {
+			return errors.Errorf("failed to find any network: %v", err)
+		}
+		if err != nil {
 			return errors.Errorf("failed to find network: %v", err)
 		}
 		if len(networkList) > 1 {

--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -297,11 +297,11 @@ func (r *OpenStackClusterReconciler) reconcileNetworkComponents(log logr.Logger,
 
 		netOpts := networks.ListOpts(openStackCluster.Spec.Network)
 		networkList, err := networkingService.GetNetworksByFilter(&netOpts)
-		if len(networkList) == 0 {
-			return errors.Errorf("failed to find any network: %v", err)
-		}
 		if err != nil {
 			return errors.Errorf("failed to find network: %v", err)
+		}
+		if len(networkList) == 0 {
+			return errors.Errorf("failed to find any network: %v", err)
 		}
 		if len(networkList) > 1 {
 			return errors.Errorf("failed to find only one network (result: %v): %v", networkList, err)


### PR DESCRIPTION
✨ 
**What this PR does / why we need it**: 
To correct  the previous #594swapping ifs precedence for error check after
https://github.com/pramchan/cluster-api-provider-openstack/blob/master/controllers/openstackcluster_controller.go#L300
to...
if err != nil {
return errors.Errorf("failed to find network: %v", err)
}
if len(networkList) == 0 {
return errors.Errorf("failed to find any network: %v", err)
}
if len(networkList) > 1 {
return errors.Errorf("failed to find only one network (result: %v): %v", networkList, err)
}
openStackCluster.Status.Network = &infrav1.Network{
ID: networkList[0].ID,
Name: networkList[0].Name,
}
**Which issue(s) this PR fixes** *:
Fixes #590 , #594

**Special notes for your reviewer**:
the way I did it is 
git log --oneline
c528adda (HEAD -> my594) revised #590 #594 wrong parameter for a user provider network
...
edited and added the controllers/openstackclsuater-controllers.go
...
git branch my594 c528adda
git checkout my594
git push --repo  https://github.com/pramchan/cluster-api-provider-openstack
remote: Create a pull request for 'my594' on GitHub by visiting:
remote:      https://github.com/pramchan/cluster-api-provider-openstack/pull/new/my594
remote:
To https://github.com/pramchan/cluster-api-provider-openstack
 * [new branch]        my594 -> my594
Not sure if this will do the trick. If not will close open a fresh pull as this certainly turned to be challenging with so may in between parallel  updates
. 