### PR TITLE
:bug: Fix Conversion from alpha3 to alpha4

### DIFF
--- a/api/v1alpha3/conversion.go
+++ b/api/v1alpha3/conversion.go
@@ -131,6 +131,7 @@ func Convert_v1alpha3_OpenStackMachineSpec_To_v1alpha4_OpenStackMachineSpec(in *
 	if in.CloudsSecret != nil {
 		out.IdentityRef = &v1alpha4.OpenStackIdentityReference{
 			Name: in.CloudsSecret.Name,
+			Kind: "Secret",
 		}
 	}
 	return autoConvert_v1alpha3_OpenStackMachineSpec_To_v1alpha4_OpenStackMachineSpec(in, out, s)


### PR DESCRIPTION
**What this PR does / why we need it**:

This patch sets the `Kind` in `IdentityRef` to `Secret` during the conversion
from the `CloudSecret` to the `OpenStackIdentityReference`. Without a `Kind`
set, the admission hook rejects the converted resource, because it is invalid, which makes it
impossible to upgrade.