### PR TITLE
🏃Remove most uses of submakes in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -357,21 +357,13 @@ IMAGE_PATCH_DIR := $(ARTIFACTS)/image-patch
 $(IMAGE_PATCH_DIR): $(ARTIFACTS)
 	mkdir -p $@
 
-.PHONY: $(RELEASE_DIR)/$(MANIFEST_FILE).yaml
-$(RELEASE_DIR)/$(MANIFEST_FILE).yaml:
-	$(MAKE) compiled-manifest \
-		PROVIDER=$(MANIFEST_FILE) \
-		OLD_IMG=$(CONTROLLER_ORIGINAL_IMG) \
-		MANIFEST_IMG=$(CONTROLLER_IMG) \
-		CONTROLLER_NAME=$(CONTROLLER_NAME) \
-		PROVIDER_CONFIG_DIR=$(CONFIG_DIR) \
-		NAMESPACE=$(NAMESPACE)
-
+$(RELEASE_DIR)/$(MANIFEST_FILE).yaml: compiled-manifest
 .PHONY: compiled-manifest
-compiled-manifest: $(RELEASE_DIR) $(KUSTOMIZE)
-	$(MAKE) image-patch-source-manifest
-	$(MAKE) image-patch-pull-policy
-	$(MAKE) image-patch-kustomization
+compiled-manifest: PROVIDER=$(MANIFEST_FILE)
+compiled-manifest: OLD_IMG=$(CONTROLLER_ORIGINAL_IMG)
+compiled-manifest: MANIFEST_IMG=$(CONTROLLER_IMG)
+compiled-manifest: PROVIDER_CONFIG_DIR=$(CONFIG_DIR)
+compiled-manifest: $(KUSTOMIZE) image-patch-source-manifest image-patch-pull-policy image-patch-kustomization | $(RELEASE_DIR)
 	$(KUSTOMIZE) build $(IMAGE_PATCH_DIR)/$(PROVIDER) > $(RELEASE_DIR)/$(PROVIDER).yaml
 
 .PHONY: image-patch-source-manifest

--- a/Makefile
+++ b/Makefile
@@ -318,13 +318,11 @@ release-manifests: compiled-manifest
 .PHONY: release-staging
 release-staging: docker-build-all docker-push-all release-alias-tag staging-manifests upload-staging-artifacts
 
+## Tags and push container images to the staging bucket. Example image tag: capi-openstack-controller:nightly_master_20210121
 .PHONY: release-staging-nightly
-release-staging-nightly: ## Tags and push container images to the staging bucket. Example image tag: capi-openstack-controller:nightly_master_20210121
-	$(eval NEW_RELEASE_ALIAS_TAG := nightly_$(RELEASE_ALIAS_TAG)_$(shell date +'%Y%m%d'))
-	echo $(NEW_RELEASE_ALIAS_TAG)
-	$(MAKE) release-alias-tag TAG=$(RELEASE_ALIAS_TAG) RELEASE_ALIAS_TAG=$(NEW_RELEASE_ALIAS_TAG)
-	$(MAKE) staging-manifests RELEASE_ALIAS_TAG=$(NEW_RELEASE_ALIAS_TAG)
-	$(MAKE) upload-staging-artifacts RELEASE_ALIAS_TAG=$(NEW_RELEASE_ALIAS_TAG)
+release-staging-nightly: RELEASE_ALIAS_TAG := nightly_$(RELEASE_ALIAS_TAG)_$(shell date +'%Y%m%d')
+release-staging-nightly: TAG=$(RELEASE_ALIAS_TAG)
+release-staging-nightly: release-alias-tag staging-manifests upload-staging-artifacts
 
 .PHONY: upload-staging-artifacts
 upload-staging-artifacts: ## Upload release artifacts to the staging bucket

--- a/Makefile
+++ b/Makefile
@@ -148,9 +148,10 @@ CONFORMANCE_GINKGO_ARGS ?= -stream
 test-conformance: $(GINKGO) $(KIND) $(KUSTOMIZE) e2e-image ## Run clusterctl based conformance test on workload cluster (requires Docker).
 	time $(GINKGO) -trace -progress -v -tags=e2e -focus="conformance" $(CONFORMANCE_GINKGO_ARGS) ./test/e2e/suites/conformance/... -- -config-path="$(E2E_CONF_PATH)" -artifacts-folder="$(ARTIFACTS)" --data-folder="$(E2E_DATA_DIR)" $(CONFORMANCE_E2E_ARGS)
 
