### PR TITLE
Validate Netlify deployment after default branch change

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,27 +1,27 @@
 # Netlify build instructions
 [build]
-command = "make -C docs/book build"
-publish = "docs/book/book"
+    command = "make -C docs/book build"
+    publish = "docs/book/book"
 
 [build.environment]
-GO_VERSION = "1.16"
+    GO_VERSION = "1.16"
 
 # Standard Netlify redirects
 [[redirects]]
-from = "https://main--kubernetes-sigs-cluster-api-openstack.netlify.com/*"
-to = "https://main.cluster-api-openstack.sigs.k8s.io/:splat"
-status = 301
-force = true
+    from = "https://main--kubernetes-sigs-cluster-api-openstack.netlify.com/*"
+    to = "https://main.cluster-api-openstack.sigs.k8s.io/:splat"
+    status = 301
+    force = true
 
 [[redirects]]
-from = "http://main--kubernetes-sigs-cluster-api-openstack.netlify.com/*"
-to = "http://main.cluster-api-openstack.sigs.k8s.io/:splat"
-status = 301
-force = true
+    from = "http://main--kubernetes-sigs-cluster-api-openstack.netlify.com/*"
+    to = "http://main.cluster-api-openstack.sigs.k8s.io/:splat"
+    status = 301
+    force = true
 
 # HTTP-to-HTTPS rules
 [[redirects]]
-from = "http://main.cluster-api-openstack.sigs.k8s.io/*"
-to = "https://main.cluster-api-openstack.sigs.k8s.io/:splat"
-status = 301
-force = true
+    from = "http://main.cluster-api-openstack.sigs.k8s.io/*"
+    to = "https://main.cluster-api-openstack.sigs.k8s.io/:splat"
+    status = 301
+    force = true


### PR DESCRIPTION
The [current Netlify deployment](https://app.netlify.com/sites/kubernetes-sigs-cluster-api-openstack/deploys) is the latest `master` commit. After this PR has been merged our Book will be updated also.

part of #855 
xref: https://github.com/kubernetes/org/issues/2883#issuecomment-956414849