### PR TITLE
📖 Update calico version in documentation

### DIFF
--- a/docs/external-cloud-provider.md
+++ b/docs/external-cloud-provider.md
@@ -15,7 +15,7 @@ To deploy a cluster using [external cloud provider](https://github.com/kubernete
 - Deploy a CNI solution
 
     ```shell
-    curl https://docs.projectcalico.org/v3.12/manifests/calico.yaml | sed "s/veth_mtu:.*/veth_mtu: \"1430\"/g" | kubectl --kubeconfig=./${CLUSTER_NAME}.kubeconfig apply -f -
+    curl https://docs.projectcalico.org/v3.16/manifests/calico.yaml | sed "s/veth_mtu:.*/veth_mtu: \"1430\"/g" | kubectl --kubeconfig=./${CLUSTER_NAME}.kubeconfig apply -f -
     ```
 
 - Create a secret containing the cloud configuration


### PR DESCRIPTION
:book: Updated calico version in external-cloud-provider documentation

**What this PR does / why we need it**:
Calico version mentioned in the document is 2 releases old. Updated the same in the document.

**Release note**:
```release-note
None
```
