### PR TITLE
🏃 Refactor: do not use networkclient in compute package

### DIFF
--- a/pkg/cloud/services/compute/bastion.go
+++ b/pkg/cloud/services/compute/bastion.go
@@ -33,7 +33,7 @@ func (s *Service) CreateBastion(openStackCluster *infrav1.OpenStackCluster, clus
 		RootVolume:    openStackCluster.Spec.Bastion.Instance.RootVolume,
 	}
 
-	securityGroups, err := s.getSecurityGroups(openStackCluster.Spec.Bastion.Instance.SecurityGroups)
+	securityGroups, err := s.networkingService.GetSecurityGroups(openStackCluster.Spec.Bastion.Instance.SecurityGroups)
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func (s *Service) CreateBastion(openStackCluster *infrav1.OpenStackCluster, clus
 	var nets []infrav1.Network
 	if len(openStackCluster.Spec.Bastion.Instance.Networks) > 0 {
 		var err error
-		nets, err = s.getServerNetworks(openStackCluster.Spec.Bastion.Instance.Networks)
+		nets, err = s.networkingService.GetNetworks(openStackCluster.Spec.Bastion.Instance.Networks)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -24,7 +24,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/gophercloud/gophercloud/openstack/common/extensions"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/floatingips"
@@ -32,14 +31,6 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/schedulerhints"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
-	netext "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsbinding"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/trunks"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 	"github.com/gophercloud/utils/openstack/compute/v2/flavors"
 	"k8s.io/apimachinery/pkg/runtime"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
@@ -49,18 +40,11 @@ import (
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/metrics"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/record"
 	capoerrors "sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/errors"
-	"sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/names"
 )
 
 const (
 	TimeoutInstanceCreate       = 5
 	RetryIntervalInstanceStatus = 10 * time.Second
-
-	TimeoutTrunkDelete       = 3 * time.Minute
-	RetryIntervalTrunkDelete = 5 * time.Second
-
-	TimeoutPortDelete       = 3 * time.Minute
-	RetryIntervalPortDelete = 5 * time.Second
 
 	TimeoutInstanceDelete = 5 * time.Minute
 )
@@ -89,7 +73,7 @@ func (s *Service) CreateInstance(openStackCluster *infrav1.OpenStackCluster, mac
 	}
 
 	if openStackMachine.Spec.Trunk {
-		trunkSupport, err := s.getTrunkSupport()
+		trunkSupport, err := s.networkingService.GetTrunkSupport()
 		if err != nil {
 			return nil, fmt.Errorf("there was an issue verifying whether trunk support is available, please disable it: %v", err)
 		}
@@ -113,7 +97,7 @@ func (s *Service) CreateInstance(openStackCluster *infrav1.OpenStackCluster, mac
 	input.Tags = machineTags
 
 	// Get security groups
-	securityGroups, err := s.getSecurityGroups(openStackMachine.Spec.SecurityGroups)
+	securityGroups, err := s.networkingService.GetSecurityGroups(openStackMachine.Spec.SecurityGroups)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +110,7 @@ func (s *Service) CreateInstance(openStackCluster *infrav1.OpenStackCluster, mac
 	}
 	input.SecurityGroups = &securityGroups
 
-	nets, err := s.constructNetworks(openStackCluster, openStackMachine)
+	nets, err := s.networkingService.ConstructNetworks(openStackCluster, openStackMachine)
 	if err != nil {
 		return nil, err
 	}
@@ -139,46 +123,6 @@ func (s *Service) CreateInstance(openStackCluster *infrav1.OpenStackCluster, mac
 	return out, nil
 }
 
-// constructNetworks builds an array of networks from the network, subnet and ports items in the machine spec.
-// If no networks or ports are in the spec, returns a single network item for a network connection to the default cluster network.
-func (s *Service) constructNetworks(openStackCluster *infrav1.OpenStackCluster, openStackMachine *infrav1.OpenStackMachine) (*[]infrav1.Network, error) {
-	var nets []infrav1.Network
-	if len(openStackMachine.Spec.Networks) > 0 {
-		var err error
-		nets, err = s.getServerNetworks(openStackMachine.Spec.Networks)
-		if err != nil {
-			return nil, err
-		}
-	}
-	for i, port := range openStackMachine.Spec.Ports {
-		if port.NetworkID != "" {
-			nets = append(nets, infrav1.Network{
-				ID:       port.NetworkID,
-				Subnet:   &infrav1.Subnet{},
-				PortOpts: &openStackMachine.Spec.Ports[i],
-			})
-		} else {
-			nets = append(nets, infrav1.Network{
-				ID: openStackCluster.Status.Network.ID,
-				Subnet: &infrav1.Subnet{
-					ID: openStackCluster.Status.Network.Subnet.ID,
-				},
-				PortOpts: &openStackMachine.Spec.Ports[i],
-			})
-		}
-	}
-	// no networks or ports found in the spec, so create a port on the cluster network
-	if len(nets) == 0 {
-		nets = []infrav1.Network{{
-			ID: openStackCluster.Status.Network.ID,
-			Subnet: &infrav1.Subnet{
-				ID: openStackCluster.Status.Network.Subnet.ID,
-			},
-		}}
-	}
-	return &nets, nil
-}
-
 func (s *Service) createInstance(eventObject runtime.Object, clusterName string, instance *infrav1.Instance) (*infrav1.Instance, error) {
 	accessIPv4 := ""
 	portList := []servers.Network{}
@@ -189,18 +133,18 @@ func (s *Service) createInstance(eventObject runtime.Object, clusterName string,
 		}
 
 		portName := getPortName(instance.Name, network.PortOpts, i)
-		port, err := s.getOrCreatePort(eventObject, clusterName, portName, network, instance.SecurityGroups)
+		port, err := s.networkingService.GetOrCreatePort(eventObject, clusterName, portName, network, instance.SecurityGroups)
 		if err != nil {
 			return nil, err
 		}
 
 		if instance.Trunk {
-			trunk, err := s.getOrCreateTrunk(eventObject, clusterName, instance.Name, port.ID)
+			trunk, err := s.networkingService.GetOrCreateTrunk(eventObject, clusterName, instance.Name, port.ID)
 			if err != nil {
 				return nil, err
 			}
 
-			if err = s.replaceAllAttributesTags(eventObject, trunk.ID, instance.Tags); err != nil {
+			if err = s.networkingService.ReplaceAllAttributesTags(eventObject, trunk.ID, instance.Tags); err != nil {
 				return nil, err
 			}
 		}
@@ -217,7 +161,7 @@ func (s *Service) createInstance(eventObject runtime.Object, clusterName string,
 	}
 
 	if instance.Subnet != "" && accessIPv4 == "" {
-		if err := s.deletePorts(eventObject, portList); err != nil {
+		if err := s.networkingService.DeletePorts(eventObject, portList); err != nil {
 			return nil, err
 		}
 		return nil, fmt.Errorf("no ports with fixed IPs found on Subnet %q", instance.Subnet)
@@ -260,11 +204,12 @@ func (s *Service) createInstance(eventObject runtime.Object, clusterName string,
 
 	if mc.ObserveRequest(err) != nil {
 		serverErr := err
-		if err = s.deletePorts(eventObject, portList); err != nil {
+		if err = s.networkingService.DeletePorts(eventObject, portList); err != nil {
 			return nil, fmt.Errorf("error creating OpenStack instance: %v, error deleting ports: %v", serverErr, err)
 		}
 		return nil, fmt.Errorf("error creating Openstack instance: %v", serverErr)
 	}
+
 	instanceCreateTimeout := getTimeout("CLUSTER_API_OPENSTACK_INSTANCE_CREATE_TIMEOUT", TimeoutInstanceCreate)
 	instanceCreateTimeout *= time.Minute
 	var createdInstance *infrav1.Instance
@@ -327,233 +272,6 @@ func applyServerGroupID(opts servers.CreateOptsBuilder, serverGroupID string) se
 		}
 	}
 	return opts
-}
-
-func (s *Service) getTrunkSupport() (bool, error) {
-	allPages, err := netext.List(s.networkClient).AllPages()
-	if err != nil {
-		return false, err
-	}
-
-	allExts, err := extensions.ExtractExtensions(allPages)
-	if err != nil {
-		return false, err
-	}
-
-	for _, ext := range allExts {
-		if ext.Alias == "trunk" {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
-func (s *Service) getSecurityGroups(securityGroupParams []infrav1.SecurityGroupParam) ([]string, error) {
-	var sgIDs []string
-	for _, sg := range securityGroupParams {
-		listOpts := groups.ListOpts(sg.Filter)
-		if listOpts.ProjectID == "" {
-			listOpts.ProjectID = s.projectID
-		}
-		listOpts.Name = sg.Name
-		listOpts.ID = sg.UUID
-		pages, err := groups.List(s.networkClient, listOpts).AllPages()
-		if err != nil {
-			return nil, err
-		}
-
-		SGList, err := groups.ExtractGroups(pages)
-		if err != nil {
-			return nil, err
-		}
-
-		if len(SGList) == 0 {
-			return nil, fmt.Errorf("security group %s not found", sg.Name)
-		}
-
-		for _, group := range SGList {
-			if isDuplicate(sgIDs, group.ID) {
-				continue
-			}
-			sgIDs = append(sgIDs, group.ID)
-		}
-	}
-	return sgIDs, nil
-}
-
-func (s *Service) getServerNetworks(networkParams []infrav1.NetworkParam) ([]infrav1.Network, error) {
-	var nets []infrav1.Network
-	for _, networkParam := range networkParams {
-		opts := networks.ListOpts(networkParam.Filter)
-		opts.ID = networkParam.UUID
-		ids, err := s.networkingService.GetNetworkIDsByFilter(&opts)
-		if err != nil {
-			return nil, err
-		}
-		for _, netID := range ids {
-			if networkParam.Subnets == nil {
-				nets = append(nets, infrav1.Network{
-					ID:     netID,
-					Subnet: &infrav1.Subnet{},
-				})
-				continue
-			}
-
-			for _, subnet := range networkParam.Subnets {
-				subnetOpts := subnets.ListOpts(subnet.Filter)
-				subnetOpts.ID = subnet.UUID
-				subnetOpts.NetworkID = netID
-				subnetsByFilter, err := s.networkingService.GetSubnetsByFilter(&subnetOpts)
-				if err != nil {
-					return nil, err
-				}
-				for _, subnetByFilter := range subnetsByFilter {
-					nets = append(nets, infrav1.Network{
-						ID: subnetByFilter.NetworkID,
-						Subnet: &infrav1.Subnet{
-							ID: subnetByFilter.ID,
-						},
-					})
-				}
-			}
-		}
-	}
-	return nets, nil
-}
-
-func (s *Service) getOrCreatePort(eventObject runtime.Object, clusterName string, portName string, net infrav1.Network, instanceSecurityGroups *[]string) (*ports.Port, error) {
-	allPages, err := ports.List(s.networkClient, ports.ListOpts{
-		Name:      portName,
-		NetworkID: net.ID,
-	}).AllPages()
-	if err != nil {
-		return nil, fmt.Errorf("searching for existing port for server: %v", err)
-	}
-	existingPorts, err := ports.ExtractPorts(allPages)
-	if err != nil {
-		return nil, fmt.Errorf("searching for existing port for server: %v", err)
-	}
-
-	if len(existingPorts) == 1 {
-		return &existingPorts[0], nil
-	}
-
-	if len(existingPorts) > 1 {
-		return nil, fmt.Errorf("multiple ports found with name \"%s\"", portName)
-	}
-
-	// no port found, so create the port
-	portOpts := net.PortOpts
-	if portOpts == nil {
-		portOpts = &infrav1.PortOpts{}
-	}
-
-	description := portOpts.Description
-	if description == "" {
-		description = names.GetDescription(clusterName)
-	}
-
-	// inherit port security groups from the instance if not explicitly specified
-	securityGroups := portOpts.SecurityGroups
-	if securityGroups == nil {
-		securityGroups = instanceSecurityGroups
-	}
-
-	createOpts := ports.CreateOpts{
-		Name:                portName,
-		NetworkID:           net.ID,
-		Description:         description,
-		AdminStateUp:        portOpts.AdminStateUp,
-		MACAddress:          portOpts.MACAddress,
-		TenantID:            portOpts.TenantID,
-		ProjectID:           portOpts.ProjectID,
-		SecurityGroups:      securityGroups,
-		AllowedAddressPairs: []ports.AddressPair{},
-	}
-
-	for _, ap := range portOpts.AllowedAddressPairs {
-		createOpts.AllowedAddressPairs = append(createOpts.AllowedAddressPairs, ports.AddressPair{
-			IPAddress:  ap.IPAddress,
-			MACAddress: ap.MACAddress,
-		})
-	}
-
-	fixedIPs := make([]ports.IP, 0, len(portOpts.FixedIPs)+1)
-	for _, fixedIP := range portOpts.FixedIPs {
-		fixedIPs = append(fixedIPs, ports.IP{
-			SubnetID:  fixedIP.SubnetID,
-			IPAddress: fixedIP.IPAddress,
-		})
-	}
-	if net.Subnet.ID != "" {
-		fixedIPs = append(fixedIPs, ports.IP{SubnetID: net.Subnet.ID})
-	}
-	if len(fixedIPs) > 0 {
-		createOpts.FixedIPs = fixedIPs
-	}
-	mc := metrics.NewMetricPrometheusContext("port", "create")
-
-	port, err := ports.Create(s.networkClient, portsbinding.CreateOptsExt{
-		CreateOptsBuilder: createOpts,
-		HostID:            portOpts.HostID,
-		VNICType:          portOpts.VNICType,
-		Profile:           nil,
-	}).Extract()
-	if mc.ObserveRequest(err) != nil {
-		record.Warnf(eventObject, "FailedCreatePort", "Failed to create port %s: %v", portName, err)
-		return nil, err
-	}
-
-	record.Eventf(eventObject, "SuccessfulCreatePort", "Created port %s with id %s", port.Name, port.ID)
-	return port, nil
-}
-
-func (s *Service) getOrCreateTrunk(eventObject runtime.Object, clusterName, trunkName, portID string) (*trunks.Trunk, error) {
-	allPages, err := trunks.List(s.networkClient, trunks.ListOpts{
-		Name:   trunkName,
-		PortID: portID,
-	}).AllPages()
-	if err != nil {
-		return nil, fmt.Errorf("searching for existing trunk for server: %v", err)
-	}
-	trunkList, err := trunks.ExtractTrunks(allPages)
-	if err != nil {
-		return nil, fmt.Errorf("searching for existing trunk for server: %v", err)
-	}
-
-	if len(trunkList) != 0 {
-		return &trunkList[0], nil
-	}
-
-	trunkCreateOpts := trunks.CreateOpts{
-		Name:        trunkName,
-		PortID:      portID,
-		Description: names.GetDescription(clusterName),
-	}
-	mc := metrics.NewMetricPrometheusContext("trunk", "create")
-
-	trunk, err := trunks.Create(s.networkClient, trunkCreateOpts).Extract()
-	if mc.ObserveRequest(err) != nil {
-		record.Warnf(eventObject, "FailedCreateTrunk", "Failed to create trunk %s: %v", trunkName, err)
-		return nil, err
-	}
-
-	record.Eventf(eventObject, "SuccessfulCreateTrunk", "Created trunk %s with id %s", trunk.Name, trunk.ID)
-	return trunk, nil
-}
-
-func (s *Service) replaceAllAttributesTags(eventObject runtime.Object, trunkID string, tags []string) error {
-	mc := metrics.NewMetricPrometheusContext("trunk", "update")
-	_, err := attributestags.ReplaceAll(s.networkClient, "trunks", trunkID, attributestags.ReplaceAllOpts{
-		Tags: tags,
-	}).Extract()
-	if mc.ObserveRequest(err) != nil {
-		record.Warnf(eventObject, "FailedReplaceAllAttributesTags", "Failed to replace all attributestags, trunk %s: %v", trunkID, err)
-		return err
-	}
-
-	record.Eventf(eventObject, "SuccessfulReplaceAllAttributeTags", "Replaced all attributestags %s with tags %s", trunkID, tags)
-	return nil
 }
 
 // Helper function for getting image ID from name.
@@ -620,7 +338,7 @@ func (s *Service) DeleteInstance(eventObject runtime.Object, instanceName string
 		return s.deleteInstance(eventObject, instance.ID)
 	}
 
-	trunkSupport, err := s.getTrunkSupport()
+	trunkSupport, err := s.networkingService.GetTrunkSupport()
 	if err != nil {
 		return fmt.Errorf("obtaining network extensions: %v", err)
 	}
@@ -631,55 +349,17 @@ func (s *Service) DeleteInstance(eventObject runtime.Object, instanceName string
 		}
 
 		if trunkSupport {
-			if err = s.deleteTrunk(eventObject, port.PortID); err != nil {
+			if err = s.networkingService.DeleteTrunk(eventObject, port.PortID); err != nil {
 				return err
 			}
 		}
 
-		if err = s.deletePort(eventObject, port.PortID); err != nil {
+		if err = s.networkingService.DeletePort(eventObject, port.PortID); err != nil {
 			return err
 		}
 	}
 
 	return s.deleteInstance(eventObject, instance.ID)
-}
-
-func (s *Service) deletePort(eventObject runtime.Object, portID string) error {
-	port, err := s.getPort(portID)
-	if err != nil {
-		return err
-	}
-	if port == nil {
-		return nil
-	}
-
-	err = util.PollImmediate(RetryIntervalPortDelete, TimeoutPortDelete, func() (bool, error) {
-		mc := metrics.NewMetricPrometheusContext("port", "delete")
-		err := ports.Delete(s.networkClient, port.ID).ExtractErr()
-		if mc.ObserveRequest(err) != nil {
-			if capoerrors.IsRetryable(err) {
-				return false, nil
-			}
-			return false, err
-		}
-		return true, nil
-	})
-	if err != nil {
-		record.Warnf(eventObject, "FailedDeletePort", "Failed to delete port %s with id %s: %v", port.Name, port.ID, err)
-		return err
-	}
-
-	record.Eventf(eventObject, "SuccessfulDeletePort", "Deleted port %s with id %s", port.Name, port.ID)
-	return nil
-}
-
-func (s *Service) deletePorts(eventObject runtime.Object, nets []servers.Network) error {
-	for _, n := range nets {
-		if err := s.deletePort(eventObject, n.Port); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (s *Service) deleteAttachInterface(eventObject runtime.Object, instanceID, portID string) error {
@@ -691,7 +371,7 @@ func (s *Service) deleteAttachInterface(eventObject runtime.Object, instanceID, 
 		return nil
 	}
 
-	port, err := s.getPort(portID)
+	port, err := s.networkingService.GetPort(portID)
 	if err != nil {
 		return err
 	}
@@ -711,62 +391,6 @@ func (s *Service) deleteAttachInterface(eventObject runtime.Object, instanceID, 
 
 	record.Eventf(eventObject, "SuccessfulDeleteAttachInterface", "Deleted attach interface: instance %s, port %s", instance.ID, port.ID)
 	return nil
-}
-
-func (s *Service) deleteTrunk(eventObject runtime.Object, portID string) error {
-	port, err := s.getPort(portID)
-	if err != nil {
-		return err
-	}
-	if port == nil {
-		return nil
-	}
-
-	listOpts := trunks.ListOpts{
-		PortID: port.ID,
-	}
-	trunkList, err := trunks.List(s.networkClient, listOpts).AllPages()
-	if err != nil {
-		return err
-	}
-	trunkInfo, err := trunks.ExtractTrunks(trunkList)
-	if err != nil {
-		return err
-	}
-	if len(trunkInfo) != 1 {
-		return nil
-	}
-
-	err = util.PollImmediate(RetryIntervalTrunkDelete, TimeoutTrunkDelete, func() (bool, error) {
-		if err := trunks.Delete(s.networkClient, trunkInfo[0].ID).ExtractErr(); err != nil {
-			if capoerrors.IsRetryable(err) {
-				return false, nil
-			}
-			return false, err
-		}
-		return true, nil
-	})
-	if err != nil {
-		record.Warnf(eventObject, "FailedDeleteTrunk", "Failed to delete trunk %s with id %s: %v", trunkInfo[0].Name, trunkInfo[0].ID, err)
-		return err
-	}
-
-	record.Eventf(eventObject, "SuccessfulDeleteTrunk", "Deleted trunk %s with id %s", trunkInfo[0].Name, trunkInfo[0].ID)
-	return nil
-}
-
-func (s *Service) getPort(portID string) (port *ports.Port, err error) {
-	if portID == "" {
-		return nil, fmt.Errorf("portID should be specified to get detail")
-	}
-	port, err = ports.Get(s.networkClient, portID).Extract()
-	if err != nil {
-		if capoerrors.IsNotFound(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("get port %q detail failed: %v", portID, err)
-	}
-	return port, nil
 }
 
 func (s *Service) deleteInstance(eventObject runtime.Object, instanceID string) error {
@@ -856,18 +480,6 @@ func (s *Service) InstanceExists(name string) (instance *infrav1.Instance, err e
 		return nil, nil
 	}
 	return instanceList[0], nil
-}
-
-func isDuplicate(list []string, name string) bool {
-	if len(list) == 0 {
-		return false
-	}
-	for _, element := range list {
-		if element == name {
-			return true
-		}
-	}
-	return false
 }
 
 func serverToInstance(v *servers.Server) (*infrav1.Instance, error) {

--- a/pkg/cloud/services/compute/service.go
+++ b/pkg/cloud/services/compute/service.go
@@ -33,7 +33,6 @@ type Service struct {
 	projectID         string
 	computeClient     *gophercloud.ServiceClient
 	identityClient    *gophercloud.ServiceClient
-	networkClient     *gophercloud.ServiceClient
 	imagesClient      *gophercloud.ServiceClient
 	networkingService *networking.Service
 	logger            logr.Logger
@@ -53,13 +52,6 @@ func NewService(client *gophercloud.ProviderClient, clientOpts *clientconfig.Cli
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create compute service client: %v", err)
-	}
-
-	networkingClient, err := openstack.NewNetworkV2(client, gophercloud.EndpointOpts{
-		Region: clientOpts.RegionName,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create networking service client: %v", err)
 	}
 
 	imagesClient, err := openstack.NewImageServiceV2(client, gophercloud.EndpointOpts{
@@ -94,7 +86,6 @@ func NewService(client *gophercloud.ProviderClient, clientOpts *clientconfig.Cli
 		projectID:         projectID,
 		identityClient:    identityClient,
 		computeClient:     computeClient,
-		networkClient:     networkingClient,
 		networkingService: networkingService,
 		imagesClient:      imagesClient,
 		logger:            logger,

--- a/pkg/cloud/services/networking/port.go
+++ b/pkg/cloud/services/networking/port.go
@@ -1,0 +1,295 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networking
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack/common/extensions"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	netext "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsbinding"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/trunks"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/cluster-api/util"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha4"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/metrics"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/record"
+	capoerrors "sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/errors"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/names"
+)
+
+const (
+	TimeoutTrunkDelete       = 3 * time.Minute
+	RetryIntervalTrunkDelete = 5 * time.Second
+
+	TimeoutPortDelete       = 3 * time.Minute
+	RetryIntervalPortDelete = 5 * time.Second
+)
+
+func (s *Service) GetPort(portID string) (port *ports.Port, err error) {
+	if portID == "" {
+		return nil, fmt.Errorf("portID should be specified to get detail")
+	}
+	port, err = ports.Get(s.client, portID).Extract()
+	if err != nil {
+		if capoerrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get port %q detail failed: %v", portID, err)
+	}
+	return port, nil
+}
+
+func (s *Service) GetTrunkSupport() (bool, error) {
+	allPages, err := netext.List(s.client).AllPages()
+	if err != nil {
+		return false, err
+	}
+
+	allExts, err := extensions.ExtractExtensions(allPages)
+	if err != nil {
+		return false, err
+	}
+
+	for _, ext := range allExts {
+		if ext.Alias == "trunk" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (s *Service) GetOrCreatePort(eventObject runtime.Object, clusterName string, portName string, net infrav1.Network, instanceSecurityGroups *[]string) (*ports.Port, error) {
+	allPages, err := ports.List(s.client, ports.ListOpts{
+		Name:      portName,
+		NetworkID: net.ID,
+	}).AllPages()
+	if err != nil {
+		return nil, fmt.Errorf("searching for existing port for server: %v", err)
+	}
+	existingPorts, err := ports.ExtractPorts(allPages)
+	if err != nil {
+		return nil, fmt.Errorf("searching for existing port for server: %v", err)
+	}
+
+	if len(existingPorts) == 1 {
+		return &existingPorts[0], nil
+	}
+
+	if len(existingPorts) > 1 {
+		return nil, fmt.Errorf("multiple ports found with name \"%s\"", portName)
+	}
+
+	// no port found, so create the port
+	portOpts := net.PortOpts
+	if portOpts == nil {
+		portOpts = &infrav1.PortOpts{}
+	}
+
+	description := portOpts.Description
+	if description == "" {
+		description = names.GetDescription(clusterName)
+	}
+
+	// inherit port security groups from the instance if not explicitly specified
+	securityGroups := portOpts.SecurityGroups
+	if securityGroups == nil {
+		securityGroups = instanceSecurityGroups
+	}
+
+	createOpts := ports.CreateOpts{
+		Name:                portName,
+		NetworkID:           net.ID,
+		Description:         description,
+		AdminStateUp:        portOpts.AdminStateUp,
+		MACAddress:          portOpts.MACAddress,
+		TenantID:            portOpts.TenantID,
+		ProjectID:           portOpts.ProjectID,
+		SecurityGroups:      securityGroups,
+		AllowedAddressPairs: []ports.AddressPair{},
+	}
+
+	for _, ap := range portOpts.AllowedAddressPairs {
+		createOpts.AllowedAddressPairs = append(createOpts.AllowedAddressPairs, ports.AddressPair{
+			IPAddress:  ap.IPAddress,
+			MACAddress: ap.MACAddress,
+		})
+	}
+
+	fixedIPs := make([]ports.IP, 0, len(portOpts.FixedIPs)+1)
+	for _, fixedIP := range portOpts.FixedIPs {
+		fixedIPs = append(fixedIPs, ports.IP{
+			SubnetID:  fixedIP.SubnetID,
+			IPAddress: fixedIP.IPAddress,
+		})
+	}
+
+	if net.Subnet.ID != "" {
+		fixedIPs = append(fixedIPs, ports.IP{SubnetID: net.Subnet.ID})
+	}
+	if len(fixedIPs) > 0 {
+		createOpts.FixedIPs = fixedIPs
+	}
+	mc := metrics.NewMetricPrometheusContext("port", "create")
+
+	port, err := ports.Create(s.client, portsbinding.CreateOptsExt{
+		CreateOptsBuilder: createOpts,
+		HostID:            portOpts.HostID,
+		VNICType:          portOpts.VNICType,
+		Profile:           nil,
+	}).Extract()
+	if mc.ObserveRequest(err) != nil {
+		record.Warnf(eventObject, "FailedCreatePort", "Failed to create port %s: %v", portName, err)
+		return nil, err
+	}
+
+	record.Eventf(eventObject, "SuccessfulCreatePort", "Created port %s with id %s", port.Name, port.ID)
+	return port, nil
+}
+
+func (s *Service) GetOrCreateTrunk(eventObject runtime.Object, clusterName, trunkName, portID string) (*trunks.Trunk, error) {
+	allPages, err := trunks.List(s.client, trunks.ListOpts{
+		Name:   trunkName,
+		PortID: portID,
+	}).AllPages()
+	if err != nil {
+		return nil, fmt.Errorf("searching for existing trunk for server: %v", err)
+	}
+	trunkList, err := trunks.ExtractTrunks(allPages)
+	if err != nil {
+		return nil, fmt.Errorf("searching for existing trunk for server: %v", err)
+	}
+
+	if len(trunkList) != 0 {
+		return &trunkList[0], nil
+	}
+
+	trunkCreateOpts := trunks.CreateOpts{
+		Name:        trunkName,
+		PortID:      portID,
+		Description: names.GetDescription(clusterName),
+	}
+	mc := metrics.NewMetricPrometheusContext("trunk", "create")
+
+	trunk, err := trunks.Create(s.client, trunkCreateOpts).Extract()
+	if mc.ObserveRequest(err) != nil {
+		record.Warnf(eventObject, "FailedCreateTrunk", "Failed to create trunk %s: %v", trunkName, err)
+		return nil, err
+	}
+
+	record.Eventf(eventObject, "SuccessfulCreateTrunk", "Created trunk %s with id %s", trunk.Name, trunk.ID)
+	return trunk, nil
+}
+
+func (s *Service) ReplaceAllAttributesTags(eventObject runtime.Object, trunkID string, tags []string) error {
+	mc := metrics.NewMetricPrometheusContext("trunk", "update")
+	_, err := attributestags.ReplaceAll(s.client, "trunks", trunkID, attributestags.ReplaceAllOpts{
+		Tags: tags,
+	}).Extract()
+	if mc.ObserveRequest(err) != nil {
+		record.Warnf(eventObject, "FailedReplaceAllAttributesTags", "Failed to replace all attributestags, trunk %s: %v", trunkID, err)
+		return err
+	}
+
+	record.Eventf(eventObject, "SuccessfulReplaceAllAttributeTags", "Replaced all attributestags %s with tags %s", trunkID, tags)
+	return nil
+}
+
+func (s *Service) DeletePort(eventObject runtime.Object, portID string) error {
+	port, err := s.GetPort(portID)
+	if err != nil {
+		return err
+	}
+	if port == nil {
+		return nil
+	}
+
+	err = util.PollImmediate(RetryIntervalPortDelete, TimeoutPortDelete, func() (bool, error) {
+		mc := metrics.NewMetricPrometheusContext("port", "delete")
+		err := ports.Delete(s.client, port.ID).ExtractErr()
+		if mc.ObserveRequest(err) != nil {
+			if capoerrors.IsRetryable(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+	if err != nil {
+		record.Warnf(eventObject, "FailedDeletePort", "Failed to delete port %s with id %s: %v", port.Name, port.ID, err)
+		return err
+	}
+
+	record.Eventf(eventObject, "SuccessfulDeletePort", "Deleted port %s with id %s", port.Name, port.ID)
+	return nil
+}
+
+func (s *Service) DeletePorts(eventObject runtime.Object, nets []servers.Network) error {
+	for _, n := range nets {
+		if err := s.DeletePort(eventObject, n.Port); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Service) DeleteTrunk(eventObject runtime.Object, portID string) error {
+	port, err := s.GetPort(portID)
+	if err != nil {
+		return err
+	}
+	if port == nil {
+		return nil
+	}
+
+	listOpts := trunks.ListOpts{
+		PortID: port.ID,
+	}
+	trunkList, err := trunks.List(s.client, listOpts).AllPages()
+	if err != nil {
+		return err
+	}
+	trunkInfo, err := trunks.ExtractTrunks(trunkList)
+	if err != nil {
+		return err
+	}
+	if len(trunkInfo) != 1 {
+		return nil
+	}
+
+	err = util.PollImmediate(RetryIntervalTrunkDelete, TimeoutTrunkDelete, func() (bool, error) {
+		if err := trunks.Delete(s.client, trunkInfo[0].ID).ExtractErr(); err != nil {
+			if capoerrors.IsRetryable(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+	if err != nil {
+		record.Warnf(eventObject, "FailedDeleteTrunk", "Failed to delete trunk %s with id %s: %v", trunkInfo[0].Name, trunkInfo[0].ID, err)
+		return err
+	}
+
+	record.Eventf(eventObject, "SuccessfulDeleteTrunk", "Deleted trunk %s with id %s", trunkInfo[0].Name, trunkInfo[0].ID)
+	return nil
+}

--- a/pkg/cloud/services/networking/router.go
+++ b/pkg/cloud/services/networking/router.go
@@ -284,30 +284,6 @@ func (s *Service) getRouterByName(routerName string) (routers.Router, error) {
 	return routers.Router{}, fmt.Errorf("found %d router with the name %s, which should not happen", len(routerList), routerName)
 }
 
-func (s *Service) getSubnetByName(subnetName string) (subnets.Subnet, error) {
-	opts := subnets.ListOpts{
-		Name: subnetName,
-	}
-
-	allPages, err := subnets.List(s.client, opts).AllPages()
-	if err != nil {
-		return subnets.Subnet{}, err
-	}
-
-	subnetList, err := subnets.ExtractSubnets(allPages)
-	if err != nil {
-		return subnets.Subnet{}, err
-	}
-
-	switch len(subnetList) {
-	case 0:
-		return subnets.Subnet{}, nil
-	case 1:
-		return subnetList[0], nil
-	}
-	return subnets.Subnet{}, fmt.Errorf("found %d subnets with the name %s, which should not happen", len(subnetList), subnetName)
-}
-
 func getRouterName(clusterName string) string {
 	return fmt.Sprintf("%s-cluster-%s", networkPrefix, clusterName)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

To makes clear the responsibility of networking package,  this PR removes networkClient usage from compute package.

- Moved port related logic in instance.go to newly created port.go in networking package.
- `getServerNetworks` method renamed `GetNetworks` and moved to  network.go
- `getSecurityGroups` method moved to securitygroups.go

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
