### PR TITLE
:sparkles: Refactor: Don't use infrav1.Instance internally

### DIFF
--- a/pkg/cloud/services/compute/bastion.go
+++ b/pkg/cloud/services/compute/bastion.go
@@ -22,9 +22,9 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha4"
 )
 
-func (s *Service) CreateBastion(openStackCluster *infrav1.OpenStackCluster, clusterName string) (*infrav1.Instance, error) {
+func (s *Service) CreateBastion(openStackCluster *infrav1.OpenStackCluster, clusterName string) (*InstanceStatus, error) {
 	name := fmt.Sprintf("%s-bastion", clusterName)
-	input := &infrav1.Instance{
+	instanceSpec := &InstanceSpec{
 		Name:          name,
 		Flavor:        openStackCluster.Spec.Bastion.Instance.Flavor,
 		SSHKeyName:    openStackCluster.Spec.Bastion.Instance.SSHKeyName,
@@ -40,7 +40,7 @@ func (s *Service) CreateBastion(openStackCluster *infrav1.OpenStackCluster, clus
 	if openStackCluster.Spec.ManagedSecurityGroups {
 		securityGroups = append(securityGroups, openStackCluster.Status.BastionSecurityGroup.ID)
 	}
-	input.SecurityGroups = &securityGroups
+	instanceSpec.SecurityGroups = securityGroups
 
 	var nets []infrav1.Network
 	if len(openStackCluster.Spec.Bastion.Instance.Networks) > 0 {
@@ -57,7 +57,7 @@ func (s *Service) CreateBastion(openStackCluster *infrav1.OpenStackCluster, clus
 			},
 		}}
 	}
-	input.Networks = &nets
+	instanceSpec.Networks = nets
 
-	return s.createInstance(openStackCluster, clusterName, input)
+	return s.createInstance(openStackCluster, clusterName, instanceSpec)
 }

--- a/pkg/cloud/services/compute/instance_types.go
+++ b/pkg/cloud/services/compute/instance_types.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compute
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha4"
+)
+
+// InstanceSpec defines the fields which can be set on a new OpenStack instance.
+//
+// InstanceSpec does not contain all of the fields of infrav1.Instance, as not
+// all of them can be set on a new instance.
+type InstanceSpec struct {
+	Name           string
+	Image          string
+	Flavor         string
+	SSHKeyName     string
+	UserData       string
+	Metadata       map[string]string
+	ConfigDrive    bool
+	FailureDomain  string
+	RootVolume     *infrav1.RootVolume
+	Subnet         string
+	ServerGroupID  string
+	Trunk          bool
+	Tags           []string
+	SecurityGroups []string
+	Networks       []infrav1.Network
+}
+
+// InstanceIdentifier describes an instance which has not necessarily been fetched.
+type InstanceIdentifier struct {
+	ID   string
+	Name string
+}
+
+// InstanceStatus represents instance data which has been returned by OpenStack.
+type InstanceStatus struct {
+	server *servers.Server
+}
+
+func NewInstanceStatusFromServer(server *servers.Server) *InstanceStatus {
+	return &InstanceStatus{server}
+}
+
+type networkInterface struct {
+	Address string  `json:"addr"`
+	Version float64 `json:"version"`
+	Type    string  `json:"OS-EXT-IPS:type"`
+}
+
+// InstanceNetworkStatus represents the network status of an OpenStack instance
+// as used by CAPO. Therefore it may use more context than just data which was
+// returned by OpenStack.
+type InstanceNetworkStatus struct {
+	addresses map[string][]networkInterface
+}
+
+func (is *InstanceStatus) ID() string {
+	return is.server.ID
+}
+
+func (is *InstanceStatus) Name() string {
+	return is.server.Name
+}
+
+func (is *InstanceStatus) State() infrav1.InstanceState {
+	return infrav1.InstanceState(is.server.Status)
+}
+
+func (is *InstanceStatus) SSHKeyName() string {
+	return is.server.KeyName
+}
+
+// APIInstance returns an infrav1.Instance object for use by the API.
+func (is *InstanceStatus) APIInstance() (*infrav1.Instance, error) {
+	i := infrav1.Instance{
+		ID:         is.ID(),
+		Name:       is.Name(),
+		SSHKeyName: is.SSHKeyName(),
+		State:      is.State(),
+	}
+
+	ns, err := is.NetworkStatus()
+	if err != nil {
+		return nil, err
+	}
+
+	i.IP = ns.IP()
+	i.FloatingIP = ns.FloatingIP()
+
+	return &i, nil
+}
+
+// InstanceIdentifier returns an InstanceIdentifier object for an InstanceStatus.
+func (is *InstanceStatus) InstanceIdentifier() *InstanceIdentifier {
+	return &InstanceIdentifier{
+		ID:   is.ID(),
+		Name: is.Name(),
+	}
+}
+
+// NetworkStatus returns an InstanceNetworkStatus object for an InstanceStatus.
+func (is *InstanceStatus) NetworkStatus() (*InstanceNetworkStatus, error) {
+	addresses := make(map[string][]networkInterface)
+
+	for networkName, b := range is.server.Addresses {
+		list, err := json.Marshal(b)
+		if err != nil {
+			return nil, fmt.Errorf("error marshalling addresses for instance %s: %w", is.ID(), err)
+		}
+		var networkList []networkInterface
+		err = json.Unmarshal(list, &networkList)
+		if err != nil {
+			return nil, fmt.Errorf("error unmarshalling addresses for instance %s: %w", is.ID(), err)
+		}
+
+		addresses[networkName] = networkList
+	}
+
+	return &InstanceNetworkStatus{addresses}, nil
+}
+
+func (ns *InstanceNetworkStatus) IP() string {
+	// Return the last listed non-floating IPv4 from the last listed network
+	// This behaviour is wrong, but consistent with the previous behaviour
+	// https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/4debc1fc4742e483302b0c36b16c076977bd165d/pkg/cloud/services/compute/instance.go#L973-L998
+	// XXX: Fix this
+	for _, vifs := range ns.addresses {
+		for _, vif := range vifs {
+			if vif.Version == 4.0 && vif.Type != "floating" {
+				return vif.Address
+			}
+		}
+	}
+	return ""
+}
+
+func (ns *InstanceNetworkStatus) FloatingIP() string {
+	// Return the last listed floating IPv4 from the last listed network
+	// This behaviour is wrong, but consistent with the previous behaviour
+	// https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/4debc1fc4742e483302b0c36b16c076977bd165d/pkg/cloud/services/compute/instance.go#L973-L998
+	// XXX: Fix this
+	for _, vifs := range ns.addresses {
+		for _, vif := range vifs {
+			if vif.Version == 4.0 && vif.Type == "floating" {
+				return vif.Address
+			}
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
This is predominantly a non-functional change. It contains some minor
changes to log messages, and omits a check for instance name being empty
prior to delete in OpenStackMachine controller because this check is no
longer relevant when we delete by ID. Apart from that it contains no
(deliberate) functional changes.

Currently we use infrav1.Instance as our internal representation of an
OpenStack instance. There are several problems with this:

* infrav1.Instance is part of the API, so is hard to change for internal
  use
* infrav1.Instance is used to represent both the 'spec' and 'status' of
  an instance
* When used as a spec for the Bastion host, it allows fields to be set
  which will be ignored
* When used as the status of an instance fetched from OpenStack not all
  fields are populated, leading to potential accidental usage errors

This change creates several new types representing different types of
instance data purely for internal use. This has the following
advantages:

* As they are not API types they can be updated easily
* When used in a function signature they make it clear what data is
  being used
* The type system will prevent accidental use of uninitialised data

The new types are:
* InstanceSpec
* InstanceIdentifier
* InstanceStatus
* InstanceNetworkStatus

They are defined and described in `instance_types.go`.

The primary driver for this work is to eventually fix the documented
errors in InstanceNetworkStatus in IP() and FloatingIP().

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

This is a refactor in support of a future change to fix https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/926. I would like to merge these in separate PRs to separate potential errors introduced by a refactor from the functional changes required to fix the issue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

I suggest the easiest way to read this change is:

* Read the commit message
* Read instance_types.go
* Everything else is pretty much a mechanical consequence

/hold
