### PR TITLE
🏃 Refactor: move getSubnetByName method

### DIFF
--- a/pkg/cloud/services/networking/network.go
+++ b/pkg/cloud/services/networking/network.go
@@ -334,6 +334,30 @@ func (s *Service) GetNetworkIDsByFilter(opts networks.ListOptsBuilder) ([]string
 	return ids, nil
 }
 
+func (s *Service) getSubnetByName(subnetName string) (subnets.Subnet, error) {
+	opts := subnets.ListOpts{
+		Name: subnetName,
+	}
+
+	allPages, err := subnets.List(s.client, opts).AllPages()
+	if err != nil {
+		return subnets.Subnet{}, err
+	}
+
+	subnetList, err := subnets.ExtractSubnets(allPages)
+	if err != nil {
+		return subnets.Subnet{}, err
+	}
+
+	switch len(subnetList) {
+	case 0:
+		return subnets.Subnet{}, nil
+	case 1:
+		return subnetList[0], nil
+	}
+	return subnets.Subnet{}, fmt.Errorf("found %d subnets with the name %s, which should not happen", len(subnetList), subnetName)
+}
+
 // A function for getting the id of a subnet by querying openstack with filters.
 func (s *Service) GetSubnetsByFilter(opts subnets.ListOptsBuilder) ([]subnets.Subnet, error) {
 	if opts == nil {

--- a/pkg/cloud/services/networking/router.go
+++ b/pkg/cloud/services/networking/router.go
@@ -284,30 +284,6 @@ func (s *Service) getRouterByName(routerName string) (routers.Router, error) {
 	return routers.Router{}, fmt.Errorf("found %d router with the name %s, which should not happen", len(routerList), routerName)
 }
 
-func (s *Service) getSubnetByName(subnetName string) (subnets.Subnet, error) {
-	opts := subnets.ListOpts{
-		Name: subnetName,
-	}
-
-	allPages, err := subnets.List(s.client, opts).AllPages()
-	if err != nil {
-		return subnets.Subnet{}, err
-	}
-
-	subnetList, err := subnets.ExtractSubnets(allPages)
-	if err != nil {
-		return subnets.Subnet{}, err
-	}
-
-	switch len(subnetList) {
-	case 0:
-		return subnets.Subnet{}, nil
-	case 1:
-		return subnetList[0], nil
-	}
-	return subnets.Subnet{}, fmt.Errorf("found %d subnets with the name %s, which should not happen", len(subnetList), subnetName)
-}
-
 func getRouterName(clusterName string) string {
 	return fmt.Sprintf("%s-cluster-%s", networkPrefix, clusterName)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Move getSubnetByName method from router.go to network.go

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
