### PR TITLE
🐛 fix release staging target

### DIFF
--- a/hack/image-patch/pull-policy-patch.yaml
+++ b/hack/image-patch/pull-policy-patch.yaml
@@ -1,3 +1,3 @@
 - op: replace
-  path: /spec/template/spec/containers/1/imagePullPolicy
+  path: /spec/template/spec/containers/0/imagePullPolicy
   value: Always


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
I broke the release staging target which I now need to release CAPO. This was caused by dropping kube-rbac-proxy. I only saw this in the post-submit image publish job.


ref: https://console.cloud.google.com/cloud-build/builds;region=global/618bcb4d-1360-4f99-812d-77f7f07e833b;step=0?project=k8s-staging-capi-openstack

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
