### PR TITLE
CI: Wget kubernetes binary be quiet

### DIFF
--- a/hack/ci/e2e-conformance/e2e-conformance_patch.yaml.tpl
+++ b/hack/ci/e2e-conformance/e2e-conformance_patch.yaml.tpl
@@ -109,7 +109,7 @@ spec:
           mkdir -p $K8S_DIR
           K8S_URL="https://dl.k8s.io/${KUBERNETES_VERSION}/kubernetes-server-linux-amd64.tar.gz"
           cd ${K8S_DIR}
-          wget ${K8S_URL}
+          wget -q ${K8S_URL}
           tar zxvf kubernetes-server-linux-amd64.tar.gz
           K8S_SERVER_BIN_DIR="${K8S_DIR}/kubernetes/server/bin"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently master node wget kubernetes binary logs quiet, but worker is not quiet. This PR makes wget kubernetes binary be quiet as master does.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
