### PR TITLE
📖 Upgrading a cluster without LBaaS is not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ previous cluster managers such as [kops][kops] and
 - Native Kubernetes manifests and API
 - Choice of Linux distribution (as long as a current cloud-init is available)
 - Support for single and multi-node control plane clusters
-- Deploy clusters with and without LBaaS available
+- Deploy clusters with and without LBaaS available (only cluster with LBaaS can be upgraded)
 - Support for security groups
 - cloud-init based nodes bootstrapping
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Upgrading a cluster without LBaaS is not supported.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #912 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
