### PR TITLE
default concurrent reconcile from 1 to 10

### DIFF
--- a/main.go
+++ b/main.go
@@ -110,7 +110,7 @@ func main() {
 
 	flag.IntVar(&openStackMachineConcurrency,
 		"openstackmachine-concurrency",
-		1,
+		10,
 		"Number of OpenStackMachines to process simultaneously",
 	)
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

make reconcile handle maximum concurrent handling machines to 10
as default 1 will handle machine one by one

note I didn't update concurrent cluster handle as it might need further test

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
