### PR TITLE
🐛 Remove the ttl flag from sshuttle invocation

### DIFF
--- a/hack/ci/devstack-on-aws-project-install.sh
+++ b/hack/ci/devstack-on-aws-project-install.sh
@@ -139,7 +139,7 @@ main() {
   # Install some local dependencies we later need in the meantime (we have to wait for cloud init anyway)
   if ! command -v sshuttle;
   then
-    # Install sshuttle from source because we need: https://github.com/sshuttle/sshuttle/pull/606
+    # Install sshuttle from source because we need: https://github.com/sshuttle/sshuttle/pull/661
     # TODO(sbueringer) install via pip after the next release after 1.0.5 via:
     # pip3 install sshuttle
     cd /tmp
@@ -169,9 +169,7 @@ main() {
 
   # Open tunnel
   echo "Opening tunnel to ${PRIVATE_IP} via ${PUBLIC_IP}"
-  # Packets from the Prow Pod or the Pods in Kind have TTL 63 or 64.
-  # We need a ttl of 65 (default 63), so all of our packets are captured by sshuttle.
-  sshuttle -r "ubuntu@${PUBLIC_IP}" "${PRIVATE_IP}/32" 172.24.4.0/24 --ttl=65 --ssh-cmd='ssh -o "StrictHostKeyChecking no" -o "UserKnownHostsFile=/dev/null"' -l 0.0.0.0 -D
+  sshuttle -r "ubuntu@${PUBLIC_IP}" "${PRIVATE_IP}/32" 172.24.4.0/24 --ssh-cmd='ssh -o "StrictHostKeyChecking no" -o "UserKnownHostsFile=/dev/null"' -l 0.0.0.0 -D
 
   export OS_REGION_NAME=RegionOne
   export OS_PROJECT_DOMAIN_ID=default

--- a/hack/ci/devstack-on-gce-project-install.sh
+++ b/hack/ci/devstack-on-gce-project-install.sh
@@ -160,7 +160,7 @@ main() {
   # Install some local dependencies we later need in the meantime (we have to wait for cloud init anyway)
   if ! command -v sshuttle;
   then
-    # Install sshuttle from source because we need: https://github.com/sshuttle/sshuttle/pull/606
+    # Install sshuttle from source because we need: https://github.com/sshuttle/sshuttle/pull/661
     # TODO(sbueringer) install via pip after the next release after 1.0.5 via:
     # pip3 install sshuttle
     cd /tmp
@@ -187,9 +187,7 @@ main() {
 
   # Open tunnel
   echo "Opening tunnel to ${PRIVATE_IP} via ${PUBLIC_IP}"
-  # Packets from the Prow Pod or the Pods in Kind have TTL 63 or 64.
-  # We need a ttl of 65 (default 63), so all of our packets are captured by sshuttle.
-  sshuttle -r "${PUBLIC_IP}" "${PRIVATE_IP}/32" 172.24.4.0/24 --ttl=65 --ssh-cmd='ssh -i ~/.ssh/google_compute_engine -o "StrictHostKeyChecking no" -o "UserKnownHostsFile=/dev/null" -o "IdentitiesOnly=yes"' -l 0.0.0.0 -D
+  sshuttle -r "${PUBLIC_IP}" "${PRIVATE_IP}/32" 172.24.4.0/24 --ssh-cmd='ssh -i ~/.ssh/google_compute_engine -o "StrictHostKeyChecking no" -o "UserKnownHostsFile=/dev/null" -o "IdentitiesOnly=yes"' -l 0.0.0.0 -D
 
   export OS_REGION_NAME=RegionOne
   export OS_PROJECT_DOMAIN_ID=default


### PR DESCRIPTION
The --ttl flag has been removed from the latest version of sshuttle.
Previously, this was required to override the default TTL that sshuttle
sets of 63, so that packets from Prow / kind pods weren't ignored.

However, in the latest version of sshuttle, the TTL of packets leaving
the sshuttle server are no longer adjusted, so let's try without this
option.

**Which issue(s) this PR fixes**
Fixes #940

/hold