### PR TITLE
🐛Pull Calico from quay.io instead of docker.io

### DIFF
--- a/test/e2e/data/cni/calico.yaml
+++ b/test/e2e/data/cni/calico.yaml
@@ -3739,7 +3739,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: docker.io/calico/cni:v3.20.1
+          image: quay.io/calico/cni:v3.20.1
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
           - configMapRef:
@@ -3766,7 +3766,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.20.1
+          image: quay.io/calico/cni:v3.20.1
           command: ["/opt/cni/bin/install"]
           envFrom:
           - configMapRef:
@@ -3807,7 +3807,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: docker.io/calico/pod2daemon-flexvol:v3.20.1
+          image: quay.io/calico/pod2daemon-flexvol:v3.20.1
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -3818,7 +3818,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.20.1
+          image: quay.io/calico/node:v3.20.1
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -4031,7 +4031,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.20.1
+          image: quay.io/calico/kube-controllers:v3.20.1
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS


### PR DESCRIPTION
docker.io is rate limited without authentication, quay.io is not. This
is causing failures in local CI testing because provisioned machines
can't pull the calico image and therefore never become Ready.

We likely avoid this issue in CI due to the implementation of rate
limiting in docker.io, but it would not be impossible to hit it there,
either.

Calico publishes images to both repositories, so this just works.
