### PR TITLE
✨ api/v1alpha4 remove obsolete UserDataSecret field

### DIFF
--- a/api/v1alpha3/zz_generated.conversion.go
+++ b/api/v1alpha3/zz_generated.conversion.go
@@ -814,7 +814,6 @@ func autoConvert_v1alpha3_OpenStackMachineSpec_To_v1alpha4_OpenStackMachineSpec(
 	out.Subnet = in.Subnet
 	out.FloatingIP = in.FloatingIP
 	out.SecurityGroups = *(*[]v1alpha4.SecurityGroupParam)(unsafe.Pointer(&in.SecurityGroups))
-	out.UserDataSecret = (*v1.SecretReference)(unsafe.Pointer(in.UserDataSecret))
 	out.Trunk = in.Trunk
 	out.Tags = *(*[]string)(unsafe.Pointer(&in.Tags))
 	out.ServerMetadata = *(*map[string]string)(unsafe.Pointer(&in.ServerMetadata))
@@ -841,7 +840,6 @@ func autoConvert_v1alpha4_OpenStackMachineSpec_To_v1alpha3_OpenStackMachineSpec(
 	out.Subnet = in.Subnet
 	out.FloatingIP = in.FloatingIP
 	out.SecurityGroups = *(*[]SecurityGroupParam)(unsafe.Pointer(&in.SecurityGroups))
-	out.UserDataSecret = (*v1.SecretReference)(unsafe.Pointer(in.UserDataSecret))
 	out.Trunk = in.Trunk
 	out.Tags = *(*[]string)(unsafe.Pointer(&in.Tags))
 	out.ServerMetadata = *(*map[string]string)(unsafe.Pointer(&in.ServerMetadata))

--- a/api/v1alpha4/openstackmachine_types.go
+++ b/api/v1alpha4/openstackmachine_types.go
@@ -68,9 +68,6 @@ type OpenStackMachineSpec struct {
 	// The names of the security groups to assign to the instance
 	SecurityGroups []SecurityGroupParam `json:"securityGroups,omitempty"`
 
-	// The name of the secret containing the user data (startup script in most cases)
-	UserDataSecret *corev1.SecretReference `json:"userDataSecret,omitempty"`
-
 	// Whether the server instance is created on a trunk port or not.
 	Trunk bool `json:"trunk,omitempty"`
 

--- a/api/v1alpha4/zz_generated.deepcopy.go
+++ b/api/v1alpha4/zz_generated.deepcopy.go
@@ -469,11 +469,6 @@ func (in *OpenStackMachineSpec) DeepCopyInto(out *OpenStackMachineSpec) {
 		*out = make([]SecurityGroupParam, len(*in))
 		copy(*out, *in)
 	}
-	if in.UserDataSecret != nil {
-		in, out := &in.UserDataSecret, &out.UserDataSecret
-		*out = new(v1.SecretReference)
-		**out = **in
-	}
 	if in.Tags != nil {
 		in, out := &in.Tags, &out.Tags
 		*out = make([]string, len(*in))

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -1326,19 +1326,6 @@ spec:
                         description: Whether the server instance is created on a trunk
                           port or not.
                         type: boolean
-                      userDataSecret:
-                        description: The name of the secret containing the user data
-                          (startup script in most cases)
-                        properties:
-                          name:
-                            description: Name is unique within a namespace to reference
-                              a secret resource.
-                            type: string
-                          namespace:
-                            description: Namespace defines the space within which
-                              the secret name must be unique.
-                            type: string
-                        type: object
                     required:
                     - flavor
                     type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
@@ -619,19 +619,6 @@ spec:
                 description: Whether the server instance is created on a trunk port
                   or not.
                 type: boolean
-              userDataSecret:
-                description: The name of the secret containing the user data (startup
-                  script in most cases)
-                properties:
-                  name:
-                    description: Name is unique within a namespace to reference a
-                      secret resource.
-                    type: string
-                  namespace:
-                    description: Namespace defines the space within which the secret
-                      name must be unique.
-                    type: string
-                type: object
             required:
             - flavor
             type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
@@ -565,19 +565,6 @@ spec:
                         description: Whether the server instance is created on a trunk
                           port or not.
                         type: boolean
-                      userDataSecret:
-                        description: The name of the secret containing the user data
-                          (startup script in most cases)
-                        properties:
-                          name:
-                            description: Name is unique within a namespace to reference
-                              a secret resource.
-                            type: string
-                          namespace:
-                            description: Namespace defines the space within which
-                              the secret name must be unique.
-                            type: string
-                        type: object
                     required:
                     - flavor
                     type: object


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the unused field `UserDataSecret` in `v1alpha4`.
It was used in an earlier CAPI version (v1alpha1 or v1alpha2) to reference a secret which contains the user data, but is not anymore.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #857

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
