### PR TITLE
✨ Align flag names with upstream Kubernetes components

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - args:
-        - --enable-leader-election
+        - --leader-elect
         image: controller:latest
         imagePullPolicy: IfNotPresent
         name: manager

--- a/config/manager/manager_auth_proxy_patch.yaml
+++ b/config/manager/manager_auth_proxy_patch.yaml
@@ -21,5 +21,5 @@ spec:
           name: https
       - name: manager
         args:
-        - "--metrics-addr=127.0.0.1:8080"
-        - "--enable-leader-election"
+        - "--metrics-bind-addr=127.0.0.1:8080"
+        - "--leader-elect"

--- a/config/webhook/manager_webhook_patch.yaml
+++ b/config/webhook/manager_webhook_patch.yaml
@@ -9,7 +9,7 @@ spec:
       containers:
       - name: manager
         args:
-        - "--metrics-addr=127.0.0.1:8080"
+        - "--metrics-bind-addr=127.0.0.1:8080"
         - "--webhook-port=9443"
         ports:
         - containerPort: 9443

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func main() {
 	klog.InitFlags(nil)
 
 	var (
-		metricsAddr                 string
+		metricsBindAddr             string
 		enableLeaderElection        bool
 		leaderElectionNamespace     string
 		watchNamespace              string
@@ -69,15 +69,15 @@ func main() {
 	)
 
 	flag.StringVar(
-		&metricsAddr,
-		"metrics-addr",
+		&metricsBindAddr,
+		"metrics-bind-addr",
 		":8080",
 		"The address the metric endpoint binds to.",
 	)
 
 	flag.BoolVar(
 		&enableLeaderElection,
-		"enable-leader-election",
+		"leader-elect",
 		false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.",
 	)
@@ -160,7 +160,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:                  scheme,
-		MetricsBindAddress:      metricsAddr,
+		MetricsBindAddress:      metricsBindAddr,
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionID:        "controller-leader-election-capo",
 		LeaderElectionNamespace: leaderElectionNamespace,


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This changes the name of following flags to allign with k8s upstream.

1. `--metrics-addr` to `--metrics-bind-addr`
2. `leader-election` to `leader-elect`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #689 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
