### PR TITLE
📖  Update how to retrieve kubeconfig

### DIFF
--- a/docs/external-cloud-provider.md
+++ b/docs/external-cloud-provider.md
@@ -7,9 +7,7 @@ To deploy a cluster using [external cloud provider](https://github.com/kubernete
 - After control plane is up and running, retrieve the workload cluster Kubeconfig:
 
     ```shell
-    kubectl --namespace=default get secret/${CLUSTER_NAME}-kubeconfig -o jsonpath={.data.value} \
-    | base64 --decode \
-    > ./${CLUSTER_NAME}.kubeconfig
+    clusterctl get kubeconfig ${CLUSTER_NAME} --namespace default > ./${CLUSTER_NAME}.kubeconfig
     ```
 
 - Deploy a CNI solution


### PR DESCRIPTION
**What this PR does / why we need it**:

Update to use clusterctl get kubeconfig which is available in clusterctl v0.3.9 or newer.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
