### PR TITLE
🏃 Refactor: use Service struct field more

### DIFF
--- a/pkg/cloud/services/compute/bastion.go
+++ b/pkg/cloud/services/compute/bastion.go
@@ -33,7 +33,7 @@ func (s *Service) CreateBastion(openStackCluster *infrav1.OpenStackCluster, clus
 		RootVolume:    openStackCluster.Spec.Bastion.Instance.RootVolume,
 	}
 
-	securityGroups, err := getSecurityGroups(s, openStackCluster.Spec.Bastion.Instance.SecurityGroups)
+	securityGroups, err := s.getSecurityGroups(openStackCluster.Spec.Bastion.Instance.SecurityGroups)
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func (s *Service) CreateBastion(openStackCluster *infrav1.OpenStackCluster, clus
 	var nets []infrav1.Network
 	if len(openStackCluster.Spec.Bastion.Instance.Networks) > 0 {
 		var err error
-		nets, err = getServerNetworks(s.networkClient, openStackCluster.Spec.Bastion.Instance.Networks)
+		nets, err = s.getServerNetworks(openStackCluster.Spec.Bastion.Instance.Networks)
 		if err != nil {
 			return nil, err
 		}
@@ -59,7 +59,7 @@ func (s *Service) CreateBastion(openStackCluster *infrav1.OpenStackCluster, clus
 	}
 	input.Networks = &nets
 
-	out, err := createInstance(s, openStackCluster, clusterName, input)
+	out, err := s.createInstance(openStackCluster, clusterName, input)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloud/services/compute/service.go
+++ b/pkg/cloud/services/compute/service.go
@@ -24,17 +24,19 @@ import (
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/utils/openstack/clientconfig"
 
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/networking"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/provider"
 )
 
 type Service struct {
-	provider       *gophercloud.ProviderClient
-	projectID      string
-	computeClient  *gophercloud.ServiceClient
-	identityClient *gophercloud.ServiceClient
-	networkClient  *gophercloud.ServiceClient
-	imagesClient   *gophercloud.ServiceClient
-	logger         logr.Logger
+	provider          *gophercloud.ProviderClient
+	projectID         string
+	computeClient     *gophercloud.ServiceClient
+	identityClient    *gophercloud.ServiceClient
+	networkClient     *gophercloud.ServiceClient
+	imagesClient      *gophercloud.ServiceClient
+	networkingService *networking.Service
+	logger            logr.Logger
 }
 
 // NewService returns an instance of the compute service.
@@ -82,13 +84,19 @@ func NewService(client *gophercloud.ProviderClient, clientOpts *clientconfig.Cli
 		return nil, fmt.Errorf("failed to get project id")
 	}
 
+	networkingService, err := networking.NewService(client, clientOpts, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create networking service: %v", err)
+	}
+
 	return &Service{
-		provider:       client,
-		projectID:      projectID,
-		identityClient: identityClient,
-		computeClient:  computeClient,
-		networkClient:  networkingClient,
-		imagesClient:   imagesClient,
-		logger:         logger,
+		provider:          client,
+		projectID:         projectID,
+		identityClient:    identityClient,
+		computeClient:     computeClient,
+		networkClient:     networkingClient,
+		networkingService: networkingService,
+		imagesClient:      imagesClient,
+		logger:            logger,
 	}, nil
 }

--- a/pkg/cloud/services/networking/floatingip.go
+++ b/pkg/cloud/services/networking/floatingip.go
@@ -19,7 +19,6 @@ package networking
 import (
 	"time"
 
-	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -33,7 +32,7 @@ func (s *Service) GetOrCreateFloatingIP(openStackCluster *infrav1.OpenStackClust
 	var fpCreateOpts floatingips.CreateOpts
 
 	if ip != "" {
-		fp, err = checkIfFloatingIPExists(s.client, ip)
+		fp, err = s.checkIfFloatingIPExists(ip)
 		if err != nil {
 			return nil, err
 		}
@@ -56,8 +55,8 @@ func (s *Service) GetOrCreateFloatingIP(openStackCluster *infrav1.OpenStackClust
 	return fp, nil
 }
 
-func checkIfFloatingIPExists(client *gophercloud.ServiceClient, ip string) (*floatingips.FloatingIP, error) {
-	allPages, err := floatingips.List(client, floatingips.ListOpts{FloatingIP: ip}).AllPages()
+func (s *Service) checkIfFloatingIPExists(ip string) (*floatingips.FloatingIP, error) {
+	allPages, err := floatingips.List(s.client, floatingips.ListOpts{FloatingIP: ip}).AllPages()
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +86,7 @@ func (s *Service) GetFloatingIPByPortID(portID string) (*floatingips.FloatingIP,
 }
 
 func (s *Service) DeleteFloatingIP(openStackCluster *infrav1.OpenStackCluster, ip string) error {
-	fip, err := checkIfFloatingIPExists(s.client, ip)
+	fip, err := s.checkIfFloatingIPExists(ip)
 	if err != nil {
 		return err
 	}
@@ -136,7 +135,7 @@ func (s *Service) AssociateFloatingIP(openStackCluster *infrav1.OpenStackCluster
 }
 
 func (s *Service) DisassociateFloatingIP(openStackCluster *infrav1.OpenStackCluster, ip string) error {
-	fip, err := checkIfFloatingIPExists(s.client, ip)
+	fip, err := s.checkIfFloatingIPExists(ip)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR refactored to use gophercloud clients and logger in Service struct instead of function argument.
We can easily log something using `s.logger` without adding logger to function argument.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
