### PR TITLE
📖 Fix Link for external openstack template

### DIFF
--- a/docs/external-cloud-provider.md
+++ b/docs/external-cloud-provider.md
@@ -1,6 +1,6 @@
 # External Cloud Provider
 
-To deploy a cluster using [external cloud provider](https://github.com/kubernetes-sigs/cloud-provider-openstack), create a cluster configuration with the [external cloud provider template](../../templates/cluster-template-external-cloud-provider.yaml).
+To deploy a cluster using [external cloud provider](https://github.com/kubernetes-sigs/cloud-provider-openstack), create a cluster configuration with the [external cloud provider template](../templates/cluster-template-external-cloud-provider.yaml).
 
 ## Steps
 


### PR DESCRIPTION
The link goes one folder up too much causing the reference link to be broken.

**What this PR does / why we need it**:
The link goes one folder up too much causing the reference link to be broken.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. 
No, this changes only the documentation.

