### PR TITLE
🐛 fix post-cluster-api-provider-openstack-push-images

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,13 +2,15 @@
 timeout: 1200s
 options:
   substitution_option: ALLOW_LOOSE
+  machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20190906-745fed4'
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200619-68869a4'
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled
     - TAG=$_GIT_TAG
     - PULL_BASE_REF=$_PULL_BASE_REF
+    - DOCKER_BUILDKIT=1
     args:
     - release-staging
 substitutions:


### PR DESCRIPTION
**What this PR does / why we need it**:

The job which pushes images post-merge has been broken: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-cluster-api-provider-openstack-push-images/1375280030887710720

This PR upgrades the image to the latest build image available. This changes the go version from 1.12 to 1.13.
Imho this is not ideal but might already fix the job. I'll try to figure out via an issue in the cluster-api Repo if we should bump the go version in this image to 1.16

/hold
