### PR TITLE
🏃 Update pull request template to use /hold per default

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,3 +18,5 @@ Fixes #
 ```release-note
 
 ```
+
+/hold


### PR DESCRIPTION
Adjust the pull request template to use /hold per default. Goal is just to avoid accidental instant merges on-/hold. We can always deliberately remove the hold if we really want to merge instantly :).

/hold
