### PR TITLE
Fix ca-file path in env.rc

### DIFF
--- a/templates/env.rc
+++ b/templates/env.rc
@@ -117,7 +117,7 @@ if [[ "$CAPO_DOMAIN_ID" != "" && "$CAPO_DOMAIN_ID" != "null" ]]; then
 fi
 
 if [[ "$CAPO_CACERT_ORIGINAL" != "" && "$CAPO_CACERT_ORIGINAL" != "null" ]]; then
-  echo "ca-file=\"${CAPO_CACERT_ORIGINAL}\"" >> ${CAPO_CLOUD_PROVIDER_CONF_TMP}
+  echo "ca-file=\"/etc/certs/cacert\"" >> ${CAPO_CLOUD_PROVIDER_CONF_TMP}
 fi
 if [[ "$CAPO_REGION" != "" && "$CAPO_REGION" != "null" ]]; then
   echo "region=\"${CAPO_REGION}\"" >> ${CAPO_CLOUD_PROVIDER_CONF_TMP}


### PR DESCRIPTION
**What this PR does / why we need it**:

When using cacert in cloud.yaml, the local CA certificate path is set also in the OpenStack VM's /etc/kubernetes/cloud.conf, while the certificate is always copied in /etc/certs/cacert

This issue causes the deployment to fail as the certificate file cannot be found in the VM.

**Which issue(s) this PR fixes**:
Fixes #715

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
