### PR TITLE
🏃 Validate OpenStackMachineTemplate spec.template.spec immutability

### DIFF
--- a/api/v1alpha4/openstackmachinetemplate_webhook_test.go
+++ b/api/v1alpha4/openstackmachinetemplate_webhook_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha4
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestOpenStackMachineTemplate_ValidateUpdate(t *testing.T) {
+	g := NewWithT(t)
+
+	tests := []struct {
+		name        string
+		oldTemplate *OpenStackMachineTemplate
+		newTemplate *OpenStackMachineTemplate
+		wantErr     bool
+	}{
+		{
+			name: "OpenStackMachineTemplate with immutable spec",
+			oldTemplate: &OpenStackMachineTemplate{
+				Spec: OpenStackMachineTemplateSpec{
+					Template: OpenStackMachineTemplateResource{
+						Spec: OpenStackMachineSpec{
+							Flavor: "foo",
+							Image:  "bar",
+						},
+					},
+				},
+			},
+			newTemplate: &OpenStackMachineTemplate{
+				Spec: OpenStackMachineTemplateSpec{
+					Template: OpenStackMachineTemplateResource{
+						Spec: OpenStackMachineSpec{
+							Flavor: "foo",
+							Image:  "NewImage",
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "OpenStackMachineTemplate with mutable metadata",
+			oldTemplate: &OpenStackMachineTemplate{
+				Spec: OpenStackMachineTemplateSpec{
+					Template: OpenStackMachineTemplateResource{
+						Spec: OpenStackMachineSpec{
+							Flavor: "foo",
+							Image:  "bar",
+						},
+					},
+				},
+				ObjectMeta: v1.ObjectMeta{
+					Name: "foo",
+				},
+			},
+			newTemplate: &OpenStackMachineTemplate{
+				Spec: OpenStackMachineTemplateSpec{
+					Template: OpenStackMachineTemplateResource{
+						Spec: OpenStackMachineSpec{
+							Flavor: "foo",
+							Image:  "bar",
+						},
+					},
+				},
+				ObjectMeta: v1.ObjectMeta{
+					Name: "bar",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.newTemplate.ValidateUpdate(tt.oldTemplate)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Johannes Frey <johannes.frey@daimler.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

This PR blocks changes to `OpenStackMachineTemplate.Spec.Template.Spec` and provides a message that a new resource should be created if the user does try to mutate it.

Credits where credit's due. This is mainly copy-pasted from https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1275 :slightly_smiling_face:.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #858

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- if necessary:
  - [ ] includes documentation
  - [X] adds unit tests

/hold

<sub>Johannes Frey [johannes.frey@daimler.com](mailto:johannes.frey@daimler.com) Daimler TSS GmbH ([Imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md))</sub>