### PR TITLE
📖 Fix Required Environment Variable Name

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,7 +47,7 @@ The SSH key pair is required. You can create one using,
 openstack keypair create [--public-key <file> | --private-key <file>] <name>
 ```
 
-The key pair name must be exposed as an environment variable `OPENSTACK_SSH_KEY_NAME`.
+The key pair name must be exposed as an environment variable `OPENSTACK_SSH_AUTHORIZED_KEY`.
 
 If you want to login to each machine by ssh,  you can [access nodes through the bastion host via SSH](#accessing-nodes-through-the-bastion-host-via-ssh). Otherwise you have to configure security groups. If `spec.managedSecurityGroups` of `OpenStackCluster` set to true, two security groups will be created and added to the instances. One is `k8s-cluster-${NAMESPACE}-${CLUSTER_NAME}-secgroup-controlplane`, another is `k8s-cluster-${NAMESPACE}-${CLUSTER_NAME}-secgroup-worker`. These security group rules include the kubeadm's [Check required ports](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#check-required-ports) so that each node can not be logged in through ssh by default. Please add pre-existing security group allowing ssh port to OpenStackMachineTemplate spec. Here is an example:
 


### PR DESCRIPTION
This is my first CNCF pull request.
Please point out any mistakes.

**What this PR does / why we need it**:
clusterctl 0.3.9 and 0.3.10 say

```
Error: value for variables [OPENSTACK_SSH_AUTHORIZED_KEY] is not set.
Please set the value using os environment variables or the clusterctl
config file
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

**Special notes for your reviewer**:
This is my first CNCF Project pull request.
Please point out any mistakes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
 * Fix ssh keypair Environment Variable Name.
```
