### PR TITLE
bump tests to Kubernetes 1.20.6

### DIFF
--- a/docs/book/src/clusteropenstack/configuration.md
+++ b/docs/book/src/clusteropenstack/configuration.md
@@ -40,7 +40,7 @@ Note: You can use [the template file](../templates/cluster-template.yaml) by man
 # Using 'external-cloud-provider' flavor
 clusterctl config cluster capi-quickstart \
   --flavor external-cloud-provider \
-  --kubernetes-version v1.20.4 \
+  --kubernetes-version v1.20.6 \
   --control-plane-machine-count=3 \
   --worker-machine-count=1 \
   > capi-quickstart.yaml
@@ -48,7 +48,7 @@ clusterctl config cluster capi-quickstart \
 # Using 'without-lb' flavor
 clusterctl config cluster capi-quickstart \
   --flavor without-lb \
-  --kubernetes-version v1.20.4 \
+  --kubernetes-version v1.20.6 \
   --control-plane-machine-count=1 \
   --worker-machine-count=1 \
   > capi-quickstart.yaml

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -93,7 +93,7 @@ providers:
 variables:
   # used to ensure we deploy to the correct management cluster
   KUBE_CONTEXT: "kind-capo-e2e"
-  KUBERNETES_VERSION: "v1.20.4"
+  KUBERNETES_VERSION: "v1.20.6"
   CNI: "../../data/cni/calico.yaml"
   CCM: "../../data/ccm/cloud-controller-manager.yaml"
   EXP_CLUSTER_RESOURCE_SET: "true"


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Bump e2e tests to latest k/k release. There are some reports which suggest there might be an issue with kubeadm join.

xref:
* https://github.com/kubernetes/kubeadm/issues/2450
* https://kubernetes.slack.com/archives/C8TSNPY4T/p1618848917097800

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [] includes documentation
  - [] adds unit tests

/hold
