### PR TITLE
:sparkles: Make floating IPs optional

### DIFF
--- a/api/v1alpha4/openstackcluster_types.go
+++ b/api/v1alpha4/openstackcluster_types.go
@@ -68,6 +68,10 @@ type OpenStackClusterSpec struct {
 	// already exists.
 	APIServerFloatingIP string `json:"apiServerFloatingIP,omitempty"`
 
+	// UseControlPlaneFIP specifies whether to use a floating IP for the
+	// control plane address. Default: true.
+	UseControlPlaneFIP *bool `json:"useControlPlaneFIP,omitempty"`
+
 	// APIServerPort is the port on which the listener on the APIServer
 	// will be created
 	APIServerPort int `json:"apiServerPort,omitempty"`

--- a/api/v1alpha4/zz_generated.deepcopy.go
+++ b/api/v1alpha4/zz_generated.deepcopy.go
@@ -326,6 +326,11 @@ func (in *OpenStackClusterSpec) DeepCopyInto(out *OpenStackClusterSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.UseControlPlaneFIP != nil {
+		in, out := &in.UseControlPlaneFIP, &out.UseControlPlaneFIP
+		*out = new(bool)
+		**out = **in
+	}
 	if in.APIServerLoadBalancerAdditionalPorts != nil {
 		in, out := &in.APIServerLoadBalancerAdditionalPorts, &out.APIServerLoadBalancerAdditionalPorts
 		*out = make([]int, len(*in))

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -1655,6 +1655,10 @@ spec:
                 items:
                   type: string
                 type: array
+              useControlPlaneFIP:
+                description: 'UseControlPlaneFIP specifies whether to use a floating
+                  IP for the control plane address. Default: true.'
+                type: boolean
             type: object
           status:
             description: OpenStackClusterStatus defines the observed state of OpenStackCluster.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
@@ -647,6 +647,10 @@ spec:
                         items:
                           type: string
                         type: array
+                      useControlPlaneFIP:
+                        description: 'UseControlPlaneFIP specifies whether to use
+                          a floating IP for the control plane address. Default: true.'
+                        type: boolean
                     type: object
                 required:
                 - spec

--- a/templates/cluster-template-external-cloud-provider.yaml
+++ b/templates/cluster-template-external-cloud-provider.yaml
@@ -29,6 +29,7 @@ spec:
   managedAPIServerLoadBalancer: true
   managedSecurityGroups: true
   nodeCidr: 10.6.0.0/24
+  useControlPlaneFIP: ${OPENSTACK_USE_CONTROL_PLANE_FIP:=true}
   dnsNameservers:
   - ${OPENSTACK_DNS_NAMESERVERS}
   externalNetworkId: ${OPENSTACK_EXTERNAL_NETWORK_ID}

--- a/templates/cluster-template-without-lb.yaml
+++ b/templates/cluster-template-without-lb.yaml
@@ -28,6 +28,7 @@ spec:
     kind: Secret
   managedSecurityGroups: true
   nodeCidr: 10.6.0.0/24
+  useControlPlaneFIP: ${OPENSTACK_USE_CONTROL_PLANE_FIP:=true}
   dnsNameservers:
   - ${OPENSTACK_DNS_NAMESERVERS}
   externalNetworkId: ${OPENSTACK_EXTERNAL_NETWORK_ID}

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -29,6 +29,7 @@ spec:
   managedAPIServerLoadBalancer: true
   managedSecurityGroups: true
   nodeCidr: 10.6.0.0/24
+  useControlPlaneFIP: ${OPENSTACK_USE_CONTROL_PLANE_FIP:=true}
   dnsNameservers:
   - ${OPENSTACK_DNS_NAMESERVERS}
   externalNetworkId: ${OPENSTACK_EXTERNAL_NETWORK_ID}

--- a/test/e2e/data/infrastructure-openstack/cluster-template-external-cloud-provider.yaml
+++ b/test/e2e/data/infrastructure-openstack/cluster-template-external-cloud-provider.yaml
@@ -32,6 +32,7 @@ spec:
   managedAPIServerLoadBalancer: true
   managedSecurityGroups: true
   nodeCidr: 10.6.0.0/24
+  useControlPlaneFIP: ${OPENSTACK_USE_CONTROL_PLANE_FIP:=true}
   dnsNameservers:
   - ${OPENSTACK_DNS_NAMESERVERS}
   bastion:

--- a/test/e2e/data/infrastructure-openstack/cluster-template-without-lb.yaml
+++ b/test/e2e/data/infrastructure-openstack/cluster-template-without-lb.yaml
@@ -30,6 +30,7 @@ spec:
     kind: Secret
   managedSecurityGroups: true
   nodeCidr: 10.6.0.0/24
+  useControlPlaneFIP: ${OPENSTACK_USE_CONTROL_PLANE_FIP:=true}
   dnsNameservers:
   - ${OPENSTACK_DNS_NAMESERVERS}
   bastion:

--- a/test/e2e/data/infrastructure-openstack/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-openstack/cluster-template.yaml
@@ -31,6 +31,7 @@ spec:
   managedAPIServerLoadBalancer: true
   managedSecurityGroups: true
   nodeCidr: 10.6.0.0/24
+  useControlPlaneFIP: ${OPENSTACK_USE_CONTROL_PLANE_FIP:=true}
   dnsNameservers:
   - ${OPENSTACK_DNS_NAMESERVERS}
   bastion:


### PR DESCRIPTION
Make floating IPs optional

At the moment, CAPO expects the control plane address to be a floating
IP. We're going to make it configurable through the "useControlPlaneFIP"
option.

In order to remain backwards compatible, it will default to "true".
If set to "false", we'll just use the control plane IP address without
attempting to create/attach a floating IP.

closes: #983
