### PR TITLE
✨ controllers: replace context.TODO with real context objects

### DIFF
--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -282,7 +282,7 @@ func (r *OpenStackMachineReconciler) reconcileNormal(ctx context.Context, logger
 		logger.Info("Bootstrap data secret reference is not yet available")
 		return ctrl.Result{}, nil
 	}
-	userData, err := r.getBootstrapData(machine, openStackMachine)
+	userData, err := r.getBootstrapData(ctx, machine, openStackMachine)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -440,7 +440,7 @@ func (r *OpenStackMachineReconciler) OpenStackClusterToOpenStackMachines(ctx con
 			return nil
 		}
 
-		cluster, err := util.GetOwnerCluster(context.TODO(), r.Client, c.ObjectMeta)
+		cluster, err := util.GetOwnerCluster(ctx, r.Client, c.ObjectMeta)
 		switch {
 		case apierrors.IsNotFound(err) || cluster == nil:
 			log.V(4).Info("Cluster for OpenStackCluster not found, skipping mapping.")
@@ -450,18 +450,18 @@ func (r *OpenStackMachineReconciler) OpenStackClusterToOpenStackMachines(ctx con
 			return nil
 		}
 
-		return r.requestsForCluster(log, cluster.Namespace, cluster.Name)
+		return r.requestsForCluster(ctx, log, cluster.Namespace, cluster.Name)
 	}
 }
 
-func (r *OpenStackMachineReconciler) getBootstrapData(machine *clusterv1.Machine, openStackMachine *infrav1.OpenStackMachine) (string, error) {
+func (r *OpenStackMachineReconciler) getBootstrapData(ctx context.Context, machine *clusterv1.Machine, openStackMachine *infrav1.OpenStackMachine) (string, error) {
 	if machine.Spec.Bootstrap.DataSecretName == nil {
 		return "", errors.New("error retrieving bootstrap data: linked Machine's bootstrap.dataSecretName is nil")
 	}
 
 	secret := &corev1.Secret{}
 	key := types.NamespacedName{Namespace: machine.Namespace, Name: *machine.Spec.Bootstrap.DataSecretName}
-	if err := r.Client.Get(context.TODO(), key, secret); err != nil {
+	if err := r.Client.Get(ctx, key, secret); err != nil {
 		return "", errors.Wrapf(err, "failed to retrieve bootstrap data secret for Openstack Machine %s/%s", machine.Namespace, openStackMachine.Name)
 	}
 
@@ -489,14 +489,14 @@ func (r *OpenStackMachineReconciler) requeueOpenStackMachinesForUnpausedCluster(
 			return nil
 		}
 
-		return r.requestsForCluster(log, c.Namespace, c.Name)
+		return r.requestsForCluster(ctx, log, c.Namespace, c.Name)
 	}
 }
 
-func (r *OpenStackMachineReconciler) requestsForCluster(log logr.Logger, namespace, name string) []ctrl.Request {
+func (r *OpenStackMachineReconciler) requestsForCluster(ctx context.Context, log logr.Logger, namespace, name string) []ctrl.Request {
 	labels := map[string]string{clusterv1.ClusterLabelName: name}
 	machineList := &clusterv1.MachineList{}
-	if err := r.Client.List(context.TODO(), machineList, client.InNamespace(namespace), client.MatchingLabels(labels)); err != nil {
+	if err := r.Client.List(ctx, machineList, client.InNamespace(namespace), client.MatchingLabels(labels)); err != nil {
 		log.Error(err, "Failed to get owned Machines, skipping mapping.")
 		return nil
 	}


### PR DESCRIPTION
Signed-off-by: Schlotter, Christian <christian.schlotter@daimler.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

Fixes occurencies of `context.TODO()` and replaces it with the real context object.

I left out the `test/e2e` directory :-)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits

/hold

<sup>
Christian Schlotter <christian.schlotter@daimler.com>, Daimler TSS GmbH, 
<a href="https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md">Provider Information</a>
</sup>