### PR TITLE
✨ Allow Trunk configuration at a Port level

### DIFF
--- a/api/v1alpha4/types.go
+++ b/api/v1alpha4/types.go
@@ -130,6 +130,8 @@ type PortOpts struct {
 	ProjectID           string        `json:"projectId,omitempty"`
 	SecurityGroups      *[]string     `json:"securityGroups,omitempty"`
 	AllowedAddressPairs []AddressPair `json:"allowedAddressPairs,omitempty"`
+	// Enables and disables trunk at port level. If not provided, openStackMachine.Spec.Trunk is inherited.
+	Trunk *bool `json:"trunk,omitempty"`
 
 	// The ID of the host where the port is allocated
 	HostID string `json:"hostId,omitempty"`

--- a/api/v1alpha4/zz_generated.deepcopy.go
+++ b/api/v1alpha4/zz_generated.deepcopy.go
@@ -812,6 +812,11 @@ func (in *PortOpts) DeepCopyInto(out *PortOpts) {
 		*out = make([]AddressPair, len(*in))
 		copy(*out, *in)
 	}
+	if in.Trunk != nil {
+		in, out := &in.Trunk, &out.Trunk
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Profile != nil {
 		in, out := &in.Profile, &out.Profile
 		*out = make(map[string]string, len(*in))

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -1322,6 +1322,10 @@ spec:
                               type: array
                             tenantId:
                               type: string
+                            trunk:
+                              description: Enables and disables trunk at port level.
+                                If not provided, openStackMachine.Spec.Trunk is inherited.
+                              type: boolean
                             vnicType:
                               description: The virtual network interface card (vNIC)
                                 type that is bound to the neutron port.
@@ -1771,6 +1775,10 @@ spec:
                               type: array
                             tenantId:
                               type: string
+                            trunk:
+                              description: Enables and disables trunk at port level.
+                                If not provided, openStackMachine.Spec.Trunk is inherited.
+                              type: boolean
                             vnicType:
                               description: The virtual network interface card (vNIC)
                                 type that is bound to the neutron port.
@@ -2047,6 +2055,10 @@ spec:
                         type: array
                       tenantId:
                         type: string
+                      trunk:
+                        description: Enables and disables trunk at port level. If
+                          not provided, openStackMachine.Spec.Trunk is inherited.
+                        type: boolean
                       vnicType:
                         description: The virtual network interface card (vNIC) type
                           that is bound to the neutron port.
@@ -2235,6 +2247,10 @@ spec:
                         type: array
                       tenantId:
                         type: string
+                      trunk:
+                        description: Enables and disables trunk at port level. If
+                          not provided, openStackMachine.Spec.Trunk is inherited.
+                        type: boolean
                       vnicType:
                         description: The virtual network interface card (vNIC) type
                           that is bound to the neutron port.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
@@ -304,6 +304,11 @@ spec:
                                       type: array
                                     tenantId:
                                       type: string
+                                    trunk:
+                                      description: Enables and disables trunk at port
+                                        level. If not provided, openStackMachine.Spec.Trunk
+                                        is inherited.
+                                      type: boolean
                                     vnicType:
                                       description: The virtual network interface card
                                         (vNIC) type that is bound to the neutron port.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
@@ -611,6 +611,10 @@ spec:
                       type: array
                     tenantId:
                       type: string
+                    trunk:
+                      description: Enables and disables trunk at port level. If not
+                        provided, openStackMachine.Spec.Trunk is inherited.
+                      type: boolean
                     vnicType:
                       description: The virtual network interface card (vNIC) type
                         that is bound to the neutron port.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
@@ -561,6 +561,10 @@ spec:
                               type: array
                             tenantId:
                               type: string
+                            trunk:
+                              description: Enables and disables trunk at port level.
+                                If not provided, openStackMachine.Spec.Trunk is inherited.
+                              type: boolean
                             vnicType:
                               description: The virtual network interface card (vNIC)
                                 type that is bound to the neutron port.


### PR DESCRIPTION
Allow Trunk configuration at a Port level

This PR enables and disables port level trunk setting as follows.

- If user provides trunk field (true or false) at Port level, then that value is used for the port.
- If user does not provide trunk field at Port level, then the port inherits the trunk field of the instance. 

Example spec:
```
apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
kind: OpenStackMachineTemplate
metadata:
  name: basic-1-control-plane
  namespace: default
spec:
  template:
    spec:
  template:
    spec:
      trunk: true
      ports:
      - description: "Port 1, no trunk specified"
      - description: "Port 2, trunk disabled"
        trunk: false
      - description: "Port 3, trunk enabled"
        trunk: true
      cloudName: openstack-1
      flavor: 2C-4GB-100GB
      identityRef:
        kind: Secret
        name: basic-1-cloud-config
      image: Ubuntu_20.04_node
```
Output:

```
(openstack) network trunk list  --sort-column Name
+--------------------------------------+-------------------------------+--------------------------------------+-----------------------------------------------------------+
| ID                                   | Name                          | Parent Port                          | Description                                               |
+--------------------------------------+-------------------------------+--------------------------------------+-----------------------------------------------------------+
| 03bbab0b-96d9-4226-bded-08ed8b3449ce | basic-1-control-plane-th8l2-0 | 6b6445f6-13af-4669-a301-cc79a79bf8ef | Created by cluster-api-provider-openstack cluster basic-1 |
| c09f979e-333f-4651-a4ff-93d7a72afc2d | basic-1-control-plane-th8l2-2 | fcd0a7ff-138c-4125-9f2a-42a2c32b13e5 | Created by cluster-api-provider-openstack cluster basic-1 |
+--------------------------------------+-------------------------------+--------------------------------------+-----------------------------------------------------------+
```

```
(openstack) port list -c Name -c Description -c ID --sort-column Name
+-------------------------------+----------------------------+--------------------------------------+
| Name                          | Description                | ID                                   |
+-------------------------------+----------------------------+--------------------------------------+
|                               |                            | 1dc33e63-3e4e-492a-86c4-70b304b58986 |
|                               |                            | 35830ee6-d984-4a1f-8e1a-703e024caca8 |
|                               |                            | e650d8ec-4786-4790-a6c9-befe7db57fae |
| basic-1-control-plane-th8l2-0 | Port 1, no trunk specified | 6b6445f6-13af-4669-a301-cc79a79bf8ef |
| basic-1-control-plane-th8l2-1 | Port 2, trunk disabled     | a944ec80-e147-41e8-aa6b-bbef1a47fe37 |
| basic-1-control-plane-th8l2-2 | Port 3, trunk enabled      | fcd0a7ff-138c-4125-9f2a-42a2c32b13e5 |
+-------------------------------+----------------------------+--------------------------------------+
(openstack) 
```

Signed-off-by: Anwar Hassen <anwar.hassen@est.tech>