### PR TITLE
🐛 Fix failure to create server with specified tags

### DIFF
--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -333,7 +333,13 @@ func reconcileBastion(log logr.Logger, osProviderClient *gophercloud.ProviderCli
 		handleUpdateOSCError(openStackCluster, errors.Errorf("failed to get or create floating IP for bastion: %v", err))
 		return errors.Errorf("failed to get or create floating IP for bastion: %v", err)
 	}
-	err = computeService.AssociateFloatingIP(instance.ID, fp.FloatingIP)
+	port, err := computeService.GetManagementPort(instance)
+	if err != nil {
+		err = errors.Errorf("getting management port for bastion: %v", err)
+		handleUpdateOSCError(openStackCluster, err)
+		return err
+	}
+	err = networkingService.AssociateFloatingIP(openStackCluster, fp, port.ID)
 	if err != nil {
 		handleUpdateOSCError(openStackCluster, errors.Errorf("failed to associate floating IP with bastion: %v", err))
 		return errors.Errorf("failed to associate floating IP with bastion: %v", err)

--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -353,7 +353,13 @@ func (r *OpenStackMachineReconciler) reconcileNormal(ctx context.Context, logger
 			handleUpdateMachineError(logger, openStackMachine, errors.Errorf("Floating IP cannot be got or created: %v", err))
 			return ctrl.Result{}, nil
 		}
-		err = computeService.AssociateFloatingIP(instance.ID, fp.FloatingIP)
+		port, err := computeService.GetManagementPort(instance)
+		if err != nil {
+			err = errors.Errorf("getting management port for control plane machine %s: %v", machine.Name, err)
+			handleUpdateMachineError(logger, openStackMachine, err)
+			return ctrl.Result{}, nil
+		}
+		err = networkingService.AssociateFloatingIP(openStackCluster, fp, port.ID)
 		if err != nil {
 			handleUpdateMachineError(logger, openStackMachine, errors.Errorf("Floating IP cannot be associated: %v", err))
 			return ctrl.Result{}, nil

--- a/docs/book/src/clusteropenstack/configuration.md
+++ b/docs/book/src/clusteropenstack/configuration.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Required configuration](#required-configuration)
+  - [OpenStack Version](#openstack-version)
   - [Operating system image](#operating-system-image)
   - [SSH key pair](#ssh-key-pair)
   - [OpenStack credential](#openstack-credential)
@@ -55,6 +56,10 @@ clusterctl config cluster capi-quickstart \
   --worker-machine-count=1 \
   > capi-quickstart.yaml
 ```
+
+## OpenStack version
+
+We currently require at least OpenStack Pike.
 
 ## Operating system image
 
@@ -233,7 +238,7 @@ Any such ports are created in addition to ports used for connections to networks
 
 ## Tagging
 
-If your cluster supports tagging servers, you have the ability to tag all resources created by the cluster in the `cluster.yaml` file. Here is an example how to configure tagging:
+You have the ability to tag all resources created by the cluster in the `cluster.yaml` file. Here is an example how to configure tagging:
 
 ```yaml
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
@@ -261,7 +266,7 @@ spec:
 
 ## Metadata
 
-Instead of tagging, you also have the option to add metadata to instances. This functionality should be more commonly available than tagging. Here is a usage example:
+You also have the option to add metadata to instances. Here is a usage example:
 
 ```yaml
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4

--- a/pkg/cloud/services/compute/service.go
+++ b/pkg/cloud/services/compute/service.go
@@ -39,6 +39,17 @@ type Service struct {
 	logger            logr.Logger
 }
 
+/*
+ NovaMinimumMicroversion is the minimum Nova microversion supported by CAPO
+ 2.53 corresponds to OpenStack Pike
+
+ For the canonical description of Nova microversions, see
+ https://docs.openstack.org/nova/latest/reference/api-microversion-history.html
+
+ CAPO uses server tags, which were added in microversion 2.52.
+*/
+const NovaMinimumMicroversion = "2.53"
+
 // NewService returns an instance of the compute service.
 func NewService(client *gophercloud.ProviderClient, clientOpts *clientconfig.ClientOpts, logger logr.Logger) (*Service, error) {
 	identityClient, err := openstack.NewIdentityV3(client, gophercloud.EndpointOpts{
@@ -54,6 +65,7 @@ func NewService(client *gophercloud.ProviderClient, clientOpts *clientconfig.Cli
 	if err != nil {
 		return nil, fmt.Errorf("failed to create compute service client: %v", err)
 	}
+	computeClient.Microversion = NovaMinimumMicroversion
 
 	networkingClient, err := openstack.NewNetworkV2(client, gophercloud.EndpointOpts{
 		Region: clientOpts.RegionName,


### PR DESCRIPTION
Trying to create a machine with specified tags would fail with:
  Additional properties are not allowed ('tags' was unexpected)

We fix this by raising the minimum supported microversion to 2.53. Note
that this means we no longer support versions of OpenStack prior to
Pike.

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #917

**Special notes for your reviewer**:

Note that this change has the potential to break code anywhere in CAPO by changing the behaviour of the Nova API. From a quick review of the microversion history I think we should be OK (the change to Flavor looked most significant, but it doesn't affect us yet). CI is especially important here.

I don't think a unit test would achieve anything here. We could assert that the microversion has been set, but that kind of unit test is usually just noise. It is the E2E tests which are vital here. We are presumably missing an E2E test which sets a server tag?

I'll push a second patch which updates the docs.

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [X] includes documentation
  - [ ] adds unit tests

/hold
