### PR TITLE
Delete watching Status when deleting

### DIFF
--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -197,7 +197,7 @@ func deleteBastion(log logr.Logger, osProviderClient *gophercloud.ProviderClient
 
 	if instance != nil && instance.FloatingIP != "" {
 		if err = networkingService.DisassociateFloatingIP(openStackCluster, instance.FloatingIP); err != nil {
-			return errors.Errorf("failed to delete floating IP: %v", err)
+			return errors.Errorf("failed to disassociate floating IP: %v", err)
 		}
 		if err = networkingService.DeleteFloatingIP(openStackCluster, instance.FloatingIP); err != nil {
 			return errors.Errorf("failed to delete floating IP: %v", err)

--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -204,9 +204,12 @@ func deleteBastion(log logr.Logger, osProviderClient *gophercloud.ProviderClient
 		}
 	}
 
-	if err = computeService.DeleteBastion(openStackCluster, cluster.Name); err != nil {
-		return errors.Errorf("failed to delete bastion: %v", err)
+	if instance != nil && instance.Name != "" {
+		if err = computeService.DeleteInstance(openStackCluster, instance.Name); err != nil {
+			return errors.Errorf("failed to delete bastion: %v", err)
+		}
 	}
+
 	openStackCluster.Status.Bastion = nil
 
 	if err = networkingService.DeleteBastionSecurityGroup(openStackCluster, fmt.Sprintf("%s-%s", cluster.Namespace, cluster.Name)); err != nil {

--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -228,10 +228,11 @@ func (r *OpenStackMachineReconciler) reconcileDelete(ctx context.Context, logger
 		return ctrl.Result{}, nil
 	}
 
-	err = computeService.InstanceDelete(machine, openStackMachine)
-	if err != nil {
-		handleUpdateMachineError(logger, openStackMachine, errors.Errorf("error deleting Openstack instance: %v", err))
-		return ctrl.Result{}, nil
+	if instance.Name != "" {
+		if err = computeService.DeleteInstance(openStackMachine, instance.Name); err != nil {
+			handleUpdateMachineError(logger, openStackMachine, errors.Errorf("error deleting Openstack instance: %v", err))
+			return ctrl.Result{}, nil
+		}
 	}
 
 	if !openStackCluster.Spec.ManagedAPIServerLoadBalancer && util.IsControlPlaneMachine(machine) && openStackCluster.Spec.APIServerFloatingIP == "" && instance.FloatingIP != "" {

--- a/pkg/cloud/services/compute/bastion.go
+++ b/pkg/cloud/services/compute/bastion.go
@@ -19,46 +19,9 @@ package compute
 import (
 	"fmt"
 
-	"sigs.k8s.io/cluster-api/util"
-
 	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha4"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/record"
-	capoerrors "sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/errors"
 )
-
-func (s *Service) DeleteBastion(openStackCluster *infrav1.OpenStackCluster, clusterName string) error {
-	instance, err := s.InstanceExists(fmt.Sprintf("%s-bastion", clusterName))
-	if err != nil {
-		return err
-	}
-
-	if instance == nil || instance.ID == "" {
-		return nil
-	}
-
-	if err = deleteInstance(s, instance.ID); err != nil {
-		record.Warnf(openStackCluster, "FailedDeleteServer", "Failed to delete server %s with id %s: %v", instance.Name, instance.ID, err)
-		return err
-	}
-
-	err = util.PollImmediate(RetryIntervalInstanceStatus, TimeoutInstanceDelete, func() (bool, error) {
-		_, err = s.GetInstance(instance.ID)
-		if err != nil {
-			if capoerrors.IsNotFound(err) {
-				return true, nil
-			}
-			return false, err
-		}
-		return false, nil
-	})
-	if err != nil {
-		record.Warnf(openStackCluster, "FailedDeleteServer", "Failed to delete server %s with id %s: %v", instance.Name, instance.ID, err)
-		return fmt.Errorf("error deleting Openstack instance %s, %v", instance.ID, err)
-	}
-
-	record.Eventf(openStackCluster, "SuccessfulDeleteServer", "Deleted server %s with id %s", instance.Name, instance.ID)
-	return nil
-}
 
 func (s *Service) CreateBastion(openStackCluster *infrav1.OpenStackCluster, clusterName string) (*infrav1.Instance, error) {
 	name := fmt.Sprintf("%s-bastion", clusterName)

--- a/pkg/cloud/services/networking/router.go
+++ b/pkg/cloud/services/networking/router.go
@@ -24,10 +24,11 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
+	"github.com/pkg/errors"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha4"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/record"
-	"sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/errors"
+	capoerrors "sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/errors"
 )
 
 func (s *Service) ReconcileRouter(openStackCluster *infrav1.OpenStackCluster, clusterName string) error {
@@ -44,7 +45,7 @@ func (s *Service) ReconcileRouter(openStackCluster *infrav1.OpenStackCluster, cl
 		return nil
 	}
 
-	routerName := fmt.Sprintf("%s-cluster-%s", networkPrefix, clusterName)
+	routerName := getRouterName(clusterName)
 	s.logger.Info("Reconciling router", "name", routerName)
 
 	allPages, err := routers.List(s.client, routers.ListOpts{
@@ -185,41 +186,41 @@ func setRouterExternalIPs(client *gophercloud.ServiceClient, openStackCluster *i
 	return nil
 }
 
-func (s *Service) DeleteRouter(openStackCluster *infrav1.OpenStackCluster, network *infrav1.Network) error {
-	if network.Router == nil || network.Router.ID == "" {
-		s.logger.V(4).Info("No need to delete router since no router exists.")
-		return nil
-	}
-	exists, err := s.existsRouter(network.Router.ID)
+func (s *Service) DeleteRouter(openStackCluster *infrav1.OpenStackCluster, clusterName string) error {
+	routerName := getRouterName(clusterName)
+	router, err := s.getRouterByName(routerName)
 	if err != nil {
 		return err
 	}
-	if !exists {
-		s.logger.Info("Skipping router deletion because router doesn't exist", "router", network.Router.ID)
-		return nil
-	}
-	if network.Subnet == nil || network.Subnet.ID == "" {
-		s.logger.V(4).Info("Skipping removing router interface since no subnet exists.")
-	} else {
-		_, err = routers.RemoveInterface(s.client, network.Router.ID, routers.RemoveInterfaceOpts{
-			SubnetID: network.Subnet.ID,
-		}).Extract()
-		if err != nil {
-			if errors.IsNotFound(err) {
-				s.logger.V(4).Info("Router Interface already removed, no actions", "id", network.Router.ID)
-				return nil
-			}
-			return fmt.Errorf("unable to remove router interface: %v", err)
-		}
-		s.logger.V(4).Info("Removed RouterInterface of Router", "id", network.Router.ID)
-	}
 
-	if err = routers.Delete(s.client, network.Router.ID).ExtractErr(); err != nil {
-		record.Warnf(openStackCluster, "FailedDeleteRouter", "Failed to delete router %s with id %s: %v", network.Router.Name, network.Router.ID, err)
+	subnetName := getSubnetName(clusterName)
+	subnet, err := s.getSubnetByName(subnetName)
+	if err != nil {
 		return err
 	}
 
-	record.Eventf(openStackCluster, "SuccessfulDeleteRouter", "Deleted router %s with id %s", network.Router.Name, network.Router.ID)
+	if router.ID != "" {
+		if subnet.ID != "" {
+			_, err = routers.RemoveInterface(s.client, router.ID, routers.RemoveInterfaceOpts{
+				SubnetID: subnet.ID,
+			}).Extract()
+			if err != nil {
+				if capoerrors.IsNotFound(err) {
+					s.logger.V(4).Info("Router Interface already removed, no actions", "id", router.ID)
+					return nil
+				}
+				return fmt.Errorf("unable to remove router interface: %v", err)
+			}
+			s.logger.V(4).Info("Removed RouterInterface of Router", "id", router.ID)
+		}
+
+		if err = routers.Delete(s.client, router.ID).ExtractErr(); err != nil {
+			record.Warnf(openStackCluster, "FailedDeleteRouter", "Failed to delete router %s with id %s: %v", router.Name, router.ID, err)
+			return err
+		}
+		record.Eventf(openStackCluster, "SuccessfulDeleteRouter", "Deleted router %s with id %s", router.Name, router.ID)
+
+	}
 	return nil
 }
 
@@ -239,19 +240,56 @@ func (s *Service) getRouterInterfaces(routerID string) ([]ports.Port, error) {
 	return portList, nil
 }
 
-func (s *Service) existsRouter(routerID string) (bool, error) {
-	if routerID == "" {
-		return false, nil
-	}
-	router, err := routers.Get(s.client, routerID).Extract()
+func (s *Service) getRouterByName(routerName string) (routers.Router, error) {
+	allPages, err := routers.List(s.client, routers.ListOpts{
+		Name: routerName,
+	}).AllPages()
 	if err != nil {
-		if errors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, err
+		return routers.Router{}, err
 	}
-	if router == nil {
-		return false, nil
+
+	routerList, err := routers.ExtractRouters(allPages)
+	if err != nil {
+		return routers.Router{}, err
 	}
-	return true, nil
+
+	if len(routerList) > 1 {
+		return routers.Router{}, fmt.Errorf("found %d router with the name %s, which should not happen", len(routerList), routerName)
+	}
+
+	switch len(routerList) {
+	case 0:
+		return routers.Router{}, nil
+	case 1:
+		return routerList[0], nil
+	}
+	return routers.Router{}, errors.New("too many resources")
+}
+
+func (s *Service) getSubnetByName(subnetName string) (subnets.Subnet, error) {
+	opts := subnets.ListOpts{
+		Name: subnetName,
+	}
+
+	allPages, err := subnets.List(s.client, opts).AllPages()
+	if err != nil {
+		return subnets.Subnet{}, err
+	}
+
+	subnetList, err := subnets.ExtractSubnets(allPages)
+	if err != nil {
+		return subnets.Subnet{}, err
+	}
+
+	switch len(subnetList) {
+	case 0:
+		return subnets.Subnet{}, nil
+	case 1:
+		return subnetList[0], nil
+	}
+	return subnets.Subnet{}, errors.New("too many resources")
+}
+
+func getRouterName(clusterName string) string {
+	return fmt.Sprintf("%s-cluster-%s", networkPrefix, clusterName)
 }

--- a/pkg/cloud/services/networking/router.go
+++ b/pkg/cloud/services/networking/router.go
@@ -207,7 +207,7 @@ func (s *Service) DeleteRouter(openStackCluster *infrav1.OpenStackCluster, clust
 			if err != nil {
 				if capoerrors.IsNotFound(err) {
 					s.logger.V(4).Info("Router Interface already removed, no actions", "id", router.ID)
-					return nil
+					// nothing to do
 				}
 				return fmt.Errorf("unable to remove router interface: %v", err)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes deleting cluster and machines.
- We can not delete OpenStack network resources just after resources are created.
- We can not delete machine before assigning provider ID.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #841 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
