### PR TITLE
✨Allow update for some param only first time update

### DIFF
--- a/api/v1alpha4/openstackcluster_webhook.go
+++ b/api/v1alpha4/openstackcluster_webhook.go
@@ -88,9 +88,15 @@ func (r *OpenStackCluster) ValidateUpdate(old runtime.Object) error {
 	newOpenStackClusterSpec := newOpenStackCluster["spec"].(map[string]interface{})
 	oldOpenStackClusterSpec := oldOpenStackCluster["spec"].(map[string]interface{})
 
-	// allow changes to ControlPlaneEndpoint
-	delete(oldOpenStackClusterSpec, "controlPlaneEndpoint")
-	delete(newOpenStackClusterSpec, "controlPlaneEndpoint")
+	// get controlPlaneEndpoint, something like {"host":"", "port":""}
+	cpe := oldOpenStackClusterSpec["controlPlaneEndpoint"].(map[string]interface{})
+
+	// allow change only for the first time
+	host, ok := cpe["host"].(string)
+	if ok && len(host) == 0 {
+		delete(oldOpenStackClusterSpec, "controlPlaneEndpoint")
+		delete(newOpenStackClusterSpec, "controlPlaneEndpoint")
+	}
 
 	if !reflect.DeepEqual(oldOpenStackClusterSpec, newOpenStackClusterSpec) {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec"), "cannot be modified"))

--- a/api/v1alpha4/openstackmachine_webhook.go
+++ b/api/v1alpha4/openstackmachine_webhook.go
@@ -88,13 +88,17 @@ func (r *OpenStackMachine) ValidateUpdate(old runtime.Object) error {
 	newOpenStackMachineSpec := newOpenStackMachine["spec"].(map[string]interface{})
 	oldOpenStackMachineSpec := oldOpenStackMachine["spec"].(map[string]interface{})
 
-	// allow changes to providerID
-	delete(oldOpenStackMachineSpec, "providerID")
-	delete(newOpenStackMachineSpec, "providerID")
+	// allow changes to providerID once
+	if oldOpenStackMachineSpec["providerID"] == nil {
+		delete(oldOpenStackMachineSpec, "providerID")
+		delete(newOpenStackMachineSpec, "providerID")
+	}
 
-	// allow changes to instanceID
-	delete(oldOpenStackMachineSpec, "instanceID")
-	delete(newOpenStackMachineSpec, "instanceID")
+	// allow changes to instanceID once
+	if oldOpenStackMachineSpec["instanceID"] == nil {
+		delete(oldOpenStackMachineSpec, "instanceID")
+		delete(newOpenStackMachineSpec, "instanceID")
+	}
 
 	if !reflect.DeepEqual(oldOpenStackMachineSpec, newOpenStackMachineSpec) {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec"), "cannot be modified"))


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

Only allow the field's update at first time, as that will be updated by CAPI internally,
after that, customer's update will be rejected..

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
follow up of #1006 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
