### PR TITLE
fix post-cluster-api-provider-openstack-push-images and add post-submit manifests

### DIFF
--- a/hack/image-patch/kustomization.yaml
+++ b/hack/image-patch/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+images:
+  - name: ""
+    newName: ""
+    newTag: ""
+kind: Kustomization
+patchesJson6902:
+  - path: pull-policy-patch.yaml
+    target:
+      group: apps
+      kind: Deployment
+      name: controller-name
+      namespace: namespace
+      version: v1
+resources:
+  - source-manifest.yaml

--- a/hack/image-patch/pull-policy-patch.yaml
+++ b/hack/image-patch/pull-policy-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/template/spec/containers/1/imagePullPolicy
+  value: Always

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -6,9 +6,8 @@ require (
 	github.com/a8m/envsubst v1.2.0
 	github.com/golang/mock v1.4.4
 	github.com/golangci/golangci-lint v1.38.0
-	github.com/mattn/go-runewidth v0.0.9 // indirect
+	github.com/itchyny/gojq v0.12.2
 	github.com/onsi/ginkgo v1.15.2
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/code-generator v0.21.0-beta.0
 	sigs.k8s.io/cluster-api v0.3.11-0.20210310224224-a9144a861bf4
 	sigs.k8s.io/cluster-api/hack/tools v0.0.0-20210313163703-752c727cf58b

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -544,6 +544,12 @@ github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
+github.com/itchyny/go-flags v1.5.0 h1:Z5q2ist2sfDjDlExVPBrMqlsEDxDR2h4zuOElB0OEYI=
+github.com/itchyny/go-flags v1.5.0/go.mod h1:lenkYuCobuxLBAd/HGFE4LRoW8D3B6iXRQfWYJ+MNbA=
+github.com/itchyny/gojq v0.12.2 h1:TxhFjk1w7Vnb0SwQPeG4FxTC98O4Es+x/mPaD5Azgfs=
+github.com/itchyny/gojq v0.12.2/go.mod h1:mi4PdXSlFllHyByM68JKUrbiArtEdEnNEmjbwxcQKAg=
+github.com/itchyny/timefmt-go v0.1.2 h1:q0Xa4P5it6K6D7ISsbLAMwx1PnWlixDcJL6/sFs93Hs=
+github.com/itchyny/timefmt-go v0.1.2/go.mod h1:0osSSCQSASBJMsIZnhAaF1C2fCBTJZXrnj37mG8/c+A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jgautheron/goconst v1.4.0 h1:hp9XKUpe/MPyDamUbfsrGpe+3dnY2whNK4EtB86dvLM=
@@ -1205,8 +1211,9 @@ golang.org/x/sys v0.0.0-20201024232916-9f70ab9862d5/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 h1:myAQVi0cGEoqQVR5POX+8RR2mrocKqNN1hmeMqhX27k=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210301091718-77cc2087c03b h1:kHlr0tATeLRMEiZJu5CknOw/E8V6h69sXXQFGoPtjcc=
+golang.org/x/sys v0.0.0-20210301091718-77cc2087c03b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/hack/tools/tools.go
+++ b/hack/tools/tools.go
@@ -23,6 +23,7 @@ import (
 	_ "github.com/a8m/envsubst"
 	_ "github.com/golang/mock/mockgen"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
+	_ "github.com/itchyny/gojq/cmd/gojq"
 	_ "github.com/onsi/ginkgo/ginkgo"
 	_ "k8s.io/code-generator"
 	_ "sigs.k8s.io/cluster-api/cmd/clusterctl"


### PR DESCRIPTION
Follow-up to: #809

**What this PR does / why we need it**:

This fixes our image push on post-submit (hopefully I tested it locally this time).

It also publishes respective manifests to: https://console.cloud.google.com/storage/browser/artifacts.k8s-staging-capi-openstack.appspot.com;tab=objects?forceOnBucketsSortingFiltering=false&project=k8s-staging-capi-openstack&prefix=&forceOnObjectsSortingFiltering=false

Those should then be available similar to CAPA via:
https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/components/<tag>/infrastructure-components.yaml


- [x] squashed commits
- if necessary:
  - [x] includes documentation
  - [x] adds unit tests

/hold
