### PR TITLE
:sparkles: AccessSubnetUUID: we can specify source subnet for access IP address

### DIFF
--- a/api/v1alpha3/openstackmachine_types.go
+++ b/api/v1alpha3/openstackmachine_types.go
@@ -57,6 +57,10 @@ type OpenStackMachineSpec struct {
 	// A networks object. Required parameter when there are multiple networks defined for the tenant.
 	// When you do not specify the networks parameter, the server attaches to the only network created for the current tenant.
 	Networks []NetworkParam `json:"networks,omitempty"`
+
+	// IP address of a port from this subnet will be marked as AccessIPv4 on the created compute instance
+	AccessSubnetUUID string `json:"accessSubnetUuid,omitempty"`
+
 	// The floatingIP which will be associated to the machine, only used for master.
 	// The floatingIP should have been created and haven't been associated.
 	FloatingIP string `json:"floatingIP,omitempty"`

--- a/api/v1alpha3/openstackmachine_types.go
+++ b/api/v1alpha3/openstackmachine_types.go
@@ -58,8 +58,8 @@ type OpenStackMachineSpec struct {
 	// When you do not specify the networks parameter, the server attaches to the only network created for the current tenant.
 	Networks []NetworkParam `json:"networks,omitempty"`
 
-	// IP address of a port from this subnet will be marked as AccessIPv4 on the created compute instance
-	AccessSubnetUUID string `json:"accessSubnetUuid,omitempty"`
+	// UUID, IP address of a port from this subnet will be marked as AccessIPv4 on the created compute instance
+	Subnet string `json:"subnet,omitempty"`
 
 	// The floatingIP which will be associated to the machine, only used for master.
 	// The floatingIP should have been created and haven't been associated.

--- a/api/v1alpha3/types.go
+++ b/api/v1alpha3/types.go
@@ -132,6 +132,7 @@ type Instance struct {
 	FailureDomain  string            `json:"failureDomain,omitempty"`
 	SecurityGroups *[]string         `json:"securigyGroups,omitempty"`
 	Networks       *[]Network        `json:"networks,omitempty"`
+	AccessSubnet   string            `json:"accessSubnet,omitempty"`
 	Tags           []string          `json:"tags,omitempty"`
 	Image          string            `json:"image,omitempty"`
 	Flavor         string            `json:"flavor,omitempty"`

--- a/api/v1alpha3/types.go
+++ b/api/v1alpha3/types.go
@@ -132,7 +132,7 @@ type Instance struct {
 	FailureDomain  string            `json:"failureDomain,omitempty"`
 	SecurityGroups *[]string         `json:"securigyGroups,omitempty"`
 	Networks       *[]Network        `json:"networks,omitempty"`
-	AccessSubnet   string            `json:"accessSubnet,omitempty"`
+	Subnet         string            `json:"subnet,omitempty"`
 	Tags           []string          `json:"tags,omitempty"`
 	Image          string            `json:"image,omitempty"`
 	Flavor         string            `json:"flavor,omitempty"`

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -476,8 +476,6 @@ spec:
             properties:
               bastion:
                 properties:
-                  accessSubnet:
-                    type: string
                   configDrive:
                     type: boolean
                   failureDomain:
@@ -592,6 +590,8 @@ spec:
                   state:
                     description: InstanceState describes the state of an OpenStack
                       instance.
+                    type: string
+                  subnet:
                     type: string
                   tags:
                     items:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -476,6 +476,8 @@ spec:
             properties:
               bastion:
                 properties:
+                  accessSubnet:
+                    type: string
                   configDrive:
                     type: boolean
                   failureDomain:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
@@ -59,6 +59,10 @@ spec:
           spec:
             description: OpenStackMachineSpec defines the desired state of OpenStackMachine
             properties:
+              accessSubnetUuid:
+                description: IP address of a port from this subnet will be marked
+                  as AccessIPv4 on the created compute instance
+                type: string
               cloudName:
                 description: The name of the cloud to use from the clouds secret
                 type: string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
@@ -59,10 +59,6 @@ spec:
           spec:
             description: OpenStackMachineSpec defines the desired state of OpenStackMachine
             properties:
-              accessSubnetUuid:
-                description: IP address of a port from this subnet will be marked
-                  as AccessIPv4 on the created compute instance
-                type: string
               cloudName:
                 description: The name of the cloud to use from the clouds secret
                 type: string
@@ -274,6 +270,10 @@ spec:
                 type: object
               sshKeyName:
                 description: The ssh key to inject in the instance
+                type: string
+              subnet:
+                description: UUID, IP address of a port from this subnet will be marked
+                  as AccessIPv4 on the created compute instance
                 type: string
               tags:
                 description: Machine tags Requires Nova api 2.52 minimum!

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
@@ -48,10 +48,6 @@ spec:
                     description: Spec is the specification of the desired behavior
                       of the machine.
                     properties:
-                      accessSubnetUuid:
-                        description: IP address of a port from this subnet will be
-                          marked as AccessIPv4 on the created compute instance
-                        type: string
                       cloudName:
                         description: The name of the cloud to use from the clouds
                           secret
@@ -269,6 +265,10 @@ spec:
                         type: object
                       sshKeyName:
                         description: The ssh key to inject in the instance
+                        type: string
+                      subnet:
+                        description: UUID, IP address of a port from this subnet will
+                          be marked as AccessIPv4 on the created compute instance
                         type: string
                       tags:
                         description: Machine tags Requires Nova api 2.52 minimum!

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
@@ -48,6 +48,10 @@ spec:
                     description: Spec is the specification of the desired behavior
                       of the machine.
                     properties:
+                      accessSubnetUuid:
+                        description: IP address of a port from this subnet will be
+                          marked as AccessIPv4 on the created compute instance
+                        type: string
                       cloudName:
                         description: The name of the cloud to use from the clouds
                           secret

--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -229,6 +229,10 @@ func createInstance(is *Service, clusterName string, i *infrav1.Instance) (*infr
 			}
 		}
 	}
+	if i.AccessSubnet != "" && accessIPv4 == "" {
+		return nil, fmt.Errorf("no ports with fixed IPs found on AccessSubnet \"%s\"", i.AccessSubnet)
+	}
+
 	var serverCreateOpts servers.CreateOptsBuilder = servers.CreateOpts{
 		Name:             i.Name,
 		ImageRef:         imageID,

--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -80,6 +80,7 @@ func (s *Service) InstanceCreate(clusterName string, machine *clusterv1.Machine,
 		ConfigDrive:   openStackMachine.Spec.ConfigDrive,
 		FailureDomain: *machine.Spec.FailureDomain,
 		RootVolume:    openStackMachine.Spec.RootVolume,
+		AccessSubnet:  openStackMachine.Spec.AccessSubnetUUID,
 	}
 
 	if openStackMachine.Spec.Trunk {
@@ -153,6 +154,7 @@ func createInstance(is *Service, clusterName string, i *infrav1.Instance) (*infr
 		return nil, fmt.Errorf("create new server err: %v", err)
 	}
 
+	accessIPv4 := ""
 	nets := i.Networks
 	portsList := []servers.Network{}
 	for _, net := range *nets {
@@ -180,6 +182,12 @@ func createInstance(is *Service, clusterName string, i *infrav1.Instance) (*infr
 			}
 		} else {
 			port = portList[0]
+		}
+
+		for _, fip := range port.FixedIPs {
+			if fip.SubnetID == i.AccessSubnet {
+				accessIPv4 = fip.IPAddress
+			}
 		}
 
 		portsList = append(portsList, servers.Network{
@@ -233,6 +241,7 @@ func createInstance(is *Service, clusterName string, i *infrav1.Instance) (*infr
 		Tags:             i.Tags,
 		Metadata:         i.Metadata,
 		ConfigDrive:      i.ConfigDrive,
+		AccessIPv4:       accessIPv4,
 	}
 
 	serverCreateOpts = applyRootVolume(serverCreateOpts, i.RootVolume)

--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -80,7 +80,7 @@ func (s *Service) InstanceCreate(clusterName string, machine *clusterv1.Machine,
 		ConfigDrive:   openStackMachine.Spec.ConfigDrive,
 		FailureDomain: *machine.Spec.FailureDomain,
 		RootVolume:    openStackMachine.Spec.RootVolume,
-		AccessSubnet:  openStackMachine.Spec.AccessSubnetUUID,
+		AccessSubnet:  openStackMachine.Spec.Subnet,
 	}
 
 	if openStackMachine.Spec.Trunk {

--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -80,7 +80,7 @@ func (s *Service) InstanceCreate(clusterName string, machine *clusterv1.Machine,
 		ConfigDrive:   openStackMachine.Spec.ConfigDrive,
 		FailureDomain: *machine.Spec.FailureDomain,
 		RootVolume:    openStackMachine.Spec.RootVolume,
-		AccessSubnet:  openStackMachine.Spec.Subnet,
+		Subnet:        openStackMachine.Spec.Subnet,
 	}
 
 	if openStackMachine.Spec.Trunk {
@@ -185,7 +185,7 @@ func createInstance(is *Service, clusterName string, i *infrav1.Instance) (*infr
 		}
 
 		for _, fip := range port.FixedIPs {
-			if fip.SubnetID == i.AccessSubnet {
+			if fip.SubnetID == i.Subnet {
 				accessIPv4 = fip.IPAddress
 			}
 		}
@@ -229,8 +229,8 @@ func createInstance(is *Service, clusterName string, i *infrav1.Instance) (*infr
 			}
 		}
 	}
-	if i.AccessSubnet != "" && accessIPv4 == "" {
-		return nil, fmt.Errorf("no ports with fixed IPs found on AccessSubnet \"%s\"", i.AccessSubnet)
+	if i.Subnet != "" && accessIPv4 == "" {
+		return nil, fmt.Errorf("no ports with fixed IPs found on Subnet \"%s\"", i.Subnet)
 	}
 
 	var serverCreateOpts servers.CreateOptsBuilder = servers.CreateOpts{


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, when we want to use multiple networks, the IP address is assigned basically randomly, this PR adds the ability to specify from which subnet the IP address will be obtained.

**Which issue(s) this PR fixes**:
none

**Special notes for your reviewer**:
This is the minimal amount of changes I found to achieve the goal of getting IP address from the correct CIDR.

**Release note**:
```release-note
Added the ability to specify source subnet of compute instance access IP address
```
