### PR TITLE
🐛 Fix doc about external cloud provider

### DIFF
--- a/docs/book/src/topics/external-cloud-provider.md
+++ b/docs/book/src/topics/external-cloud-provider.md
@@ -13,7 +13,7 @@ To deploy a cluster using [external cloud provider](https://github.com/kubernete
 - Deploy a CNI solution
 
     ```shell
-    curl https://docs.projectcalico.org/v3.16/manifests/calico.yaml | sed "s/veth_mtu:.*/veth_mtu: \"1430\"/g" | kubectl --kubeconfig=./${CLUSTER_NAME}.kubeconfig apply -f -
+    curl https://docs.projectcalico.org/v3.19/manifests/calico.yaml | sed "s/veth_mtu:.*/veth_mtu: \"1430\"/g" | kubectl --kubeconfig=./${CLUSTER_NAME}.kubeconfig apply -f -
     ```
 
 - Create a secret containing the cloud configuration
@@ -33,8 +33,8 @@ To deploy a cluster using [external cloud provider](https://github.com/kubernete
 - Create RBAC resources and openstack-cloud-controller-manager deamonset
 
     ```shell
-    kubectl --kubeconfig=./${CLUSTER_NAME}.kubeconfig apply -f https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/master/cluster/addons/rbac/cloud-controller-manager-roles.yaml
-    kubectl --kubeconfig=./${CLUSTER_NAME}.kubeconfig apply -f https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/master/cluster/addons/rbac/cloud-controller-manager-role-bindings.yaml
+    kubectl --kubeconfig=./${CLUSTER_NAME}.kubeconfig apply -f https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/master/manifests/controller-manager/cloud-controller-manager-roles.yaml
+    kubectl --kubeconfig=./${CLUSTER_NAME}.kubeconfig apply -f https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/master/manifests/controller-manager/cloud-controller-manager-role-bindings.yaml
     kubectl --kubeconfig=./${CLUSTER_NAME}.kubeconfig apply -f https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/master/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
     ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This comes from manual testing v0.4.0-beta.0.

- Bump calico version v3.16 to v3.19 which is tested against v1.19, v1.20, and v1.21.
   Please refer to: https://docs.projectcalico.org/getting-started/kubernetes/requirements
- Fix URLs of RBAC resources

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #898 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
