### PR TITLE
🏃 use amphora image from GCS in e2e tests

### DIFF
--- a/hack/ci/devstack-default-cloud-init.yaml.tpl
+++ b/hack/ci/devstack-default-cloud-init.yaml.tpl
@@ -103,7 +103,7 @@ write_files:
     # Don't download default images, just our test images
     DOWNLOAD_DEFAULT_IMAGES=False
     # We upload the Amphora image so it doesn't have to be build
-    IMAGE_URLS="https://github.com/sbueringer/cluster-api-provider-openstack-images/releases/download/amphora-victoria-1/amphora-x64-haproxy.qcow2"
+    IMAGE_URLS="https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/amphora/2021-03-27/amphora-x64-haproxy.qcow2"
 
     # See: https://docs.openstack.org/nova/victoria/configuration/sample-config.html
     # Helpful commands (on the devstack VM):


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

After this PR we only use images from the CAPO GCS bucket in our tests. I uploaded the amphora image together with the others a while ago, but forgot to change the cloud init yaml.

Note: https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/794 still has to be done in a follow-up issue.

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

