### PR TITLE
🏃 Delete spec.kubeadmConfigSpec.ntp.servers in cluster-template-without-lb.yaml

### DIFF
--- a/templates/cluster-template-without-lb.yaml
+++ b/templates/cluster-template-without-lb.yaml
@@ -91,8 +91,6 @@ spec:
       permissions: "0600"
       content: ${OPENSTACK_CLOUD_CACERT_B64}
       encoding: base64
-    ntp:
-      servers: []
   version: "${KUBERNETES_VERSION}"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit deletes spec.kubeadmConfigSpec.ntp.servers of KubeadmControlPlane resource in cluster-template-without-lb.yaml.
Other templates(HA version and external version) do not have spec.kubeadmConfigSpec.ntp.servers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