-
-test-conformance-fast: ## Run clusterctl based conformance test on workload cluster (requires Docker) using a subset of the conformance suite in parallel.
-	$(MAKE) test-conformance CONFORMANCE_E2E_ARGS="-kubetest.config-file=$(KUBETEST_FAST_CONF_PATH) -kubetest.ginkgo-nodes=5 $(E2E_ARGS)"
+## Run clusterctl based conformance test on workload cluster (requires Docker) using a subset of the conformance suite in parallel.
+.PHONY: test-conformance-fast
+test-conformance-fast: CONFORMANCE_E2E_ARGS="-kubetest.config-file=$(KUBETEST_FAST_CONF_PATH) -kubetest.ginkgo-nodes=5 $(E2E_ARGS)"
+test-conformance-fast: test-conformance
 
 ## --------------------------------------
 ## Binaries

--- a/Makefile
+++ b/Makefile
@@ -311,8 +311,9 @@ set-manifest-pull-policy:
 	sed -i'' -e 's@imagePullPolicy: .*@imagePullPolicy: '"$(PULL_POLICY)"'@' ./config/default/manager_pull_policy.yaml
 
 .PHONY: release-manifests
-release-manifests:
-	$(MAKE) $(RELEASE_DIR)/$(MANIFEST_FILE).yaml TAG=$(RELEASE_TAG) PULL_POLICY=IfNotPresent
+release-manifests: TAG=$(RELEASE_TAG)
+release-manifests: PULL_POLICY=IfNotPresent
+release-manifests: compiled-manifest
 	# Add metadata to the release artifacts
 	cp metadata.yaml $(RELEASE_DIR)/metadata.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -195,9 +195,8 @@ modules: ## Runs go mod to ensure proper vendoring.
 generate: generate-go generate-manifests
 
 .PHONY: generate-go
-generate-go: $(MOCKGEN)
+generate-go: $(MOCKGEN) $(CONTROLLER_GEN) $(CONVERSION_GEN) $(DEFAULTER_GEN)
 	go generate ./...
-	$(MAKE) -B $(CONTROLLER_GEN) $(CONVERSION_GEN) $(DEFAULTER_GEN)
 	$(CONTROLLER_GEN) \
 		paths=./api/... \
 		object:headerFile=./hack/boilerplate/boilerplate.generatego.txt

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,8 @@ BUCKET ?= $(STAGING_BUCKET)
 PROD_REGISTRY ?= k8s.gcr.io/capi-openstack
 REGISTRY ?= $(STAGING_REGISTRY)
 RELEASE_TAG ?= $(shell git describe --abbrev=0 2>/dev/null)
-PULL_BASE_REF ?= $(RELEASE_TAG) # PULL_BASE_REF will be provided by Prow
+# PULL_BASE_REF will be provided by Prow
+PULL_BASE_REF ?= $(RELEASE_TAG)
 RELEASE_ALIAS_TAG ?= $(PULL_BASE_REF)
 RELEASE_DIR := out
 

--- a/Makefile
+++ b/Makefile
@@ -280,15 +280,18 @@ list-staging-releases: ## List staging images for image promotion
 list-image:
 	gcloud container images list-tags $(STAGING_REGISTRY)/$(IMAGE) --filter="tags=('$(RELEASE_TAG)')" --format=json
 
+## Builds and push container images using the latest git tag for the commit.
 .PHONY: release
-release: $(RELEASE_NOTES) clean-release $(RELEASE_DIR)  ## Builds and push container images using the latest git tag for the commit.
+release: $(RELEASE_NOTES) clean-release release-checkout-tag release-manifest-modification release-manifests release-templates | $(RELEASE_DIR)
+
+release-checkout-tag:
 	@if [ -z "${RELEASE_TAG}" ]; then echo "RELEASE_TAG is not set"; exit 1; fi
 	@if ! [ -z "$$(git status --porcelain)" ]; then echo "Your local git repository contains uncommitted changes, use git clean before proceeding."; fi
 	git checkout "${RELEASE_TAG}"
-	# Set the manifest image to the production bucket.
-	$(MAKE) manifest-modification REGISTRY=$(PROD_REGISTRY)
-	$(MAKE) release-manifests
-	$(MAKE) release-templates
+
+.PHONY: release-manifest-modification
+release-manifest-modification: REGISTRY=$(PROD_REGISTRY)
+release-manifest-modification: manifest-modification
 
 .PHONY: manifest-modification
 manifest-modification: # Set the manifest images to the staging/production bucket.

--- a/Makefile
+++ b/Makefile
@@ -161,8 +161,7 @@ test-conformance-fast: test-conformance
 binaries: managers ## Builds and installs all binaries
 
 .PHONY: managers
-managers:
-	$(MAKE) manager-openstack-infrastructure
+managers: manager-openstack-infrastructure
 
 .PHONY: manager-openstack-infrastructure
 manager-openstack-infrastructure: ## Build manager binary.

--- a/Makefile
+++ b/Makefile
@@ -293,22 +293,22 @@ release-checkout-tag:
 release-manifest-modification: REGISTRY=$(PROD_REGISTRY)
 release-manifest-modification: manifest-modification
 
