### PR TITLE
✨Add InstanceStatus.AvailabilityZone()

### DIFF
--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -880,19 +880,18 @@ func (s *Service) GetInstanceStatus(resourceID string) (instance *InstanceStatus
 	if resourceID == "" {
 		return nil, fmt.Errorf("resourceId should be specified to get detail")
 	}
+
 	mc := metrics.NewMetricPrometheusContext("server", "get")
-	server, err := servers.Get(s.computeClient, resourceID).Extract()
+	var server ServerExt
+	err = servers.Get(s.computeClient, resourceID).ExtractInto(&server)
 	if mc.ObserveRequestIgnoreNotFound(err) != nil {
 		if capoerrors.IsNotFound(err) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("get server %q detail failed: %v", resourceID, err)
 	}
-	if server == nil {
-		return nil, nil
-	}
 
-	return &InstanceStatus{server: server}, nil
+	return &InstanceStatus{server: &server}, nil
 }
 
 func (s *Service) GetInstanceStatusByName(eventObject runtime.Object, name string) (instance *InstanceStatus, err error) {
@@ -913,7 +912,8 @@ func (s *Service) GetInstanceStatusByName(eventObject runtime.Object, name strin
 	if mc.ObserveRequest(err) != nil {
 		return nil, fmt.Errorf("get server list: %v", err)
 	}
-	serverList, err := servers.ExtractServers(allPages)
+	var serverList []ServerExt
+	err = servers.ExtractServersInto(allPages, &serverList)
 	if err != nil {
 		return nil, fmt.Errorf("extract server list: %v", err)
 	}

--- a/pkg/cloud/services/compute/instance_types.go
+++ b/pkg/cloud/services/compute/instance_types.go
@@ -20,10 +20,17 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha4"
 )
+
+// ServerExt is the base gophercloud Server with extensions used by InstanceStatus.
+type ServerExt struct {
+	servers.Server
+	availabilityzones.ServerAvailabilityZoneExt
+}
 
 // InstanceSpec defines the fields which can be set on a new OpenStack instance.
 //
@@ -55,10 +62,10 @@ type InstanceIdentifier struct {
 
 // InstanceStatus represents instance data which has been returned by OpenStack.
 type InstanceStatus struct {
-	server *servers.Server
+	server *ServerExt
 }
 
-func NewInstanceStatusFromServer(server *servers.Server) *InstanceStatus {
+func NewInstanceStatusFromServer(server *ServerExt) *InstanceStatus {
 	return &InstanceStatus{server}
 }
 
@@ -89,6 +96,10 @@ func (is *InstanceStatus) State() infrav1.InstanceState {
 
 func (is *InstanceStatus) SSHKeyName() string {
 	return is.server.KeyName
+}
+
+func (is *InstanceStatus) AvailabilityZone() string {
+	return is.server.AvailabilityZone
 }
 
 // APIInstance returns an infrav1.Instance object for use by the API.

--- a/test/e2e/shared/openstack.go
+++ b/test/e2e/shared/openstack.go
@@ -170,7 +170,8 @@ func getOpenStackServers(e2eCtx *E2EContext) (map[string]server, error) {
 		return nil, fmt.Errorf("error listing server: %v", err)
 	}
 
-	serverList, err := servers.ExtractServers(allPages)
+	var serverList []compute.ServerExt
+	err = servers.ExtractServersInto(allPages, &serverList)
 	if err != nil {
 		return nil, fmt.Errorf("error extracting server: %v", err)
 	}


### PR DESCRIPTION
This is currently only required by MAPO, where it's used to label the
node with its AZ. It doesn't fetch any additional data from OpenStack,
just exposes it in Go.

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
CAPO doesn't need it, yet. MAPO does, though, it's 'free', and CAPO will almost certainly require it eventually.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->