### PR TITLE
🏃 Move deletePorts back to compute package

### DIFF
--- a/pkg/cloud/services/networking/port.go
+++ b/pkg/cloud/services/networking/port.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsbinding"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsecurity"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
@@ -222,15 +221,6 @@ func (s *Service) DeletePort(eventObject runtime.Object, portID string) error {
 	}
 
 	record.Eventf(eventObject, "SuccessfulDeletePort", "Deleted port %s with id %s", port.Name, port.ID)
-	return nil
-}
-
-func (s *Service) DeletePorts(eventObject runtime.Object, nets []servers.Network) error {
-	for _, n := range nets {
-		if err := s.DeletePort(eventObject, n.Port); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 


### PR DESCRIPTION
Following up on @mdbooth's review of #950, this moves the `deletePorts` function from the networking package back to the compute package where it can be made a private function.

**What this PR does / why we need it**: fixes a nit from a review of #950 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:

- [x] squashed commits

/hold