+## Set the manifest images to the staging/production bucket.
 .PHONY: manifest-modification
-manifest-modification: # Set the manifest images to the staging/production bucket.
-	$(MAKE) set-manifest-image \
-		MANIFEST_IMG=$(REGISTRY)/$(IMAGE_NAME) MANIFEST_TAG=$(RELEASE_TAG) \
-		TARGET_RESOURCE="./config/default/manager_image_patch.yaml"
-	$(MAKE) set-manifest-pull-policy PULL_POLICY=IfNotPresent TARGET_RESOURCE="./config/default/manager_pull_policy.yaml"
+manifest-modification: MANIFEST_IMG=$(REGISTRY)/$(IMAGE_NAME)
+manifest-modification: MANIFEST_TAG=$(RELEASE_TAG)
+manifest-modification: PULL_POLICY=IfNotPresent
+manifest-modification: set-manifest-image set-manifest-pull-policy
 
 .PHONY: set-manifest-image
 set-manifest-image:
 	$(info Updating kustomize image patch file for manager resource)
-	sed -i'' -e 's@image: .*@image: '"${MANIFEST_IMG}:$(MANIFEST_TAG)"'@' $(TARGET_RESOURCE)
+	sed -i'' -e 's@image: .*@image: '"${MANIFEST_IMG}:$(MANIFEST_TAG)"'@' ./config/default/manager_image_patch.yaml
 
 .PHONY: set-manifest-pull-policy
 set-manifest-pull-policy:
 	$(info Updating kustomize pull policy file for manager resources)
-	sed -i'' -e 's@imagePullPolicy: .*@imagePullPolicy: '"$(PULL_POLICY)"'@' $(TARGET_RESOURCE)
+	sed -i'' -e 's@imagePullPolicy: .*@imagePullPolicy: '"$(PULL_POLICY)"'@' ./config/default/manager_pull_policy.yaml
 
 .PHONY: release-manifests
 release-manifests:

--- a/Makefile
+++ b/Makefile
@@ -248,8 +248,7 @@ docker-build-%:
 	$(MAKE) ARCH=$* docker-build
 
 .PHONY: docker-push-all ## Push all the architecture docker images
-docker-push-all: $(addprefix docker-push-,$(ALL_ARCH))
-	$(MAKE) docker-push-manifest
+docker-push-all: $(addprefix docker-push-,$(ALL_ARCH)) docker-push-manifest
 
 docker-push-%:
 	$(MAKE) ARCH=$* docker-push

--- a/Makefile
+++ b/Makefile
@@ -192,9 +192,7 @@ modules: ## Runs go mod to ensure proper vendoring.
 	cd $(TOOLS_DIR); go mod tidy
 
 .PHONY: generate
-generate: ## Generate code
-	$(MAKE) generate-go
-	$(MAKE) generate-manifests
+generate: generate-go generate-manifests
 
 .PHONY: generate-go
 generate-go: $(MOCKGEN)

--- a/Makefile
+++ b/Makefile
@@ -314,13 +314,9 @@ release-manifests: compiled-manifest
 	# Add metadata to the release artifacts
 	cp metadata.yaml $(RELEASE_DIR)/metadata.yaml
 
+## Builds and push container images and manifests to the staging bucket.
 .PHONY: release-staging
-release-staging: ## Builds and push container images and manifests to the staging bucket.
-	$(MAKE) docker-build-all
-	$(MAKE) docker-push-all
-	$(MAKE) release-alias-tag
-	$(MAKE) staging-manifests
-	$(MAKE) upload-staging-artifacts
+release-staging: docker-build-all docker-push-all release-alias-tag staging-manifests upload-staging-artifacts
 
 .PHONY: release-staging-nightly
 release-staging-nightly: ## Tags and push container images to the staging bucket. Example image tag: capi-openstack-controller:nightly_master_20210121

--- a/Makefile
+++ b/Makefile
@@ -261,8 +261,9 @@ docker-push-manifest: ## Push the fat manifest docker image.
 	docker manifest push --purge ${CONTROLLER_IMG}:${TAG}
 
 .PHONY: staging-manifests
-staging-manifests:
-	$(MAKE) $(RELEASE_DIR)/$(MANIFEST_FILE).yaml PULL_POLICY=IfNotPresent TAG=$(RELEASE_ALIAS_TAG)
+staging-manifests: PULL_POLICY=IfNotPresent
+staging-manifests: TAG=$(RELEASE_ALIAS_TAG)
+staging-manifests: compiled-manifest
 
 ## --------------------------------------
 ## Release


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This commit series systematically removes most uses of submakes in the top level Makefile. It was fairly easy to write and I personally think it results in a more maintainable Makefile.

**HOWEVER**, I'm not aware of any bugs it addresses (yet), there's obviously the possibility that it has introduced bugs, and we don't have great test coverage of the Makefile, so... is it worth it?

/hold
