### PR TITLE
📖 fix getting log

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -17,7 +17,7 @@ This guide (based on Minikube but others should be similar) explains general inf
 ## Get logs of Cluster API controller containers
 
 ```bash
-kubectl --kubeconfig minikube.kubeconfig -n capo-system logs -l control-plane=capo-controller-manager
+kubectl --kubeconfig minikube.kubeconfig -n capo-system logs -l control-plane=capo-controller-manager -c manager
 ```
 
 Similarly, the logs of the other controllers in the namespaces `capi-system` and `cabpk-system` can be retrieved.


### PR DESCRIPTION
**What this PR does / why we need it**:

Since capo-controller has two containers, kubectl logs needs -c option.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
