### PR TITLE
⚠️ Don't overwrite openstackcluster.status.network on reconciliation

### DIFF
--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -397,11 +397,12 @@ func reconcileNetworkComponents(log logr.Logger, osProviderClient *gophercloud.P
 			handleUpdateOSCError(openStackCluster, errors.Errorf("failed to find only one network (result: %v): %v", networkList, err))
 			return errors.Errorf("failed to find only one network (result: %v): %v", networkList, err)
 		}
-		openStackCluster.Status.Network = &infrav1.Network{
-			ID:   networkList[0].ID,
-			Name: networkList[0].Name,
-			Tags: networkList[0].Tags,
+		if openStackCluster.Status.Network == nil {
+			openStackCluster.Status.Network = &infrav1.Network{}
 		}
+		openStackCluster.Status.Network.ID = networkList[0].ID
+		openStackCluster.Status.Network.Name = networkList[0].Name
+		openStackCluster.Status.Network.Tags = networkList[0].Tags
 
 		subnetOpts := subnets.ListOpts(openStackCluster.Spec.Subnet)
 		subnetOpts.NetworkID = networkList[0].ID


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

Assumption: provisioned openstackcluster

When the controller for openstackcluster does reconcile and returns an error after [line 406](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/master/controllers/openstackcluster_controller.go#L406) the defer patch will update the openstackcluster and remove values because the openstackcluster.status.network gets rebuilt on each reconciliation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
<sup>
Christian Schlotter <christian.schlotter@daimler.com>, Daimler TSS GmbH, 
<a href="https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md">Imprint</a>
</sup>