### PR TITLE
🐛 Fix e2e test Kubernetes official binaries version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -379,6 +379,8 @@ create-cluster: $(CLUSTERCTL) $(KUSTOMIZE) $(ENVSUBST) ## Create a development K
 
     # Patch Kubernetes version
 	cat ./hack/ci/e2e-conformance/e2e-conformance_patch.yaml.tpl | \
+	  sed "s|\$${OPENSTACK_CLOUD_PROVIDER_CONF_B64}|$(OPENSTACK_CLOUD_PROVIDER_CONF_B64)|" | \
+	  sed "s|\$${OPENSTACK_CLOUD_CACERT_B64}|$(OPENSTACK_CLOUD_CACERT_B64)|" | \
 	  sed "s|\$${KUBERNETES_VERSION}|$(KUBERNETES_VERSION)|" | \
 	  sed "s|\$${CLUSTER_NAME}|$(CLUSTER_NAME)|"  \
 	   > ./hack/ci/e2e-conformance/e2e-conformance_patch.yaml

--- a/hack/ci/e2e-conformance/e2e-conformance_patch.yaml.tpl
+++ b/hack/ci/e2e-conformance/e2e-conformance_patch.yaml.tpl
@@ -13,6 +13,59 @@ spec:
         kubeletExtraArgs:
           v: "8"
     verbosity: 8
+    preKubeadmCommands:
+    - bash -c /tmp/kubeadm-bootstrap.sh
+    files:
+    - path: /etc/kubernetes/cloud.conf
+      owner: root
+      permissions: "0600"
+      content: ${OPENSTACK_CLOUD_PROVIDER_CONF_B64}
+      encoding: base64
+    - path: /etc/certs/cacert
+      owner: root
+      permissions: "0600"
+      content: ${OPENSTACK_CLOUD_CACERT_B64}
+      encoding: base64
+    - path: /tmp/kubeadm-bootstrap.sh
+      owner: "root:root"
+      permissions: "0744"
+      content: |
+        #!/bin/bash
+
+        set -o nounset
+        set -o pipefail
+        set -o errexit
+        set -e
+
+        [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
+
+        # This script installs kubectl, kubelet, and kubeadm binaries.
+        LINE_SEPARATOR="*************************************************"
+        echo "$LINE_SEPARATOR"
+
+        K8S_DIR="/tmp/k8s"
+        mkdir -p ${K8S_DIR}
+        K8S_URL="https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/kubernetes-server-linux-amd64.tar.gz"
+        cd ${K8S_DIR}
+        wget -q ${K8S_URL}
+        tar zxf kubernetes-server-linux-amd64.tar.gz
+        K8S_SERVER_BIN_DIR="${K8S_DIR}/kubernetes/server/bin"
+
+        declare -a BINARIES_TO_TEST=("kubectl" "kubelet" "kubeadm")
+        for BINARY in "${BINARIES_TO_TEST[@]}"; do
+          # move old binary away to avoid err "Text file busy"
+          ${SUDO} mv /usr/bin/${BINARY} /usr/bin/${BINARY}.bak
+          ${SUDO} cp ${K8S_SERVER_BIN_DIR}/${BINARY} /usr/bin/${BINARY}
+          ${SUDO} chmod +x /usr/bin/${BINARY}
+        done
+
+        echo "$(date): checking binary versions"
+        echo "ctr version: " $(ctr version)
+        echo "kubeadm version: " $(kubeadm version -o=short)
+        echo "kubectl version: " $(kubectl version --client=true --short=true)
+        echo "kubelet version: " $(kubelet --version)
+
+        echo "$LINE_SEPARATOR"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
@@ -22,3 +75,56 @@ spec:
   template:
     spec:
       verbosity: 8
+      preKubeadmCommands:
+      - bash -c /tmp/kubeadm-bootstrap.sh
+      files:
+      - content: ${OPENSTACK_CLOUD_PROVIDER_CONF_B64}
+        encoding: base64
+        owner: root
+        path: /etc/kubernetes/cloud.conf
+        permissions: "0600"
+      - content: ${OPENSTACK_CLOUD_CACERT_B64}
+        encoding: base64
+        owner: root
+        path: /etc/certs/cacert
+        permissions: "0600"
+      - path: /tmp/kubeadm-bootstrap.sh
+        owner: "root:root"
+        permissions: "0744"
+        content: |
+          #!/bin/bash
+
+          set -o nounset
+          set -o pipefail
+          set -o errexit
+          set -e
+
+          [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
+
+          # This script installs kubectl, kubelet, and kubeadm binaries.
+          LINE_SEPARATOR="*************************************************"
+          echo "$LINE_SEPARATOR"
+
+          K8S_DIR=/tmp/k8s
+          mkdir -p $K8S_DIR
+          K8S_URL="https://dl.k8s.io/${KUBERNETES_VERSION}/kubernetes-server-linux-amd64.tar.gz"
+          cd ${K8S_DIR}
+          wget ${K8S_URL}
+          tar zxvf kubernetes-server-linux-amd64.tar.gz
+          K8S_SERVER_BIN_DIR="${K8S_DIR}/kubernetes/server/bin"
+
+          declare -a BINARIES_TO_TEST=("kubectl" "kubelet" "kubeadm")
+          for BINARY in "${BINARIES_TO_TEST[@]}"; do
+            # move old binary away to avoid err "Text file busy"
+            ${SUDO} mv /usr/bin/${BINARY} /usr/bin/${BINARY}.bak
+            ${SUDO} cp ${K8S_SERVER_BIN_DIR}/${BINARY} /usr/bin/${BINARY}
+            ${SUDO} chmod +x /usr/bin/${BINARY}
+          done
+
+          echo "$(date): checking binary versions"
+          echo "ctr version: " $(ctr version)
+          echo "kubeadm version: " $(kubeadm version -o=short)
+          echo "kubectl version: " $(kubectl version --client=true --short=true)
+          echo "kubelet version: " $(kubelet --version)
+
+          echo "$LINE_SEPARATOR"


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

#613 was incomplete. The PR removed preKubeadmCommands at all. By #613, Image version actually becomes official version, but binaries(kubeadm, kubectl, and kubelet) are not updated. This PR fixes to update binaries version by preKubeadmCommands.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #612 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
