### PR TITLE
🏃 Refactor all network client calls into networking package

### DIFF
--- a/pkg/cloud/services/compute/bastion.go
+++ b/pkg/cloud/services/compute/bastion.go
@@ -33,7 +33,7 @@ func (s *Service) CreateBastion(openStackCluster *infrav1.OpenStackCluster, clus
 		RootVolume:    openStackCluster.Spec.Bastion.Instance.RootVolume,
 	}
 
-	securityGroups, err := s.getSecurityGroups(openStackCluster.Spec.Bastion.Instance.SecurityGroups)
+	securityGroups, err := s.networkingService.GetSecurityGroups(openStackCluster.Spec.Bastion.Instance.SecurityGroups)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -22,19 +22,12 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/gophercloud/gophercloud/openstack/common/extensions"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/schedulerhints"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
-	netext "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsbinding"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsecurity"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/trunks"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
@@ -47,20 +40,12 @@ import (
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/metrics"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/record"
 	capoerrors "sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/errors"
-	"sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/names"
 )
 
 const (
 	timeoutInstanceCreate       = 5
 	retryIntervalInstanceStatus = 10 * time.Second
-
-	timeoutTrunkDelete       = 3 * time.Minute
-	retryIntervalTrunkDelete = 5 * time.Second
-
-	timeoutPortDelete       = 3 * time.Minute
-	retryIntervalPortDelete = 5 * time.Second
-
-	timeoutInstanceDelete = 5 * time.Minute
+	timeoutInstanceDelete       = 5 * time.Minute
 )
 
 func (s *Service) CreateInstance(openStackCluster *infrav1.OpenStackCluster, machine *clusterv1.Machine, openStackMachine *infrav1.OpenStackMachine, clusterName string, userData string) (instance *InstanceStatus, err error) {
@@ -87,7 +72,7 @@ func (s *Service) CreateInstance(openStackCluster *infrav1.OpenStackCluster, mac
 	}
 
 	if openStackMachine.Spec.Trunk {
-		trunkSupport, err := s.getTrunkSupport()
+		trunkSupport, err := s.networkingService.GetTrunkSupport()
 		if err != nil {
 			return nil, fmt.Errorf("there was an issue verifying whether trunk support is available, please disable it: %v", err)
 		}
@@ -111,7 +96,7 @@ func (s *Service) CreateInstance(openStackCluster *infrav1.OpenStackCluster, mac
 	instanceSpec.Tags = machineTags
 
 	// Get security groups
-	securityGroups, err := s.getSecurityGroups(openStackMachine.Spec.SecurityGroups)
+	securityGroups, err := s.networkingService.GetSecurityGroups(openStackMachine.Spec.SecurityGroups)
 	if err != nil {
 		return nil, err
 	}
@@ -194,7 +179,7 @@ func (s *Service) createInstance(eventObject runtime.Object, clusterName string,
 			iTags = instanceSpec.Tags
 		}
 		portName := getPortName(instanceSpec.Name, network.PortOpts, i)
-		port, err := s.getOrCreatePort(eventObject, clusterName, portName, network, &instanceSpec.SecurityGroups, iTags)
+		port, err := s.networkingService.GetOrCreatePort(eventObject, clusterName, portName, network, &instanceSpec.SecurityGroups, iTags)
 		if err != nil {
 			return nil, err
 		}
@@ -211,7 +196,7 @@ func (s *Service) createInstance(eventObject runtime.Object, clusterName string,
 	}
 
 	if instanceSpec.Subnet != "" && accessIPv4 == "" {
-		if err := s.deletePorts(eventObject, portList); err != nil {
+		if err := s.networkingService.DeletePorts(eventObject, portList); err != nil {
 			return nil, err
 		}
 		return nil, fmt.Errorf("no ports with fixed IPs found on Subnet %q", instanceSpec.Subnet)
@@ -254,7 +239,7 @@ func (s *Service) createInstance(eventObject runtime.Object, clusterName string,
 
 	if mc.ObserveRequest(err) != nil {
 		serverErr := err
-		if err = s.deletePorts(eventObject, portList); err != nil {
+		if err = s.networkingService.DeletePorts(eventObject, portList); err != nil {
 			return nil, fmt.Errorf("error creating OpenStack instance: %v, error deleting ports: %v", serverErr, err)
 		}
 		return nil, fmt.Errorf("error creating Openstack instance: %v", serverErr)
@@ -326,60 +311,6 @@ func applyServerGroupID(opts servers.CreateOptsBuilder, serverGroupID string) se
 	return opts
 }
 
-func (s *Service) getTrunkSupport() (bool, error) {
-	mc := metrics.NewMetricPrometheusContext("network_extension", "list")
-	allPages, err := netext.List(s.networkClient).AllPages()
-	if mc.ObserveRequest(err) != nil {
-		return false, err
-	}
-
-	allExts, err := extensions.ExtractExtensions(allPages)
-	if err != nil {
-		return false, err
-	}
-
-	for _, ext := range allExts {
-		if ext.Alias == "trunk" {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
-func (s *Service) getSecurityGroups(securityGroupParams []infrav1.SecurityGroupParam) ([]string, error) {
-	var sgIDs []string
-	for _, sg := range securityGroupParams {
-		listOpts := groups.ListOpts(sg.Filter)
-		if listOpts.ProjectID == "" {
-			listOpts.ProjectID = s.projectID
-		}
-		listOpts.Name = sg.Name
-		listOpts.ID = sg.UUID
-		mc := metrics.NewMetricPrometheusContext("security_group", "list")
-		pages, err := groups.List(s.networkClient, listOpts).AllPages()
-		if mc.ObserveRequest(err) != nil {
-			return nil, err
-		}
-
-		SGList, err := groups.ExtractGroups(pages)
-		if err != nil {
-			return nil, err
-		}
-
-		if len(SGList) == 0 {
-			return nil, fmt.Errorf("security group %s not found", sg.Name)
-		}
-
-		for _, group := range SGList {
-			if isDuplicate(sgIDs, group.ID) {
-				continue
-			}
-			sgIDs = append(sgIDs, group.ID)
-		}
-	}
-	return sgIDs, nil
-}
-
 func (s *Service) getServerNetworks(networkParams []infrav1.NetworkParam) ([]infrav1.Network, error) {
 	var nets []infrav1.Network
 	for _, networkParam := range networkParams {
@@ -420,188 +351,6 @@ func (s *Service) getServerNetworks(networkParams []infrav1.NetworkParam) ([]inf
 	return nets, nil
 }
 
-func (s *Service) getOrCreatePort(eventObject runtime.Object, clusterName string, portName string, net infrav1.Network, instanceSecurityGroups *[]string, tags []string) (*ports.Port, error) {
-	mc := metrics.NewMetricPrometheusContext("port", "list")
-	allPages, err := ports.List(s.networkClient, ports.ListOpts{
-		Name:      portName,
-		NetworkID: net.ID,
-	}).AllPages()
-	if mc.ObserveRequest(err) != nil {
-		return nil, fmt.Errorf("searching for existing port for server: %v", err)
-	}
-	existingPorts, err := ports.ExtractPorts(allPages)
-	if err != nil {
-		return nil, fmt.Errorf("searching for existing port for server: %v", err)
-	}
-
-	if len(existingPorts) == 1 {
-		return &existingPorts[0], nil
-	}
-
-	if len(existingPorts) > 1 {
-		return nil, fmt.Errorf("multiple ports found with name \"%s\"", portName)
-	}
-
-	// no port found, so create the port
-	portOpts := net.PortOpts
-	if portOpts == nil {
-		portOpts = &infrav1.PortOpts{}
-	}
-
-	description := portOpts.Description
-	if description == "" {
-		description = names.GetDescription(clusterName)
-	}
-
-	var securityGroups *[]string
-	addressPairs := []ports.AddressPair{}
-	if portOpts.DisablePortSecurity == nil || !*portOpts.DisablePortSecurity {
-		for _, ap := range portOpts.AllowedAddressPairs {
-			addressPairs = append(addressPairs, ports.AddressPair{
-				IPAddress:  ap.IPAddress,
-				MACAddress: ap.MACAddress,
-			})
-		}
-
-		securityGroups = portOpts.SecurityGroups
-
-		// inherit port security groups from the instance if not explicitly specified
-		if securityGroups == nil {
-			securityGroups = instanceSecurityGroups
-		}
-	}
-
-	var fixedIPs interface{}
-	if len(portOpts.FixedIPs) > 0 {
-		fips := make([]ports.IP, 0, len(portOpts.FixedIPs)+1)
-		for _, fixedIP := range portOpts.FixedIPs {
-			fips = append(fips, ports.IP{
-				SubnetID:  fixedIP.SubnetID,
-				IPAddress: fixedIP.IPAddress,
-			})
-		}
-		if net.Subnet.ID != "" {
-			fips = append(fips, ports.IP{SubnetID: net.Subnet.ID})
-		}
-		fixedIPs = fips
-	}
-
-	var createOpts ports.CreateOptsBuilder
-	createOpts = ports.CreateOpts{
-		Name:                portName,
-		NetworkID:           net.ID,
-		Description:         description,
-		AdminStateUp:        portOpts.AdminStateUp,
-		MACAddress:          portOpts.MACAddress,
-		TenantID:            portOpts.TenantID,
-		ProjectID:           portOpts.ProjectID,
-		SecurityGroups:      securityGroups,
-		AllowedAddressPairs: addressPairs,
-		FixedIPs:            fixedIPs,
-	}
-
-	if portOpts.DisablePortSecurity != nil {
-		portSecurity := !*portOpts.DisablePortSecurity
-		createOpts = portsecurity.PortCreateOptsExt{
-			CreateOptsBuilder:   createOpts,
-			PortSecurityEnabled: &portSecurity,
-		}
-	}
-
-	createOpts = portsbinding.CreateOptsExt{
-		CreateOptsBuilder: createOpts,
-		HostID:            portOpts.HostID,
-		VNICType:          portOpts.VNICType,
-		Profile:           getPortProfile(portOpts.Profile),
-	}
-
-	mc = metrics.NewMetricPrometheusContext("port", "create")
-	port, err := ports.Create(s.networkClient, createOpts).Extract()
-	if mc.ObserveRequest(err) != nil {
-		record.Warnf(eventObject, "FailedCreatePort", "Failed to create port %s: %v", portName, err)
-		return nil, err
-	}
-
-	record.Eventf(eventObject, "SuccessfulCreatePort", "Created port %s with id %s", port.Name, port.ID)
-	if portOpts.Trunk != nil && *portOpts.Trunk {
-		trunk, err := s.getOrCreateTrunk(eventObject, clusterName, port.Name, port.ID)
-		if err != nil {
-			record.Warnf(eventObject, "FailedCreateTrunk", "Failed to create trunk for port %s: %v", portName, err)
-			return nil, err
-		}
-		if err = s.replaceAllAttributesTags(eventObject, trunk.ID, tags); err != nil {
-			record.Warnf(eventObject, "FailedReplaceTags", "Failed to replace trunk tags %s: %v", portName, err)
-			return nil, err
-		}
-	}
-
-	return port, nil
-}
-
-func getPortProfile(p map[string]string) map[string]interface{} {
-	portProfile := make(map[string]interface{})
-	for k, v := range p {
-		portProfile[k] = v
-	}
-	// We need return nil if there is no profiles
-	// to have backward compatible defaults.
-	// To set profiles, your tenant needs this permission:
-	// rule:create_port and rule:create_port:binding:profile
-	if len(portProfile) == 0 {
-		return nil
-	}
-	return portProfile
-}
-
-func (s *Service) getOrCreateTrunk(eventObject runtime.Object, clusterName, trunkName, portID string) (*trunks.Trunk, error) {
-	mc := metrics.NewMetricPrometheusContext("trunk", "list")
-	allPages, err := trunks.List(s.networkClient, trunks.ListOpts{
-		Name:   trunkName,
-		PortID: portID,
-	}).AllPages()
-	if mc.ObserveRequest(err) != nil {
-		return nil, fmt.Errorf("searching for existing trunk for port: %v", err)
-	}
-	trunkList, err := trunks.ExtractTrunks(allPages)
-	if err != nil {
-		return nil, fmt.Errorf("searching for existing trunk for port: %v", err)
-	}
-
-	if len(trunkList) != 0 {
-		return &trunkList[0], nil
-	}
-
-	trunkCreateOpts := trunks.CreateOpts{
-		Name:        trunkName,
-		PortID:      portID,
-		Description: names.GetDescription(clusterName),
-	}
-
-	mc = metrics.NewMetricPrometheusContext("trunk", "create")
-	trunk, err := trunks.Create(s.networkClient, trunkCreateOpts).Extract()
-	if mc.ObserveRequest(err) != nil {
-		record.Warnf(eventObject, "FailedCreateTrunk", "Failed to create trunk %s: %v", trunkName, err)
-		return nil, err
-	}
-
-	record.Eventf(eventObject, "SuccessfulCreateTrunk", "Created trunk %s with id %s", trunk.Name, trunk.ID)
-	return trunk, nil
-}
-
-func (s *Service) replaceAllAttributesTags(eventObject runtime.Object, trunkID string, tags []string) error {
-	mc := metrics.NewMetricPrometheusContext("trunk", "update")
-	_, err := attributestags.ReplaceAll(s.networkClient, "trunks", trunkID, attributestags.ReplaceAllOpts{
-		Tags: tags,
-	}).Extract()
-	if mc.ObserveRequest(err) != nil {
-		record.Warnf(eventObject, "FailedReplaceAllAttributesTags", "Failed to replace all attributestags, trunk %s: %v", trunkID, err)
-		return err
-	}
-
-	record.Eventf(eventObject, "SuccessfulReplaceAllAttributeTags", "Replaced all attributestags %s with tags %s", trunkID, tags)
-	return nil
-}
-
 // Helper function for getting image ID from name.
 func (s *Service) getImageID(imageName string) (string, error) {
 	if imageName == "" {
@@ -640,49 +389,14 @@ func (s *Service) GetManagementPort(instanceStatus *InstanceStatus) (*ports.Port
 	if err != nil {
 		return nil, err
 	}
-
-	mc := metrics.NewMetricPrometheusContext("port", "list")
-	portOpts := ports.ListOpts{
-		DeviceID: instanceStatus.ID(),
-		FixedIPs: []ports.FixedIPOpts{
-			{
-				IPAddress: ns.IP(),
-			},
-		},
-		Limit: 1,
-	}
-	allPages, err := ports.List(s.networkClient, portOpts).AllPages()
-	if mc.ObserveRequest(err) != nil {
-		return nil, fmt.Errorf("lookup management port for server %s: %w", instanceStatus.ID(), err)
-	}
-	allPorts, err := ports.ExtractPorts(allPages)
+	allPorts, err := s.networkingService.GetPortFromInstanceIP(instanceStatus.ID(), ns.IP())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("lookup management port for server %s: %w", instanceStatus.ID(), err)
 	}
 	if len(allPorts) < 1 {
 		return nil, fmt.Errorf("did not find management port for server %s", instanceStatus.ID())
 	}
 	return &allPorts[0], nil
-}
-
-func (s *Service) garbageCollectErrorInstancesPort(eventObject runtime.Object, instance *InstanceStatus) error {
-	pager, err := ports.List(s.networkClient, ports.ListOpts{
-		Name: instance.Name(),
-	}).AllPages()
-	if err != nil {
-		return err
-	}
-	portList, err := ports.ExtractPorts(pager)
-	if err != nil {
-		return err
-	}
-	for _, p := range portList {
-		if err := s.deletePort(eventObject, p.ID); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 func (s *Service) DeleteInstance(eventObject runtime.Object, instance *InstanceStatus) error {
@@ -697,7 +411,7 @@ func (s *Service) DeleteInstance(eventObject runtime.Object, instance *InstanceS
 		return err
 	}
 
-	trunkSupport, err := s.getTrunkSupport()
+	trunkSupport, err := s.networkingService.GetTrunkSupport()
 	if err != nil {
 		return fmt.Errorf("obtaining network extensions: %v", err)
 	}
@@ -708,65 +422,24 @@ func (s *Service) DeleteInstance(eventObject runtime.Object, instance *InstanceS
 		}
 
 		if trunkSupport {
-			if err = s.deleteTrunk(eventObject, port.PortID); err != nil {
+			if err = s.networkingService.DeleteTrunk(eventObject, port.PortID); err != nil {
 				return err
 			}
 		}
 
-		if err = s.deletePort(eventObject, port.PortID); err != nil {
+		if err = s.networkingService.DeletePort(eventObject, port.PortID); err != nil {
 			return err
 		}
 	}
 
 	// delete port of error instance
 	if instance.State() == infrav1.InstanceStateError {
-		if err := s.garbageCollectErrorInstancesPort(eventObject, instance); err != nil {
+		if err := s.networkingService.GarbageCollectErrorInstancesPort(eventObject, instance.Name()); err != nil {
 			return err
 		}
 	}
 
 	return s.deleteInstance(eventObject, instanceIdentifier)
-}
-
-func (s *Service) deletePort(eventObject runtime.Object, portID string) error {
-	port, err := s.getPort(portID)
-	if err != nil {
-		return err
-	}
-	if port == nil {
-		return nil
-	}
-
-	err = util.PollImmediate(retryIntervalPortDelete, timeoutPortDelete, func() (bool, error) {
-		mc := metrics.NewMetricPrometheusContext("port", "delete")
-		err := ports.Delete(s.networkClient, port.ID).ExtractErr()
-		if mc.ObserveRequestIgnoreNotFound(err) != nil {
-			if capoerrors.IsNotFound(err) {
-				record.Eventf(eventObject, "SuccessfulDeletePort", "Port %s with id %d did not exist", port.Name, port.ID)
-			}
-			if capoerrors.IsRetryable(err) {
-				return false, nil
-			}
-			return false, err
-		}
-		return true, nil
-	})
-	if err != nil {
-		record.Warnf(eventObject, "FailedDeletePort", "Failed to delete port %s with id %s: %v", port.Name, port.ID, err)
-		return err
-	}
-
-	record.Eventf(eventObject, "SuccessfulDeletePort", "Deleted port %s with id %s", port.Name, port.ID)
-	return nil
-}
-
-func (s *Service) deletePorts(eventObject runtime.Object, nets []servers.Network) error {
-	for _, n := range nets {
-		if err := s.deletePort(eventObject, n.Port); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (s *Service) deleteAttachInterface(eventObject runtime.Object, instance *InstanceIdentifier, portID string) error {
@@ -788,61 +461,6 @@ func (s *Service) deleteAttachInterface(eventObject runtime.Object, instance *In
 
 	record.Eventf(eventObject, "SuccessfulDeleteAttachInterface", "Deleted attach interface: instance %s, port %s", instance.ID, portID)
 	return nil
-}
-
-func (s *Service) deleteTrunk(eventObject runtime.Object, portID string) error {
-	listOpts := trunks.ListOpts{
-		PortID: portID,
-	}
-	mc := metrics.NewMetricPrometheusContext("trunk", "list")
-	trunkList, err := trunks.List(s.networkClient, listOpts).AllPages()
-	if mc.ObserveRequest(err) != nil {
-		return err
-	}
-	trunkInfo, err := trunks.ExtractTrunks(trunkList)
-	if err != nil {
-		return err
-	}
-	if len(trunkInfo) != 1 {
-		return nil
-	}
-
-	err = util.PollImmediate(retryIntervalTrunkDelete, timeoutTrunkDelete, func() (bool, error) {
-		mc := metrics.NewMetricPrometheusContext("trunk", "delete")
-		if err := trunks.Delete(s.networkClient, trunkInfo[0].ID).ExtractErr(); mc.ObserveRequestIgnoreNotFound(err) != nil {
-			if capoerrors.IsNotFound(err) {
-				record.Eventf(eventObject, "SuccessfulDeleteTrunk", "Trunk %s with id %s did not exist", trunkInfo[0].Name, trunkInfo[0].ID)
-				return true, nil
-			}
-			if capoerrors.IsRetryable(err) {
-				return false, nil
-			}
-			return false, err
-		}
-		return true, nil
-	})
-	if err != nil {
-		record.Warnf(eventObject, "FailedDeleteTrunk", "Failed to delete trunk %s with id %s: %v", trunkInfo[0].Name, trunkInfo[0].ID, err)
-		return err
-	}
-
-	record.Eventf(eventObject, "SuccessfulDeleteTrunk", "Deleted trunk %s with id %s", trunkInfo[0].Name, trunkInfo[0].ID)
-	return nil
-}
-
-func (s *Service) getPort(portID string) (port *ports.Port, err error) {
-	if portID == "" {
-		return nil, fmt.Errorf("portID should be specified to get detail")
-	}
-	mc := metrics.NewMetricPrometheusContext("port", "get")
-	port, err = ports.Get(s.networkClient, portID).Extract()
-	if mc.ObserveRequestIgnoreNotFound(err) != nil {
-		if capoerrors.IsNotFound(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("get port %q detail failed: %v", portID, err)
-	}
-	return port, nil
 }
 
 func (s *Service) deleteInstance(eventObject runtime.Object, instance *InstanceIdentifier) error {
@@ -927,18 +545,6 @@ func (s *Service) GetInstanceStatusByName(eventObject runtime.Object, name strin
 		return &InstanceStatus{server: &serverList[i]}, nil
 	}
 	return nil, nil
-}
-
-func isDuplicate(list []string, name string) bool {
-	if len(list) == 0 {
-		return false
-	}
-	for _, element := range list {
-		if element == name {
-			return true
-		}
-	}
-	return false
 }
 
 // deduplicate takes a slice of input strings and filters out any duplicate

--- a/pkg/cloud/services/compute/service.go
+++ b/pkg/cloud/services/compute/service.go
@@ -33,7 +33,6 @@ type Service struct {
 	projectID         string
 	computeClient     *gophercloud.ServiceClient
 	identityClient    *gophercloud.ServiceClient
-	networkClient     *gophercloud.ServiceClient
 	imagesClient      *gophercloud.ServiceClient
 	networkingService *networking.Service
 	logger            logr.Logger
@@ -67,13 +66,6 @@ func NewService(client *gophercloud.ProviderClient, clientOpts *clientconfig.Cli
 	}
 	computeClient.Microversion = NovaMinimumMicroversion
 
-	networkingClient, err := openstack.NewNetworkV2(client, gophercloud.EndpointOpts{
-		Region: clientOpts.RegionName,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create networking service client: %v", err)
-	}
-
 	imagesClient, err := openstack.NewImageServiceV2(client, gophercloud.EndpointOpts{
 		Region: clientOpts.RegionName,
 	})
@@ -106,7 +98,6 @@ func NewService(client *gophercloud.ProviderClient, clientOpts *clientconfig.Cli
 		projectID:         projectID,
 		identityClient:    identityClient,
 		computeClient:     computeClient,
-		networkClient:     networkingClient,
 		networkingService: networkingService,
 		imagesClient:      imagesClient,
 		logger:            logger,

--- a/pkg/cloud/services/networking/mock_networking/client_mock.go
+++ b/pkg/cloud/services/networking/mock_networking/client_mock.go
@@ -22,11 +22,13 @@ package mock_networking
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	extensions "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions"
 	attributestags "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags"
 	floatingips "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
 	routers "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
 	groups "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
 	rules "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
+	trunks "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/trunks"
 	networks "github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	ports "github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	subnets "github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
@@ -176,6 +178,21 @@ func (mr *MockNetworkClientMockRecorder) CreateSubnet(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSubnet", reflect.TypeOf((*MockNetworkClient)(nil).CreateSubnet), arg0)
 }
 
+// CreateTrunk mocks base method
+func (m *MockNetworkClient) CreateTrunk(arg0 trunks.CreateOptsBuilder) (*trunks.Trunk, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateTrunk", arg0)
+	ret0, _ := ret[0].(*trunks.Trunk)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateTrunk indicates an expected call of CreateTrunk
+func (mr *MockNetworkClientMockRecorder) CreateTrunk(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTrunk", reflect.TypeOf((*MockNetworkClient)(nil).CreateTrunk), arg0)
+}
+
 // DeleteFloatingIP mocks base method
 func (m *MockNetworkClient) DeleteFloatingIP(arg0 string) error {
 	m.ctrl.T.Helper()
@@ -272,6 +289,20 @@ func (m *MockNetworkClient) DeleteSubnet(arg0 string) error {
 func (mr *MockNetworkClientMockRecorder) DeleteSubnet(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSubnet", reflect.TypeOf((*MockNetworkClient)(nil).DeleteSubnet), arg0)
+}
+
+// DeleteTrunk mocks base method
+func (m *MockNetworkClient) DeleteTrunk(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteTrunk", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteTrunk indicates an expected call of DeleteTrunk
+func (mr *MockNetworkClientMockRecorder) DeleteTrunk(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTrunk", reflect.TypeOf((*MockNetworkClient)(nil).DeleteTrunk), arg0)
 }
 
 // GetFloatingIP mocks base method
@@ -379,6 +410,21 @@ func (mr *MockNetworkClientMockRecorder) GetSubnet(arg0 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnet", reflect.TypeOf((*MockNetworkClient)(nil).GetSubnet), arg0)
 }
 
+// ListExtensions mocks base method
+func (m *MockNetworkClient) ListExtensions() ([]extensions.Extension, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListExtensions")
+	ret0, _ := ret[0].([]extensions.Extension)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListExtensions indicates an expected call of ListExtensions
+func (mr *MockNetworkClientMockRecorder) ListExtensions() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListExtensions", reflect.TypeOf((*MockNetworkClient)(nil).ListExtensions))
+}
+
 // ListFloatingIP mocks base method
 func (m *MockNetworkClient) ListFloatingIP(arg0 floatingips.ListOptsBuilder) ([]floatingips.FloatingIP, error) {
 	m.ctrl.T.Helper()
@@ -482,6 +528,21 @@ func (m *MockNetworkClient) ListSubnet(arg0 subnets.ListOptsBuilder) ([]subnets.
 func (mr *MockNetworkClientMockRecorder) ListSubnet(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSubnet", reflect.TypeOf((*MockNetworkClient)(nil).ListSubnet), arg0)
+}
+
+// ListTrunk mocks base method
+func (m *MockNetworkClient) ListTrunk(arg0 trunks.ListOptsBuilder) ([]trunks.Trunk, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListTrunk", arg0)
+	ret0, _ := ret[0].([]trunks.Trunk)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListTrunk indicates an expected call of ListTrunk
+func (mr *MockNetworkClientMockRecorder) ListTrunk(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTrunk", reflect.TypeOf((*MockNetworkClient)(nil).ListTrunk), arg0)
 }
 
 // RemoveRouterInterface mocks base method

--- a/pkg/cloud/services/networking/port.go
+++ b/pkg/cloud/services/networking/port.go
@@ -1,0 +1,251 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networking
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsbinding"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsecurity"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/cluster-api/util"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha4"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/record"
+	capoerrors "sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/errors"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/names"
+)
+
+const (
+	timeoutPortDelete       = 3 * time.Minute
+	retryIntervalPortDelete = 5 * time.Second
+)
+
+func (s *Service) getPort(portID string) (port *ports.Port, err error) {
+	if portID == "" {
+		return nil, fmt.Errorf("portID should be specified to get detail")
+	}
+	port, err = s.client.GetPort(portID)
+	if err != nil {
+		if capoerrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get port %q detail failed: %v", portID, err)
+	}
+	return port, nil
+}
+
+// GetPortFromInstanceIP returns at most one port attached to the instance with given ID
+// and with the IP address provided.
+func (s *Service) GetPortFromInstanceIP(instanceID string, ip string) ([]ports.Port, error) {
+	portOpts := ports.ListOpts{
+		DeviceID: instanceID,
+		FixedIPs: []ports.FixedIPOpts{
+			{
+				IPAddress: ip,
+			},
+		},
+		Limit: 1,
+	}
+	return s.client.ListPort(portOpts)
+}
+
+func (s *Service) GetOrCreatePort(eventObject runtime.Object, clusterName string, portName string, net infrav1.Network, instanceSecurityGroups *[]string, tags []string) (*ports.Port, error) {
+	existingPorts, err := s.client.ListPort(ports.ListOpts{
+		Name:      portName,
+		NetworkID: net.ID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("searching for existing port for server: %v", err)
+	}
+
+	if len(existingPorts) == 1 {
+		return &existingPorts[0], nil
+	}
+
+	if len(existingPorts) > 1 {
+		return nil, fmt.Errorf("multiple ports found with name \"%s\"", portName)
+	}
+
+	// no port found, so create the port
+	portOpts := net.PortOpts
+	if portOpts == nil {
+		portOpts = &infrav1.PortOpts{}
+	}
+
+	description := portOpts.Description
+	if description == "" {
+		description = names.GetDescription(clusterName)
+	}
+
+	var securityGroups *[]string
+	addressPairs := []ports.AddressPair{}
+	if portOpts.DisablePortSecurity == nil || !*portOpts.DisablePortSecurity {
+		for _, ap := range portOpts.AllowedAddressPairs {
+			addressPairs = append(addressPairs, ports.AddressPair{
+				IPAddress:  ap.IPAddress,
+				MACAddress: ap.MACAddress,
+			})
+		}
+
+		securityGroups = portOpts.SecurityGroups
+
+		// inherit port security groups from the instance if not explicitly specified
+		if securityGroups == nil {
+			securityGroups = instanceSecurityGroups
+		}
+	}
+
+	var fixedIPs interface{}
+	if len(portOpts.FixedIPs) > 0 {
+		fips := make([]ports.IP, 0, len(portOpts.FixedIPs)+1)
+		for _, fixedIP := range portOpts.FixedIPs {
+			fips = append(fips, ports.IP{
+				SubnetID:  fixedIP.SubnetID,
+				IPAddress: fixedIP.IPAddress,
+			})
+		}
+		if net.Subnet.ID != "" {
+			fips = append(fips, ports.IP{SubnetID: net.Subnet.ID})
+		}
+		fixedIPs = fips
+	}
+
+	var createOpts ports.CreateOptsBuilder
+	createOpts = ports.CreateOpts{
+		Name:                portName,
+		NetworkID:           net.ID,
+		Description:         description,
+		AdminStateUp:        portOpts.AdminStateUp,
+		MACAddress:          portOpts.MACAddress,
+		TenantID:            portOpts.TenantID,
+		ProjectID:           portOpts.ProjectID,
+		SecurityGroups:      securityGroups,
+		AllowedAddressPairs: addressPairs,
+		FixedIPs:            fixedIPs,
+	}
+
+	if portOpts.DisablePortSecurity != nil {
+		portSecurity := !*portOpts.DisablePortSecurity
+		createOpts = portsecurity.PortCreateOptsExt{
+			CreateOptsBuilder:   createOpts,
+			PortSecurityEnabled: &portSecurity,
+		}
+	}
+
+	createOpts = portsbinding.CreateOptsExt{
+		CreateOptsBuilder: createOpts,
+		HostID:            portOpts.HostID,
+		VNICType:          portOpts.VNICType,
+		Profile:           getPortProfile(portOpts.Profile),
+	}
+
+	port, err := s.client.CreatePort(createOpts)
+	if err != nil {
+		record.Warnf(eventObject, "FailedCreatePort", "Failed to create port %s: %v", portName, err)
+		return nil, err
+	}
+
+	record.Eventf(eventObject, "SuccessfulCreatePort", "Created port %s with id %s", port.Name, port.ID)
+	if portOpts.Trunk != nil && *portOpts.Trunk {
+		trunk, err := s.getOrCreateTrunk(eventObject, clusterName, port.Name, port.ID)
+		if err != nil {
+			record.Warnf(eventObject, "FailedCreateTrunk", "Failed to create trunk for port %s: %v", portName, err)
+			return nil, err
+		}
+		if err = s.replaceAllAttributesTags(eventObject, trunk.ID, tags); err != nil {
+			record.Warnf(eventObject, "FailedReplaceTags", "Failed to replace trunk tags %s: %v", portName, err)
+			return nil, err
+		}
+	}
+
+	return port, nil
+}
+
+func getPortProfile(p map[string]string) map[string]interface{} {
+	portProfile := make(map[string]interface{})
+	for k, v := range p {
+		portProfile[k] = v
+	}
+	// We need return nil if there is no profiles
+	// to have backward compatible defaults.
+	// To set profiles, your tenant needs this permission:
+	// rule:create_port and rule:create_port:binding:profile
+	if len(portProfile) == 0 {
+		return nil
+	}
+	return portProfile
+}
+
+func (s *Service) DeletePort(eventObject runtime.Object, portID string) error {
+	port, err := s.getPort(portID)
+	if err != nil {
+		return err
+	}
+	if port == nil {
+		return nil
+	}
+
+	err = util.PollImmediate(retryIntervalPortDelete, timeoutPortDelete, func() (bool, error) {
+		err := s.client.DeletePort(port.ID)
+		if err != nil {
+			if capoerrors.IsNotFound(err) {
+				record.Eventf(eventObject, "SuccessfulDeletePort", "Port %s with id %d did not exist", port.Name, port.ID)
+			}
+			if capoerrors.IsRetryable(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+	if err != nil {
+		record.Warnf(eventObject, "FailedDeletePort", "Failed to delete port %s with id %s: %v", port.Name, port.ID, err)
+		return err
+	}
+
+	record.Eventf(eventObject, "SuccessfulDeletePort", "Deleted port %s with id %s", port.Name, port.ID)
+	return nil
+}
+
+func (s *Service) DeletePorts(eventObject runtime.Object, nets []servers.Network) error {
+	for _, n := range nets {
+		if err := s.DeletePort(eventObject, n.Port); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Service) GarbageCollectErrorInstancesPort(eventObject runtime.Object, instanceName string) error {
+	portList, err := s.client.ListPort(ports.ListOpts{
+		Name: instanceName,
+	})
+	if err != nil {
+		return err
+	}
+	for _, p := range portList {
+		if err := s.DeletePort(eventObject, p.ID); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/cloud/services/networking/trunk.go
+++ b/pkg/cloud/services/networking/trunk.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networking
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/trunks"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/cluster-api/util"
+
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/metrics"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/record"
+	capoerrors "sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/errors"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/names"
+)
+
+const (
+	timeoutTrunkDelete       = 3 * time.Minute
+	retryIntervalTrunkDelete = 5 * time.Second
+)
+
+func (s *Service) GetTrunkSupport() (bool, error) {
+	allExts, err := s.client.ListExtensions()
+	if err != nil {
+		return false, err
+	}
+
+	for _, ext := range allExts {
+		if ext.Alias == "trunk" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (s *Service) getOrCreateTrunk(eventObject runtime.Object, clusterName, trunkName, portID string) (*trunks.Trunk, error) {
+	trunkList, err := s.client.ListTrunk(trunks.ListOpts{
+		Name:   trunkName,
+		PortID: portID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("searching for existing trunk for server: %v", err)
+	}
+
+	if len(trunkList) != 0 {
+		return &trunkList[0], nil
+	}
+
+	trunkCreateOpts := trunks.CreateOpts{
+		Name:        trunkName,
+		PortID:      portID,
+		Description: names.GetDescription(clusterName),
+	}
+
+	trunk, err := s.client.CreateTrunk(trunkCreateOpts)
+	if err != nil {
+		record.Warnf(eventObject, "FailedCreateTrunk", "Failed to create trunk %s: %v", trunkName, err)
+		return nil, err
+	}
+
+	record.Eventf(eventObject, "SuccessfulCreateTrunk", "Created trunk %s with id %s", trunk.Name, trunk.ID)
+	return trunk, nil
+}
+
+func (s *Service) replaceAllAttributesTags(eventObject runtime.Object, trunkID string, tags []string) error {
+	mc := metrics.NewMetricPrometheusContext("trunk", "update")
+	_, err := s.client.ReplaceAllAttributesTags("trunks", trunkID, attributestags.ReplaceAllOpts{
+		Tags: tags,
+	})
+	if mc.ObserveRequest(err) != nil {
+		record.Warnf(eventObject, "FailedReplaceAllAttributesTags", "Failed to replace all attributestags, trunk %s: %v", trunkID, err)
+		return err
+	}
+
+	record.Eventf(eventObject, "SuccessfulReplaceAllAttributeTags", "Replaced all attributestags %s with tags %s", trunkID, tags)
+	return nil
+}
+
+func (s *Service) DeleteTrunk(eventObject runtime.Object, portID string) error {
+	listOpts := trunks.ListOpts{
+		PortID: portID,
+	}
+	trunkInfo, err := s.client.ListTrunk(listOpts)
+	if err != nil {
+		return err
+	}
+	if len(trunkInfo) != 1 {
+		return nil
+	}
+
+	err = util.PollImmediate(retryIntervalTrunkDelete, timeoutTrunkDelete, func() (bool, error) {
+		if err := s.client.DeleteTrunk(trunkInfo[0].ID); err != nil {
+			if capoerrors.IsNotFound(err) {
+				record.Eventf(eventObject, "SuccessfulDeleteTrunk", "Trunk %s with id %s did not exist", trunkInfo[0].Name, trunkInfo[0].ID)
+				return true, nil
+			}
+			if capoerrors.IsRetryable(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+	if err != nil {
+		record.Warnf(eventObject, "FailedDeleteTrunk", "Failed to delete trunk %s with id %s: %v", trunkInfo[0].Name, trunkInfo[0].ID, err)
+		return err
+	}
+
+	record.Eventf(eventObject, "SuccessfulDeleteTrunk", "Deleted trunk %s with id %s", trunkInfo[0].Name, trunkInfo[0].ID)
+	return nil
+}


### PR DESCRIPTION
This refactors all networking client behavior into the networking package. The network client has been removed from the compute Service struct, instead, we use the networking Service. Ports and trunking logic have been moved out of instance.go in the compute package into port.go and trunk.go in the networking package.

The process for refactoring is simple enough:

1. Delete network client from compute package
2. Move any functions using the network client to the networking package
3. Refactor the functions to call the networking client interface instead of gophercloud directly

**What this PR does / why we need it**:
This will allow us to write unit tests for ports and trunk functionality using the mocks in the networking package. It also considerably tidies up instance.go, since now all networking client calls are made in the networking package only.

**Which issue(s) this PR fixes**:
Continuing work on #843, finishes #883 after #935 was merged.

**Special notes for your reviewer**:
~~This is going to cause some rebasing to be required on open PRs around trunks and port security features, namely #934, #914, #921, but will at least allow these features to have unit tests written for them. I think the rebase should be straightforward, the `getOrCreatePort` function in instance.go has simply moved to `GetOrCreatePort` in the networking package. Alternatively, I don't mind waiting and rebasing this PR if those features are ready to go in.~~

PR is ready to go!

- [x] squashed commits

/hold
