### PR TITLE
🐛 openstackcluster reconciliation: reset .Status.failureMessage and .Status.FailureReason on success

### DIFF
--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -290,6 +290,8 @@ func reconcileNormal(ctx context.Context, log logr.Logger, client client.Client,
 	}
 
 	openStackCluster.Status.Ready = true
+	openStackCluster.Status.FailureMessage = nil
+	openStackCluster.Status.FailureReason = nil
 	log.Info("Reconciled Cluster create successfully")
 	return reconcile.Result{}, nil
 }


### PR DESCRIPTION
…
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

On successful execution of `reconcileNormal` this ensures to reset the `.Status.FailureMessage` and `.Status.FailureReason` fields to nil.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #951

**Special notes for your reviewer**:

This could also be done for the openstack machine reconciliaton at https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/master/controllers/openstackmachine_controller.go#L364

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold

<sup>
Christian Schlotter <christian.schlotter@daimler.com>, Daimler TSS GmbH, 
<a href="https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md">Imprint</a>
</sup>