### PR TITLE
🏃 Remove unused release note section in the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,13 +18,4 @@ Fixes #
   - [ ] includes documentation
   - [ ] adds unit tests
 
-**Release note**:
-<!--  Write your release note:
-1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
-2. If no release note is required, just write "NONE".
--->
-```release-note
-
-```
-
 /hold


### PR DESCRIPTION


**What this PR does / why we need it**:

We don't actually use this data. It's for tooling of the main Kubernetes project we don't use in CAPO. We only 
rely on PR title and icon.


- [x] squashed commits
- if necessary:
  - [x] includes documentation
  - [x] adds unit tests

/hold
