### PR TITLE
🐛 Don't make unnecessary REST API calls in getServerNetworks

### DIFF
--- a/api/v1alpha4/types.go
+++ b/api/v1alpha4/types.go
@@ -55,7 +55,9 @@ type SecurityGroupFilter struct {
 }
 
 type NetworkParam struct {
-	// The UUID of the network. Required if you omit the port attribute.
+	// Optional UUID of the network.
+	// If specified this will not be validated prior to server creation.
+	// Required if `Subnets` specifies a subnet by UUID.
 	UUID string `json:"uuid,omitempty"`
 	// A fixed IPv4 address for the NIC.
 	FixedIP string `json:"fixedIP,omitempty"`
@@ -85,10 +87,12 @@ type Filter struct {
 }
 
 type SubnetParam struct {
-	// The UUID of the network. Required if you omit the port attribute.
+	// Optional UUID of the subnet.
+	// If specified this will not be validated prior to server creation.
+	// If specified, the enclosing `NetworkParam` must also be specified by UUID.
 	UUID string `json:"uuid,omitempty"`
 
-	// Filters for optional network query
+	// Filters for optional subnet query
 	Filter SubnetFilter `json:"filter,omitempty"`
 }
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -1211,7 +1211,7 @@ spec:
                               items:
                                 properties:
                                   filter:
-                                    description: Filters for optional network query
+                                    description: Filters for optional subnet query
                                     properties:
                                       cidr:
                                         type: string
@@ -1257,14 +1257,17 @@ spec:
                                         type: string
                                     type: object
                                   uuid:
-                                    description: The UUID of the network. Required
-                                      if you omit the port attribute.
+                                    description: Optional UUID of the subnet. If specified
+                                      this will not be validated prior to server creation.
+                                      If specified, the enclosing `NetworkParam` must
+                                      also be specified by UUID.
                                     type: string
                                 type: object
                               type: array
                             uuid:
-                              description: The UUID of the network. Required if you
-                                omit the port attribute.
+                              description: Optional UUID of the network. If specified
+                                this will not be validated prior to server creation.
+                                Required if `Subnets` specifies a subnet by UUID.
                               type: string
                           type: object
                         type: array
@@ -1508,7 +1511,7 @@ spec:
                         Gateway of this router
                       properties:
                         filter:
-                          description: Filters for optional network query
+                          description: Filters for optional subnet query
                           properties:
                             cidr:
                               type: string
@@ -1554,8 +1557,10 @@ spec:
                               type: string
                           type: object
                         uuid:
-                          description: The UUID of the network. Required if you omit
-                            the port attribute.
+                          description: Optional UUID of the subnet. If specified this
+                            will not be validated prior to server creation. If specified,
+                            the enclosing `NetworkParam` must also be specified by
+                            UUID.
                           type: string
                       type: object
                   required:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
@@ -194,7 +194,7 @@ spec:
                                       items:
                                         properties:
                                           filter:
-                                            description: Filters for optional network
+                                            description: Filters for optional subnet
                                               query
                                             properties:
                                               cidr:
@@ -241,14 +241,19 @@ spec:
                                                 type: string
                                             type: object
                                           uuid:
-                                            description: The UUID of the network.
-                                              Required if you omit the port attribute.
+                                            description: Optional UUID of the subnet.
+                                              If specified this will not be validated
+                                              prior to server creation. If specified,
+                                              the enclosing `NetworkParam` must also
+                                              be specified by UUID.
                                             type: string
                                         type: object
                                       type: array
                                     uuid:
-                                      description: The UUID of the network. Required
-                                        if you omit the port attribute.
+                                      description: Optional UUID of the network. If
+                                        specified this will not be validated prior
+                                        to server creation. Required if `Subnets`
+                                        specifies a subnet by UUID.
                                       type: string
                                   type: object
                                 type: array
@@ -501,7 +506,7 @@ spec:
                                 for the Gateway of this router
                               properties:
                                 filter:
-                                  description: Filters for optional network query
+                                  description: Filters for optional subnet query
                                   properties:
                                     cidr:
                                       type: string
@@ -547,8 +552,10 @@ spec:
                                       type: string
                                   type: object
                                 uuid:
-                                  description: The UUID of the network. Required if
-                                    you omit the port attribute.
+                                  description: Optional UUID of the subnet. If specified
+                                    this will not be validated prior to server creation.
+                                    If specified, the enclosing `NetworkParam` must
+                                    also be specified by UUID.
                                   type: string
                               type: object
                           required:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
@@ -487,7 +487,7 @@ spec:
                       items:
                         properties:
                           filter:
-                            description: Filters for optional network query
+                            description: Filters for optional subnet query
                             properties:
                               cidr:
                                 type: string
@@ -533,14 +533,17 @@ spec:
                                 type: string
                             type: object
                           uuid:
-                            description: The UUID of the network. Required if you
-                              omit the port attribute.
+                            description: Optional UUID of the subnet. If specified
+                              this will not be validated prior to server creation.
+                              If specified, the enclosing `NetworkParam` must also
+                              be specified by UUID.
                             type: string
                         type: object
                       type: array
                     uuid:
-                      description: The UUID of the network. Required if you omit the
-                        port attribute.
+                      description: Optional UUID of the network. If specified this
+                        will not be validated prior to server creation. Required if
+                        `Subnets` specifies a subnet by UUID.
                       type: string
                   type: object
                 type: array

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
@@ -432,7 +432,7 @@ spec:
                               items:
                                 properties:
                                   filter:
-                                    description: Filters for optional network query
+                                    description: Filters for optional subnet query
                                     properties:
                                       cidr:
                                         type: string
@@ -478,14 +478,17 @@ spec:
                                         type: string
                                     type: object
                                   uuid:
-                                    description: The UUID of the network. Required
-                                      if you omit the port attribute.
+                                    description: Optional UUID of the subnet. If specified
+                                      this will not be validated prior to server creation.
+                                      If specified, the enclosing `NetworkParam` must
+                                      also be specified by UUID.
                                     type: string
                                 type: object
                               type: array
                             uuid:
-                              description: The UUID of the network. Required if you
-                                omit the port attribute.
+                              description: Optional UUID of the network. If specified
+                                this will not be validated prior to server creation.
+                                Required if `Subnets` specifies a subnet by UUID.
                               type: string
                           type: object
                         type: array

--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -313,38 +313,71 @@ func applyServerGroupID(opts servers.CreateOptsBuilder, serverGroupID string) se
 
 func (s *Service) getServerNetworks(networkParams []infrav1.NetworkParam) ([]infrav1.Network, error) {
 	var nets []infrav1.Network
+
+	addSubnet := func(netID, subnetID string) {
+		nets = append(nets, infrav1.Network{
+			ID: netID,
+			Subnet: &infrav1.Subnet{
+				ID: subnetID,
+			},
+		})
+	}
+
+	addSubnets := func(networkParam infrav1.NetworkParam, netID string) error {
+		if len(networkParam.Subnets) == 0 && netID != "" {
+			addSubnet(netID, "")
+			return nil
+		}
+
+		for _, subnet := range networkParam.Subnets {
+			// Don't lookup subnet if it was specified explicitly by UUID
+			if subnet.UUID != "" {
+				// If subnet was supplied by UUID then network
+				// must also have been supplied by UUID.
+				if netID == "" {
+					return fmt.Errorf("validation error adding network for subnet %s: "+
+						"network uuid must be specified when subnet uuid is specified", subnet.UUID)
+				}
+
+				addSubnet(netID, subnet.UUID)
+			} else {
+				subnetOpts := subnets.ListOpts(subnet.Filter)
+				if netID != "" {
+					subnetOpts.NetworkID = netID
+				}
+				subnetsByFilter, err := s.networkingService.GetSubnetsByFilter(&subnetOpts)
+				if err != nil {
+					return err
+				}
+				for _, subnetByFilter := range subnetsByFilter {
+					addSubnet(subnetByFilter.NetworkID, subnetByFilter.ID)
+				}
+			}
+		}
+
+		return nil
+	}
+
 	for _, networkParam := range networkParams {
+		// Don't lookup network if we specified one explicitly by UUID
+		// Don't lookup network if we didn't specify a network filter
+		// If there is no explicit network UUID and no network filter,
+		// we will look for subnets matching any given subnet filters in
+		// all networks.
+		if networkParam.UUID != "" || networkParam.Filter == (infrav1.Filter{}) {
+			if err := addSubnets(networkParam, networkParam.UUID); err != nil {
+				return nil, err
+			}
+			continue
+		}
 		opts := networks.ListOpts(networkParam.Filter)
-		opts.ID = networkParam.UUID
 		ids, err := s.networkingService.GetNetworkIDsByFilter(&opts)
 		if err != nil {
 			return nil, err
 		}
 		for _, netID := range ids {
-			if networkParam.Subnets == nil {
-				nets = append(nets, infrav1.Network{
-					ID:     netID,
-					Subnet: &infrav1.Subnet{},
-				})
-				continue
-			}
-
-			for _, subnet := range networkParam.Subnets {
-				subnetOpts := subnets.ListOpts(subnet.Filter)
-				subnetOpts.ID = subnet.UUID
-				subnetOpts.NetworkID = netID
-				subnetsByFilter, err := s.networkingService.GetSubnetsByFilter(&subnetOpts)
-				if err != nil {
-					return nil, err
-				}
-				for _, subnetByFilter := range subnetsByFilter {
-					nets = append(nets, infrav1.Network{
-						ID: subnetByFilter.NetworkID,
-						Subnet: &infrav1.Subnet{
-							ID: subnetByFilter.ID,
-						},
-					})
-				}
+			if err := addSubnets(networkParam, netID); err != nil {
+				return nil, err
 			}
 		}
 	}

--- a/pkg/cloud/services/networking/service.go
+++ b/pkg/cloud/services/networking/service.go
@@ -69,3 +69,12 @@ func NewService(providerClient *gophercloud.ProviderClient, clientOpts *clientco
 		logger:    logger,
 	}, nil
 }
+
+// NewTestService returns a Service with no initialisation. It should only be used by tests.
+func NewTestService(projectID string, client NetworkClient, logger logr.Logger) *Service {
+	return &Service{
+		projectID: projectID,
+		client:    client,
+		logger:    logger,
+	}
+}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

If we specify a network with a subnet filter but no network filter, we now execute a single subnet query rather than executing one for every network. We also no longer execute queries at all when the user has specified a uuid explicitly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #993

**Special notes for your reviewer**:

This PR is intentionally structured in 2 commits:

The first adds unit tests for getServerNetworks (ironically using the excellent work in #935, which also happened to be the commit which introduced the regression). The second fixes getServerNetworks and makes the necessary changes to the unit tests.

The purpose of doing this is to highlight functional changes introduced by the second commit. These can be clearly seen in the unit test changes:

* We make fewer gophercloud calls without changing the returned data
* The target case no longer returns an error

Apart from the target case, we can see that the output of the test cases are unaffected.