### PR TITLE
✨ Fix Webhook names for OpenStackMachineTemplate and OpenStackCluster

### DIFF
--- a/api/v1alpha4/openstackcluster_webhook.go
+++ b/api/v1alpha4/openstackcluster_webhook.go
@@ -34,8 +34,8 @@ func (r *OpenStackCluster) SetupWebhookWithManager(mgr manager.Manager) error {
 		Complete()
 }
 
-// +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1alpha4-openstackcluster,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=openstackcluster,versions=v1alpha4,name=validation.openstackcluster.infrastructure.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
-// +kubebuilder:webhook:verbs=create;update,path=/mutate-infrastructure-cluster-x-k8s-io-v1alpha4-openstackcluster,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=openstackcluster,versions=v1alpha4,name=default.openstackcluster.infrastructure.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
+// +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1alpha4-openstackcluster,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=openstackcluster,versions=v1alpha4,name=validation.openstackcluster.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
+// +kubebuilder:webhook:verbs=create;update,path=/mutate-infrastructure-cluster-x-k8s-io-v1alpha4-openstackcluster,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=openstackcluster,versions=v1alpha4,name=default.openstackcluster.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
 
 var (
 	_ webhook.Defaulter = &OpenStackCluster{}

--- a/api/v1alpha4/openstackmachinetemplate_webhook.go
+++ b/api/v1alpha4/openstackmachinetemplate_webhook.go
@@ -35,7 +35,7 @@ func (r *OpenStackMachineTemplate) SetupWebhookWithManager(mgr manager.Manager) 
 		Complete()
 }
 
-// +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1alpha4-openstackmachinetemplate,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.x-k8s.io,resources=openstackmachinetemplates,versions=v1alpha4,name=validation.openstackmachinetemplate.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
+// +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1alpha4-openstackmachinetemplate,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=openstackmachinetemplates,versions=v1alpha4,name=validation.openstackmachinetemplate.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
 
 var _ webhook.Validator = &OpenStackMachineTemplate{}
 

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -15,7 +15,7 @@ webhooks:
       path: /mutate-infrastructure-cluster-x-k8s-io-v1alpha4-openstackcluster
   failurePolicy: Fail
   matchPolicy: Equivalent
-  name: default.openstackcluster.infrastructure.x-k8s.io
+  name: default.openstackcluster.infrastructure.cluster.x-k8s.io
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -86,7 +86,7 @@ webhooks:
       path: /validate-infrastructure-cluster-x-k8s-io-v1alpha4-openstackcluster
   failurePolicy: Fail
   matchPolicy: Equivalent
-  name: validation.openstackcluster.infrastructure.x-k8s.io
+  name: validation.openstackcluster.infrastructure.cluster.x-k8s.io
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -152,7 +152,7 @@ webhooks:
   name: validation.openstackmachinetemplate.infrastructure.cluster.x-k8s.io
   rules:
   - apiGroups:
-    - infrastructure.x-k8s.io
+    - infrastructure.cluster.x-k8s.io
     apiVersions:
     - v1alpha4
     operations:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the Webhook names for the `OpenStackMachineTemplate` and `OpenStackCluster`.
As this fix is only for the webhook names (i.e., `ValidatingWebhookConfiguration.webhooks.name` and `MutatingWebhookConfiguration.webhooks.name`), it should only be updated.

diff of `kubectl kustomize`

```diff
--- /tmp/without-fixed-names.yaml	2021-07-20 07:50:41.591885981 +0200
+++ /tmp/with-fixed-names.yaml	2021-07-20 07:52:11.807954324 +0200
@@ -7823,7 +7823,7 @@
       path: /mutate-infrastructure-cluster-x-k8s-io-v1alpha4-openstackcluster
   failurePolicy: Fail
   matchPolicy: Equivalent
-  name: default.openstackcluster.infrastructure.x-k8s.io
+  name: default.openstackcluster.infrastructure.cluster.x-k8s.io
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -7875,7 +7875,7 @@
       path: /validate-infrastructure-cluster-x-k8s-io-v1alpha4-openstackcluster
   failurePolicy: Fail
   matchPolicy: Equivalent
-  name: validation.openstackcluster.infrastructure.x-k8s.io
+  name: validation.openstackcluster.infrastructure.cluster.x-k8s.io
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -7917,7 +7917,7 @@
       path: /validate-infrastructure-cluster-x-k8s-io-v1alpha4-openstackmachinetemplate
   failurePolicy: Fail
   matchPolicy: Equivalent
-  name: validation.openstackmachinetemplate.infrastructure.x-k8s.io
+  name: validation.openstackmachinetemplate.infrastructure.cluster.x-k8s.io
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -8156,7 +8156,7 @@
       path: /mutate-infrastructure-cluster-x-k8s-io-v1alpha4-openstackcluster
   failurePolicy: Fail
   matchPolicy: Equivalent
-  name: default.openstackcluster.infrastructure.x-k8s.io
+  name: default.openstackcluster.infrastructure.cluster.x-k8s.io
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -8205,7 +8205,7 @@
       path: /validate-infrastructure-cluster-x-k8s-io-v1alpha4-openstackcluster
   failurePolicy: Fail
   matchPolicy: Equivalent
-  name: validation.openstackcluster.infrastructure.x-k8s.io
+  name: validation.openstackcluster.infrastructure.cluster.x-k8s.io
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -8247,7 +8247,7 @@
       path: /validate-infrastructure-cluster-x-k8s-io-v1alpha4-openstackmachinetemplate
   failurePolicy: Fail
   matchPolicy: Equivalent
-  name: validation.openstackmachinetemplate.infrastructure.x-k8s.io
+  name: validation.openstackmachinetemplate.infrastructure.cluster.x-k8s.io
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
```

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
