### PR TITLE
Fix error logging for OpenStack instance creation

### DIFF
--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -228,10 +228,11 @@ func (s *Service) createInstance(eventObject runtime.Object, clusterName string,
 	}).Extract()
 
 	if mc.ObserveRequest(err) != nil {
+		serverErr := err
 		if err = s.deletePorts(eventObject, portList); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error creating OpenStack instance: %v, error deleting ports: %v", serverErr, err)
 		}
-		return nil, fmt.Errorf("error creating Openstack instance: %v", err)
+		return nil, fmt.Errorf("error creating Openstack instance: %v", serverErr)
 	}
 	instanceCreateTimeout := getTimeout("CLUSTER_API_OPENSTACK_INSTANCE_CREATE_TIMEOUT", TimeoutInstanceCreate)
 	instanceCreateTimeout *= time.Minute


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**: Ensure that errors are logged properly when OpenStack instance creation fails.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #888

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits

/hold
