### PR TITLE
🏃 Revert Merge pull request #725

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -19,7 +19,6 @@ spec:
       containers:
       - args:
         - --leader-elect
-        - --metrics-bind-addr=127.0.0.1:8080
         image: controller:latest
         imagePullPolicy: IfNotPresent
         name: manager


### PR DESCRIPTION
**What this PR does / why we need it**:

This reverts commit 8f51aa22db22e0b5f53b7cb7aa28bae9d6ce8fea.

Because `--metrics-bind-addr=127.0.0.1:8080` is added by patches:

- https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/master/config/manager/manager_auth_proxy_patch.yaml#L24
- https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/master/config/webhook/manager_webhook_patch.yaml#L12

Actually we can get the same result using `kustomize build` under `config` directory.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
