### PR TITLE
🏃 Standardize metrics in networking package

### DIFF
--- a/pkg/cloud/services/networking/trunk.go
+++ b/pkg/cloud/services/networking/trunk.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/cluster-api/util"
 
-	"sigs.k8s.io/cluster-api-provider-openstack/pkg/metrics"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/record"
 	capoerrors "sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/errors"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/names"
@@ -80,11 +79,10 @@ func (s *Service) getOrCreateTrunk(eventObject runtime.Object, clusterName, trun
 }
 
 func (s *Service) replaceAllAttributesTags(eventObject runtime.Object, trunkID string, tags []string) error {
-	mc := metrics.NewMetricPrometheusContext("trunk", "update")
 	_, err := s.client.ReplaceAllAttributesTags("trunks", trunkID, attributestags.ReplaceAllOpts{
 		Tags: tags,
 	})
-	if mc.ObserveRequest(err) != nil {
+	if err != nil {
 		record.Warnf(eventObject, "FailedReplaceAllAttributesTags", "Failed to replace all attributestags, trunk %s: %v", trunkID, err)
 		return err
 	}


### PR DESCRIPTION
This ensures that all calls made by the client in the networking package have a Prometheus metric associated with them.

Delete and Get calls are standardized to not record an error in the metrics if the resource in OpenStack is not found. (However, the not found error will still be returned by the function as nil, err.)

Finally, the replace all attributes tags call is no longer recorded as a trunk update event.

**What this PR does / why we need it**: based off fixing a comment in @mdbooth 's review of #950.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Partially fix #997 (for networking related calls, but compute related calls are still TODO.)

**TODOs**:
- [x] squashed commits

/hold
