### PR TITLE
✨ getOrCreatePort: add support to configure QoS profile ID on ports

### DIFF
--- a/api/v1alpha4/types.go
+++ b/api/v1alpha4/types.go
@@ -148,6 +148,9 @@ type PortOpts struct {
 	// information to the plug-in.
 	Profile map[string]string `json:"profile,omitempty"`
 
+	// A string for the QoS policy ID of the network where this port is plugged.
+	QoSPolicyID string `json:"qosPolicyId,omitempty"`
+
 	// DisablePortSecurity enables or disables the port security when set.
 	// When not set, it takes the value of the corresponding field at the network level.
 	DisablePortSecurity *bool `json:"disablePortSecurity,omitempty"`

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -1337,6 +1337,10 @@ spec:
                               type: object
                             projectId:
                               type: string
+                            qosPolicyId:
+                              description: A string for the QoS policy ID of the network
+                                where this port is plugged.
+                              type: string
                             securityGroups:
                               items:
                                 type: string
@@ -1806,6 +1810,10 @@ spec:
                               type: object
                             projectId:
                               type: string
+                            qosPolicyId:
+                              description: A string for the QoS policy ID of the network
+                                where this port is plugged.
+                              type: string
                             securityGroups:
                               items:
                                 type: string
@@ -2086,6 +2094,10 @@ spec:
                         type: object
                       projectId:
                         type: string
+                      qosPolicyId:
+                        description: A string for the QoS policy ID of the network
+                          where this port is plugged.
+                        type: string
                       securityGroups:
                         items:
                           type: string
@@ -2277,6 +2289,10 @@ spec:
                           interface (VIF) port-specific information to the plug-in.
                         type: object
                       projectId:
+                        type: string
+                      qosPolicyId:
+                        description: A string for the QoS policy ID of the network
+                          where this port is plugged.
                         type: string
                       securityGroups:
                         items:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
@@ -324,6 +324,10 @@ spec:
                                       type: object
                                     projectId:
                                       type: string
+                                    qosPolicyId:
+                                      description: A string for the QoS policy ID
+                                        of the network where this port is plugged.
+                                      type: string
                                     securityGroups:
                                       items:
                                         type: string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
@@ -608,6 +608,10 @@ spec:
                       type: object
                     projectId:
                       type: string
+                    qosPolicyId:
+                      description: A string for the QoS policy ID of the network where
+                        this port is plugged.
+                      type: string
                     securityGroups:
                       items:
                         type: string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
@@ -558,6 +558,10 @@ spec:
                               type: object
                             projectId:
                               type: string
+                            qosPolicyId:
+                              description: A string for the QoS policy ID of the network
+                                where this port is plugged.
+                              type: string
                             securityGroups:
                               items:
                                 type: string

--- a/docs/book/src/clusteropenstack/configuration.md
+++ b/docs/book/src/clusteropenstack/configuration.md
@@ -233,7 +233,7 @@ spec:
 
 ## Ports
 
-A server can also be connected to networks by describing what ports to create. Describing a server's connection with `ports` allows for finer and more advanced configuration. For example, you can specify per-port security groups, fixed IPs, VNIC type or profile.
+A server can also be connected to networks by describing what ports to create. Describing a server's connection with `ports` allows for finer and more advanced configuration. For example, you can specify per-port security groups, fixed IPs, VNIC type, QoS profile, or profile.
 
 ```yaml
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
@@ -254,6 +254,7 @@ spec:
     profile:
       capabilities:
         - <capability>
+    qosPolicyId: <your-qos-policy-id>
 ```
 
 Any such ports are created in addition to ports used for connections to networks or subnets.

--- a/hack/ci/devstack-on-aws-project-install.sh
+++ b/hack/ci/devstack-on-aws-project-install.sh
@@ -208,6 +208,9 @@ main() {
   openstack quota set --cores 32 demo
   openstack quota set --secgroups 50 demo
 
+  # Create a Neutron QoS policy
+  openstack network qos policy create --share demo-policy
+  
   export OS_TENANT_NAME=demo
   export OS_USERNAME=demo
   export OS_PROJECT_NAME=demo

--- a/hack/ci/devstack-on-gce-project-install.sh
+++ b/hack/ci/devstack-on-gce-project-install.sh
@@ -226,6 +226,9 @@ main() {
   openstack quota set --cores 32 demo
   openstack quota set --secgroups 50 demo
 
+  # Create a Neutron QoS policy
+  openstack network qos policy create --share demo-policy
+
   export OS_TENANT_NAME=demo
   export OS_USERNAME=demo
   export OS_PROJECT_NAME=demo

--- a/pkg/cloud/services/networking/port.go
+++ b/pkg/cloud/services/networking/port.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsbinding"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsecurity"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/policies"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/cluster-api/util"
@@ -139,6 +140,14 @@ func (s *Service) GetOrCreatePort(eventObject runtime.Object, clusterName string
 		SecurityGroups:      securityGroups,
 		AllowedAddressPairs: addressPairs,
 		FixedIPs:            fixedIPs,
+	}
+
+	if portOpts.QoSPolicyID != "" {
+		policyID := portOpts.QoSPolicyID
+		createOpts = policies.PortCreateOptsExt{
+			CreateOptsBuilder: createOpts,
+			QoSPolicyID:       policyID,
+		}
 	}
 
 	if portOpts.DisablePortSecurity != nil {

--- a/test/e2e/data/infrastructure-openstack/cluster-template-multi-network.yaml
+++ b/test/e2e/data/infrastructure-openstack/cluster-template-multi-network.yaml
@@ -122,6 +122,7 @@ spec:
           networkId: "${CLUSTER_EXTRA_NET_1}"
         - description: "Extra Network 2"
           networkId: "${CLUSTER_EXTRA_NET_2}"
+          qosPolicyId: "${CLUSTER_QOS_POLICY_ID}"
 ---
 apiVersion: cluster.x-k8s.io/v1alpha4
 kind: MachineDeployment

--- a/test/e2e/suites/e2e/e2e_test.go
+++ b/test/e2e/suites/e2e/e2e_test.go
@@ -201,6 +201,7 @@ var _ = Describe("e2e tests", func() {
 
 	Describe("Workload cluster (multiple attached networks)", func() {
 		var extraNet1, extraNet2 *networks.Network
+		var policyID string
 
 		BeforeEach(func() {
 			var err error
@@ -229,6 +230,12 @@ var _ = Describe("e2e tests", func() {
 
 			os.Setenv("CLUSTER_EXTRA_NET_1", extraNet1.ID)
 			os.Setenv("CLUSTER_EXTRA_NET_2", extraNet2.ID)
+
+			policyName := "demo-policy"
+			policyID, err = shared.GetOpenStackQosPolicyID(e2eCtx, policyName)
+			Expect(err).To(BeNil())
+			Expect(policyID).NotTo(BeNil(), "Neutron QoS policy does not exist: %s", policyName)
+			os.Setenv("CLUSTER_QOS_POLICY_ID", policyID)
 		})
 
 		It("should attach all machines to multiple networks", func() {


### PR DESCRIPTION
**What this PR does / why we need it:**

Adding support to configure Neutron ports with a specific QoS profile
ID:
https://docs.openstack.org/api-ref/network/v2/?expanded=show-port-details-detail#id54

This feature is already supported by Gophercloud:
https://github.com/gophercloud/gophercloud/blob/master/openstack/networking/v2/extensions/qos/policies/requests.go


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1007
