### PR TITLE
🐛 do not propagate the cloud field to clientconfig.AuthOptions

### DIFF
--- a/pkg/cloud/services/provider/provider.go
+++ b/pkg/cloud/services/provider/provider.go
@@ -80,7 +80,6 @@ func NewClient(cloud clientconfig.Cloud, caCert []byte) (*gophercloud.ProviderCl
 	if cloud.AuthInfo != nil {
 		clientOpts.AuthInfo = cloud.AuthInfo
 		clientOpts.AuthType = cloud.AuthType
-		clientOpts.Cloud = cloud.Cloud
 		clientOpts.RegionName = cloud.RegionName
 	}
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

This PR stops propagating the `cloud` field to `clientconfig.AuthOptions`. If this field is actually set, we hit a branch in `AuthOptions` which always fails: (I don't think we have to validate that the field is not set, when we can just change the code that it doesn't matter if it is set or not)

https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/31df024b3205232c3545631afb5027f1f0a3f213/pkg/cloud/services/provider/provider.go#L80-L91

https://github.com/gophercloud/utils/blob/7b186010c04f90ca48b5ce471a222911ff076e00/openstack/clientconfig/requests.go#L352-L370

https://github.com/gophercloud/utils/blob/7b186010c04f90ca48b5ce471a222911ff076e00/openstack/clientconfig/requests.go#L192

https://github.com/gophercloud/utils/blob/7b186010c04f90ca48b5ce471a222911ff076e00/openstack/clientconfig/requests.go#L119

there's not cloud.yaml there which could be found...


Alternative would be to duplicate the code from `AuthOptions` we actually want, but I wouldn't like to maintain that much code on our side:

https://github.com/gophercloud/utils/blob/7b186010c04f90ca48b5ce471a222911ff076e00/openstack/clientconfig/requests.go#L390-L396






**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #825

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [x] includes documentation
  - [x] adds unit tests

/hold
