### PR TITLE
🐛 InstanceExists should not do substring search on name

### DIFF
--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -666,7 +666,10 @@ func (s *Service) InstanceExists(name string) (instance *infrav1.Instance, err e
 	var listOpts servers.ListOpts
 	if name != "" {
 		listOpts = servers.ListOpts{
-			Name: name,
+			// The name parameter to /servers is a regular expression. Unless we
+			// explicitly specify a whole string match this will be a substring
+			// match.
+			Name: fmt.Sprintf("^%s$", name),
 		}
 	} else {
 		listOpts = servers.ListOpts{}


### PR DESCRIPTION
The server list api defines the name parameter to be a regular
expression:

https://docs.openstack.org/api-ref/compute/?expanded=list-servers-detail#list-servers

This meant that the usage of it in InstanceExists was a
substring lookup rather than the intended lookup by name.

This is an 'upstream port' of the fix for https://bugzilla.redhat.com/show_bug.cgi?id=1747270