### PR TITLE
🐛 use APIServerFloatingIP instead of ControlPlaneEndpoint.Host for LB

### DIFF
--- a/pkg/cloud/services/loadbalancer/loadbalancer.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer.go
@@ -71,7 +71,7 @@ func (s *Service) ReconcileLoadBalancer(clusterName string, openStackCluster *in
 		}
 	}
 
-	fp, err := s.networkingService.GetOrCreateFloatingIP(openStackCluster, openStackCluster.Spec.ControlPlaneEndpoint.Host)
+	fp, err := s.networkingService.GetOrCreateFloatingIP(openStackCluster, openStackCluster.Spec.APIServerFloatingIP)
 	if err != nil {
 		return err
 	}

--- a/pkg/cloud/services/loadbalancer/loadbalancer.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer.go
@@ -71,7 +71,11 @@ func (s *Service) ReconcileLoadBalancer(clusterName string, openStackCluster *in
 		}
 	}
 
-	fp, err := s.networkingService.GetOrCreateFloatingIP(openStackCluster, openStackCluster.Spec.APIServerFloatingIP)
+	fip := openStackCluster.Spec.ControlPlaneEndpoint.Host
+	if openStackCluster.Spec.APIServerFloatingIP != "" {
+		fip = openStackCluster.Spec.APIServerFloatingIP
+	}
+	fp, err := s.networkingService.GetOrCreateFloatingIP(openStackCluster, fip)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #754

**Special notes for your reviewer**:
I'm not sure this is the correct way to solve this, but fixed the problem for us

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
```release-note
You can use a FQDN in `openStackCluster.Spec.ControlPlaneEndpoint.Host`
```
