### PR TITLE
🐛  Make conversion-gen output location explicit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ export GO111MODULE=on
 export DOCKER_CLI_EXPERIMENTAL := enabled
 
 # Directories.
+REPO_ROOT := $(shell git rev-parse --show-toplevel)
 TOOLS_DIR := hack/tools
 TOOLS_BIN_DIR := $(TOOLS_DIR)/bin
 BIN_DIR := bin
@@ -49,6 +50,11 @@ CONVERSION_GEN := $(TOOLS_BIN_DIR)/conversion-gen
 RELEASE_NOTES_BIN := bin/release-notes
 RELEASE_NOTES := $(TOOLS_DIR)/$(RELEASE_NOTES_BIN)
 GINKGO := $(TOOLS_BIN_DIR)/ginkgo
+
+# Set --output-base for conversion-gen if we are not within GOPATH
+ifneq ($(abspath $(REPO_ROOT)),$(shell go env GOPATH)/src/sigs.k8s.io/cluster-api-provider-openstack)
+	GEN_OUTPUT_BASE := --output-base=$(REPO_ROOT)
+endif
 
 # Define Docker related variables. Releases should modify and double check these vars.
 REGISTRY ?= gcr.io/k8s-staging-capi-openstack
@@ -183,7 +189,7 @@ generate-go: $(CONTROLLER_GEN) $(CONVERSION_GEN) $(MOCKGEN) ## Runs Go related g
 
 	$(CONVERSION_GEN) \
 		--input-dirs=./api/v1alpha3 \
-		--output-file-base=zz_generated.conversion \
+		--output-file-base=zz_generated.conversion $(GEN_OUTPUT_BASE) \
 		--go-header-file=./hack/boilerplate/boilerplate.generatego.txt
 	go generate ./...
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The conversion-gen command has an --output-base argument to control
where generated files are placed. The default value for this argument
can vary depending on whether or not $GOPATH is set or not. This results
in our generated files being created in the wrong place for some people
in a subtle and non-obvious way.

For those running `make generate` with GOPATH set, the files are created
in `$GOPATH/src/[file path]`. For those without GOPATH set, files are
created where we expect them to be within the repo at `./[file path]`.

To make sure files are always generated to the location where we expect
them to be, this updates our calls to conversion-gen to always be
explicit when not within GOPATH by setting  `--output-base=[repo_path]`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #801

**Special notes for your reviewer**:

Should be able to reproduce locally to validate by cloning repo outside of GOPATH. Check and remove any remnants found under ls "$(go env GOPATH)/src", then run make generate-go-core. Prior to applying this change, you will see awsclient and others show up under $GOPATH/src, after you will see updates within the repo.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
