### PR TITLE
:bug: Add alpha3 Resources to Scheme

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
+	infrav1old "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha3"
 	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha4"
 	"sigs.k8s.io/cluster-api-provider-openstack/controllers"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/metrics"
@@ -71,6 +72,7 @@ func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = clusterv1.AddToScheme(scheme)
 	_ = infrav1.AddToScheme(scheme)
+	_ = infrav1old.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme
 
 	metrics.RegisterAPIPrometheusMetrics()


### PR DESCRIPTION
Upgrading from alpha3 to alpha4 is only possible, if the schemes are added.
Otherwise the controller is not able to fetch those resources.

**What this PR does / why we need it**:

This PR adds the old alpha3 schemes to the controller. We need it, because otherwise it is impossible to use those resources and the conversion does not work properly.

This is pretty similar to https://github.com/kubernetes-sigs/cluster-api/pull/4417