### PR TITLE
:bug: Fix domain_name and domain_id usage in env.rc

### DIFF
--- a/templates/env.rc
+++ b/templates/env.rc
@@ -72,11 +72,11 @@ CAPO_DOMAIN_NAME=$(echo "$CAPO_OPENSTACK_CLOUD_YAML_CONTENT" | yq r - clouds.${C
 CAPO_APPLICATION_CREDENTIAL_NAME=$(echo "$CAPO_OPENSTACK_CLOUD_YAML_CONTENT" | yq r - clouds.${CAPO_CLOUD}.auth.application_credential_name)
 CAPO_APPLICATION_CREDENTIAL_ID=$(echo "$CAPO_OPENSTACK_CLOUD_YAML_CONTENT" | yq r - clouds.${CAPO_CLOUD}.auth.application_credential_id)
 CAPO_APPLICATION_CREDENTIAL_SECRET=$(echo "$CAPO_OPENSTACK_CLOUD_YAML_CONTENT" | yq r - clouds.${CAPO_CLOUD}.auth.application_credential_secret)
-if [[ "$CAPO_DOMAIN_NAME" = "null" ]]; then
+if [[ "$CAPO_DOMAIN_NAME" = "" || "$CAPO_DOMAIN_NAME" = "null" ]]; then
   CAPO_DOMAIN_NAME=$(echo "$CAPO_OPENSTACK_CLOUD_YAML_CONTENT" | yq r - clouds.${CAPO_CLOUD}.auth.domain_name)
 fi
 CAPO_DOMAIN_ID=$(echo "$CAPO_OPENSTACK_CLOUD_YAML_CONTENT" | yq r - clouds.${CAPO_CLOUD}.auth.user_domain_id)
-if [[ "$CAPO_DOMAIN_ID" = "null" ]]; then
+if [[ "$CAPO_DOMAIN_ID" = "" || "$CAPO_DOMAIN_ID" = "null" ]]; then
   CAPO_DOMAIN_ID=$(echo "$CAPO_OPENSTACK_CLOUD_YAML_CONTENT" | yq r - clouds.${CAPO_CLOUD}.auth.domain_id)
 fi
 CAPO_CACERT_ORIGINAL=$(echo "$CAPO_OPENSTACK_CLOUD_YAML_CONTENT" | yq r - clouds.${CAPO_CLOUD}.cacert)


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, _domain_name_ and _domain_id_ are being ignored when getting the OpenStack credentials from clouds.yaml.

Fixes #713 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.


**Release note**:
```release-note
NONE
```
