### PR TITLE
:sparkles: Implement allowAllInClusterTraffic flag

### DIFF
--- a/api/v1alpha4/openstackcluster_types.go
+++ b/api/v1alpha4/openstackcluster_types.go
@@ -75,13 +75,20 @@ type OpenStackClusterSpec struct {
 	// APIServerLoadBalancerAdditionalPorts adds additional ports to the APIServerLoadBalancer
 	APIServerLoadBalancerAdditionalPorts []int `json:"apiServerLoadBalancerAdditionalPorts,omitempty"`
 
-	// ManagedSecurityGroups defines that kubernetes manages the OpenStack security groups
-	// for now, that means that we'll create security group allows traffic to/from
-	// machines belonging to that group based on Calico CNI plugin default network
-	// requirements: BGP and IP-in-IP for master node(s) and worker node(s) respectively.
-	// In the future, we could make this more flexible.
+	// ManagedSecurityGroups determines whether OpenStack security groups for the cluster
+	// will be managed by the OpenStack provider or whether pre-existing security groups will
+	// be specified as part of the configuration.
+	// By default, the managed security groups have rules that allow the Kubelet, etcd, the
+	// Kubernetes API server and the Calico CNI plugin to function correctly.
 	// +optional
 	ManagedSecurityGroups bool `json:"managedSecurityGroups"`
+
+	// AllowAllInClusterTraffic is only used when managed security groups are in use.
+	// If set to true, the rules for the managed security groups are configured so that all
+	// ingress and egress between cluster nodes is permitted, allowing CNIs other than
+	// Calico to be used.
+	// +optional
+	AllowAllInClusterTraffic bool `json:"allowAllInClusterTraffic"`
 
 	// DisablePortSecurity disables the port security of the network created for the
 	// Kubernetes cluster, which also disables SecurityGroups

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -1072,6 +1072,12 @@ spec:
           spec:
             description: OpenStackClusterSpec defines the desired state of OpenStackCluster.
             properties:
+              allowAllInClusterTraffic:
+                description: AllowAllInClusterTraffic is only used when managed security
+                  groups are in use. If set to true, the rules for the managed security
+                  groups are configured so that all ingress and egress between cluster
+                  nodes is permitted, allowing CNIs other than Calico to be used.
+                type: boolean
               apiServerFloatingIP:
                 description: APIServerFloatingIP is the floatingIP which will be associated
                   to the APIServer. The floatingIP will be created if it not already
@@ -1553,12 +1559,12 @@ spec:
                   properties are mandatory: APIServerFloatingIP, APIServerPort'
                 type: boolean
               managedSecurityGroups:
-                description: 'ManagedSecurityGroups defines that kubernetes manages
-                  the OpenStack security groups for now, that means that we''ll create
-                  security group allows traffic to/from machines belonging to that
-                  group based on Calico CNI plugin default network requirements: BGP
-                  and IP-in-IP for master node(s) and worker node(s) respectively.
-                  In the future, we could make this more flexible.'
+                description: ManagedSecurityGroups determines whether OpenStack security
+                  groups for the cluster will be managed by the OpenStack provider
+                  or whether pre-existing security groups will be specified as part
+                  of the configuration. By default, the managed security groups have
+                  rules that allow the Kubelet, etcd, the Kubernetes API server and
+                  the Calico CNI plugin to function correctly.
                 type: boolean
               network:
                 description: If NodeCIDR cannot be set this can be used to detect

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
@@ -50,6 +50,13 @@ spec:
                     description: OpenStackClusterSpec defines the desired state of
                       OpenStackCluster.
                     properties:
+                      allowAllInClusterTraffic:
+                        description: AllowAllInClusterTraffic is only used when managed
+                          security groups are in use. If set to true, the rules for
+                          the managed security groups are configured so that all ingress
+                          and egress between cluster nodes is permitted, allowing
+                          CNIs other than Calico to be used.
+                        type: boolean
                       apiServerFloatingIP:
                         description: APIServerFloatingIP is the floatingIP which will
                           be associated to the APIServer. The floatingIP will be created
@@ -544,13 +551,13 @@ spec:
                           APIServerPort'
                         type: boolean
                       managedSecurityGroups:
-                        description: 'ManagedSecurityGroups defines that kubernetes
-                          manages the OpenStack security groups for now, that means
-                          that we''ll create security group allows traffic to/from
-                          machines belonging to that group based on Calico CNI plugin
-                          default network requirements: BGP and IP-in-IP for master
-                          node(s) and worker node(s) respectively. In the future,
-                          we could make this more flexible.'
+                        description: ManagedSecurityGroups determines whether OpenStack
+                          security groups for the cluster will be managed by the OpenStack
+                          provider or whether pre-existing security groups will be
+                          specified as part of the configuration. By default, the
+                          managed security groups have rules that allow the Kubelet,
+                          etcd, the Kubernetes API server and the Calico CNI plugin
+                          to function correctly.
                         type: boolean
                       network:
                         description: If NodeCIDR cannot be set this can be used to

--- a/pkg/cloud/services/networking/securitygroups.go
+++ b/pkg/cloud/services/networking/securitygroups.go
@@ -134,145 +134,202 @@ func (s *Service) generateDesiredSecGroups(openStackCluster *infrav1.OpenStackCl
 		}
 	}
 
