### PR TITLE
Add force move of secret cloud config

### DIFF
--- a/templates/cluster-template-external-cloud-provider.yaml
+++ b/templates/cluster-template-external-cloud-provider.yaml
@@ -137,6 +137,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: ${CLUSTER_NAME}-cloud-config
+  labels:
+    clusterctl.cluster.x-k8s.io/move: "true"
 data:
   clouds.yaml: ${OPENSTACK_CLOUD_YAML_B64}
   cacert: ${OPENSTACK_CLOUD_CACERT_B64}

--- a/templates/cluster-template-without-lb.yaml
+++ b/templates/cluster-template-without-lb.yaml
@@ -178,6 +178,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: ${CLUSTER_NAME}-cloud-config
+  labels:
+    clusterctl.cluster.x-k8s.io/move: "true"
 data:
   clouds.yaml: ${OPENSTACK_CLOUD_YAML_B64}
   cacert: ${OPENSTACK_CLOUD_CACERT_B64}

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -177,6 +177,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: ${CLUSTER_NAME}-cloud-config
+  labels:
+    clusterctl.cluster.x-k8s.io/move: "true"
 data:
   clouds.yaml: ${OPENSTACK_CLOUD_YAML_B64}
   cacert: ${OPENSTACK_CLOUD_CACERT_B64}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #626 

with this , latest clusterctl should be able to force move secret we created in CAPO
```
commit 0e886b905a67c68b5bce3f249aaff13079affeeb (origin/bug/3603, bug/3603)
Author: jichenjc <jichenjc@cn.ibm.com>
Date:   Thu Sep 10 02:59:08 2020 +0000

    Add force move support for object

```

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
