### PR TITLE
🐛 Delete spec.disableServerTags of OpenStackCluster

### DIFF
--- a/templates/cluster-template-external-cloud-provider.yaml
+++ b/templates/cluster-template-external-cloud-provider.yaml
@@ -32,7 +32,6 @@ spec:
   dnsNameservers:
   - ${OPENSTACK_DNS_NAMESERVERS}
   disablePortSecurity: false
-  disableServerTags: true
   useOctavia: true
 ---
 kind: KubeadmControlPlane


### PR DESCRIPTION
**What this PR does / why we need it**:

Spec.disableServerTags of OpenStackCluster is deleted in e58572d3ec46a8a9767e98ef9b8cd223d7dfaf09. But cluster-template-external-cloud-provider.yaml was missed. This PR deletes it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #691 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
