### PR TITLE
🏃Return error if instance go error

### DIFF
--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -276,6 +276,9 @@ func (s *Service) createInstance(eventObject runtime.Object, clusterName string,
 			}
 			return false, err
 		}
+		if createdInstance.State == infrav1.InstanceStateError {
+			return false, fmt.Errorf("openstack instance %s go error.", createdInstance.ID)
+		}
 		return createdInstance.State == infrav1.InstanceStateActive, nil
 	})
 	if err != nil {

--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -277,7 +277,7 @@ func (s *Service) createInstance(eventObject runtime.Object, clusterName string,
 			return false, err
 		}
 		if createdInstance.State == infrav1.InstanceStateError {
-			return false, fmt.Errorf("openstack instance %s go error.", createdInstance.ID)
+			return false, fmt.Errorf("error creating OpenStack instance %s, status changed to error", createdInstance.ID)
 		}
 		return createdInstance.State == infrav1.InstanceStateActive, nil
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
If instance go error due to some exceptions of openstack, we can return error at once and not nesscessary to wait for timeout.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #968

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