-	controlPlaneRules := append(
-		[]infrav1.SecurityGroupRule{
-			{
-				Description:  "Kubernetes API",
-				Direction:    "ingress",
-				EtherType:    "IPv4",
-				PortRangeMin: 6443,
-				PortRangeMax: 6443,
-				Protocol:     "tcp",
-			},
-			{
-				Description:   "Etcd",
-				Direction:     "ingress",
-				EtherType:     "IPv4",
-				PortRangeMin:  2379,
-				PortRangeMax:  2380,
-				Protocol:      "tcp",
-				RemoteGroupID: remoteGroupIDSelf,
-			},
-			{
-				// kubeadm says this is needed
-				Description:   "Kubelet API",
-				Direction:     "ingress",
-				EtherType:     "IPv4",
-				PortRangeMin:  10250,
-				PortRangeMax:  10250,
-				Protocol:      "tcp",
-				RemoteGroupID: remoteGroupIDSelf,
-			},
-			{
-				// This is needed to support metrics-server deployments
-				Description:   "Kubelet API",
-				Direction:     "ingress",
-				EtherType:     "IPv4",
-				PortRangeMin:  10250,
-				PortRangeMax:  10250,
-				Protocol:      "tcp",
-				RemoteGroupID: secWorkerGroupID,
-			},
-			{
-				Description:   "BGP (calico)",
-				Direction:     "ingress",
-				EtherType:     "IPv4",
-				PortRangeMin:  179,
-				PortRangeMax:  179,
-				Protocol:      "tcp",
-				RemoteGroupID: remoteGroupIDSelf,
-			},
-			{
-				Description:   "BGP (calico)",
-				Direction:     "ingress",
-				EtherType:     "IPv4",
-				PortRangeMin:  179,
-				PortRangeMax:  179,
-				Protocol:      "tcp",
-				RemoteGroupID: secWorkerGroupID,
-			},
-			{
-				Description:   "IP-in-IP (calico)",
-				Direction:     "ingress",
-				EtherType:     "IPv4",
-				Protocol:      "4",
-				RemoteGroupID: remoteGroupIDSelf,
-			},
-			{
-				Description:   "IP-in-IP (calico)",
-				Direction:     "ingress",
-				EtherType:     "IPv4",
-				Protocol:      "4",
-				RemoteGroupID: secWorkerGroupID,
-			},
+	// Start with the default rules
+	controlPlaneRules := append([]infrav1.SecurityGroupRule{}, defaultRules...)
+	workerRules := append([]infrav1.SecurityGroupRule{}, defaultRules...)
+
+	// Allow all traffic, including from outside the cluster, to access the API
+	controlPlaneRules = append(controlPlaneRules,
+		infrav1.SecurityGroupRule{
+			Description:  "Kubernetes API",
+			Direction:    "ingress",
+			EtherType:    "IPv4",
+			PortRangeMin: 6443,
+			PortRangeMax: 6443,
+			Protocol:     "tcp",
 		},
-		defaultRules...,
+	)
+	// Allow all traffic, including from outside the cluster, to access node port services
+	workerRules = append(workerRules,
+		infrav1.SecurityGroupRule{
+			Description:  "Node Port Services",
+			Direction:    "ingress",
+			EtherType:    "IPv4",
+			PortRangeMin: 30000,
+			PortRangeMax: 32767,
+			Protocol:     "tcp",
+		},
 	)
 
-	workerRules := append(
-		[]infrav1.SecurityGroupRule{
-			{
-				Description:  "Node Port Services",
-				Direction:    "ingress",
-				EtherType:    "IPv4",
-				PortRangeMin: 30000,
-				PortRangeMax: 32767,
-				Protocol:     "tcp",
-			},
-			{
-				// This is needed to support metrics-server deployments
-				Description:   "Kubelet API",
-				Direction:     "ingress",
-				EtherType:     "IPv4",
-				PortRangeMin:  10250,
-				PortRangeMax:  10250,
-				Protocol:      "tcp",
-				RemoteGroupID: remoteGroupIDSelf,
-			},
-			{
-				Description:   "Kubelet API",
-				Direction:     "ingress",
-				EtherType:     "IPv4",
-				PortRangeMin:  10250,
-				PortRangeMax:  10250,
-				Protocol:      "tcp",
-				RemoteGroupID: secControlPlaneGroupID,
-			},
-			{
-				Description:   "BGP (calico)",
-				Direction:     "ingress",
-				EtherType:     "IPv4",
-				PortRangeMin:  179,
-				PortRangeMax:  179,
-				Protocol:      "tcp",
-				RemoteGroupID: remoteGroupIDSelf,
-			},
-			{
-				Description:   "BGP (calico)",
-				Direction:     "ingress",
-				EtherType:     "IPv4",
-				PortRangeMin:  179,
-				PortRangeMax:  179,
-				Protocol:      "tcp",
-				RemoteGroupID: secControlPlaneGroupID,
-			},
-			{
-				Description:   "IP-in-IP (calico)",
-				Direction:     "ingress",
-				EtherType:     "IPv4",
-				Protocol:      "4",
-				RemoteGroupID: remoteGroupIDSelf,
-			},
-			{
-				Description:   "IP-in-IP (calico)",
-				Direction:     "ingress",
-				EtherType:     "IPv4",
-				Protocol:      "4",
-				RemoteGroupID: secControlPlaneGroupID,
-			},
-		},
-		defaultRules...,
-	)
+	if openStackCluster.Spec.AllowAllInClusterTraffic {
+		// Permit all ingress from the cluster security groups
+		controlPlaneRules = append(controlPlaneRules,
+			[]infrav1.SecurityGroupRule{
+				{
+					Description:   "In-cluster Ingress",
+					Direction:     "ingress",
+					EtherType:     "IPv4",
+					PortRangeMin:  0,
+					PortRangeMax:  0,
+					Protocol:      "",
+					RemoteGroupID: remoteGroupIDSelf,
+				},
+				{
+					Description:   "In-cluster Ingress",
+					Direction:     "ingress",
+					EtherType:     "IPv4",
+					PortRangeMin:  0,
+					PortRangeMax:  0,
+					Protocol:      "",
+					RemoteGroupID: secWorkerGroupID,
+				},
+			}...,
+		)
+		workerRules = append(workerRules,
+			[]infrav1.SecurityGroupRule{
+				{
+					Description:   "In-cluster Ingress",
+					Direction:     "ingress",
+					EtherType:     "IPv4",
+					PortRangeMin:  0,
+					PortRangeMax:  0,
+					Protocol:      "",
+					RemoteGroupID: remoteGroupIDSelf,
+				},
+				{
+					Description:   "In-cluster Ingress",
+					Direction:     "ingress",
+					EtherType:     "IPv4",
+					PortRangeMin:  0,
+					PortRangeMax:  0,
+					Protocol:      "",
+					RemoteGroupID: secControlPlaneGroupID,
+				},
+			}...,
+		)
+	} else {
+		// Permit traffic for etcd, kubelet and Calico only
+		controlPlaneRules = append(controlPlaneRules,
+			[]infrav1.SecurityGroupRule{
+				{
+					Description:   "Etcd",
+					Direction:     "ingress",
+					EtherType:     "IPv4",
+					PortRangeMin:  2379,
+					PortRangeMax:  2380,
+					Protocol:      "tcp",
+					RemoteGroupID: remoteGroupIDSelf,
+				},
+				{
+					// kubeadm says this is needed
+					Description:   "Kubelet API",
+					Direction:     "ingress",
+					EtherType:     "IPv4",
+					PortRangeMin:  10250,
+					PortRangeMax:  10250,
+					Protocol:      "tcp",
+					RemoteGroupID: remoteGroupIDSelf,
+				},
+				{
+					// This is needed to support metrics-server deployments
+					Description:   "Kubelet API",
+					Direction:     "ingress",
+					EtherType:     "IPv4",
+					PortRangeMin:  10250,
+					PortRangeMax:  10250,
+					Protocol:      "tcp",
+					RemoteGroupID: secWorkerGroupID,
+				},
+				{
+					Description:   "BGP (calico)",
+					Direction:     "ingress",
+					EtherType:     "IPv4",
+					PortRangeMin:  179,
+					PortRangeMax:  179,
+					Protocol:      "tcp",
+					RemoteGroupID: remoteGroupIDSelf,
+				},
+				{
+					Description:   "BGP (calico)",
+					Direction:     "ingress",
+					EtherType:     "IPv4",
+					PortRangeMin:  179,
+					PortRangeMax:  179,
+					Protocol:      "tcp",
+					RemoteGroupID: secWorkerGroupID,
+				},
+				{
+					Description:   "IP-in-IP (calico)",
+					Direction:     "ingress",
+					EtherType:     "IPv4",
+					Protocol:      "4",
+					RemoteGroupID: remoteGroupIDSelf,
+				},
+				{
+					Description:   "IP-in-IP (calico)",
+					Direction:     "ingress",
+					EtherType:     "IPv4",
+					Protocol:      "4",
+					RemoteGroupID: secWorkerGroupID,
+				},
+			}...,
+		)
+		workerRules = append(workerRules,
+			[]infrav1.SecurityGroupRule{
+				{
+					// This is needed to support metrics-server deployments
+					Description:   "Kubelet API",
+					Direction:     "ingress",
+					EtherType:     "IPv4",
+					PortRangeMin:  10250,
+					PortRangeMax:  10250,
+					Protocol:      "tcp",
+					RemoteGroupID: remoteGroupIDSelf,
+				},
+				{
+					Description:   "Kubelet API",
+					Direction:     "ingress",
+					EtherType:     "IPv4",
+					PortRangeMin:  10250,
+					PortRangeMax:  10250,
+					Protocol:      "tcp",
+					RemoteGroupID: secControlPlaneGroupID,
+				},
+				{
+					Description:   "BGP (calico)",
+					Direction:     "ingress",
+					EtherType:     "IPv4",
+					PortRangeMin:  179,
+					PortRangeMax:  179,
+					Protocol:      "tcp",
+					RemoteGroupID: remoteGroupIDSelf,
+				},
+				{
+					Description:   "BGP (calico)",
+					Direction:     "ingress",
+					EtherType:     "IPv4",
+					PortRangeMin:  179,
+					PortRangeMax:  179,
+					Protocol:      "tcp",
+					RemoteGroupID: secControlPlaneGroupID,
+				},
+				{
+					Description:   "IP-in-IP (calico)",
+					Direction:     "ingress",
+					EtherType:     "IPv4",
+					Protocol:      "4",
+					RemoteGroupID: remoteGroupIDSelf,
+				},
+				{
+					Description:   "IP-in-IP (calico)",
+					Direction:     "ingress",
+					EtherType:     "IPv4",
+					Protocol:      "4",
+					RemoteGroupID: secControlPlaneGroupID,
+				},
+			}...,
+		)
+	}
 
 	if openStackCluster.Spec.Bastion != nil && openStackCluster.Spec.Bastion.Enabled {
 		controlPlaneRules = append(controlPlaneRules,

--- a/test/e2e/data/infrastructure-openstack/cluster-template-external-cloud-provider.yaml
+++ b/test/e2e/data/infrastructure-openstack/cluster-template-external-cloud-provider.yaml
@@ -31,6 +31,7 @@ spec:
     kind: Secret
   managedAPIServerLoadBalancer: true
   managedSecurityGroups: true
+  allowAllInClusterTraffic: true
   nodeCidr: 10.6.0.0/24
   dnsNameservers:
   - ${OPENSTACK_DNS_NAMESERVERS}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR implements an additional flag that allows the creation of managed security groups that permit all in-cluster traffic. Note that all traffic from outside the cluster (except API server and NodePort services) is still blocked.

This makes it much easier to deploy a CNI other than Calico while still using managed security groups.

In the future, we could look at maintaining rules for multiple CNIs which can be selected from, or allowing users to specify custom rules for the managed security groups. However I think this represents a good catch-all.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #995 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
