### PR TITLE
:sparkles:  Add tags on security groups created by capo

### DIFF
--- a/pkg/cloud/services/networking/securitygroups.go
+++ b/pkg/cloud/services/networking/securitygroups.go
@@ -19,6 +19,7 @@ package networking
 import (
 	"fmt"
 
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
 
@@ -546,6 +547,16 @@ func (s *Service) createSecurityGroupIfNotExists(openStackCluster *infrav1.OpenS
 			record.Warnf(openStackCluster, "FailedCreateSecurityGroup", "Failed to create security group %s: %v", groupName, err)
 			return err
 		}
+
+		if len(openStackCluster.Spec.Tags) > 0 {
+			_, err = s.client.ReplaceAllAttributesTags("security-groups", group.ID, attributestags.ReplaceAllOpts{
+				Tags: openStackCluster.Spec.Tags,
+			})
+			if err != nil {
+				return err
+			}
+		}
+
 		record.Eventf(openStackCluster, "SuccessfulCreateSecurityGroup", "Created security group %s with id %s", groupName, group.ID)
 		return nil
 	}

--- a/test/e2e/data/infrastructure-openstack/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-openstack/cluster-template.yaml
@@ -24,6 +24,8 @@ kind: OpenStackCluster
 metadata:
   name: ${CLUSTER_NAME}
 spec:
+  tags:
+  - ${CLUSTER_NAME}
   cloudName: ${OPENSTACK_CLOUD}
   identityRef:
     name: ${CLUSTER_NAME}-cloud-config
@@ -111,6 +113,8 @@ metadata:
 spec:
   template:
     spec:
+      tags:
+      - control-plane
       flavor: ${OPENSTACK_CONTROL_PLANE_MACHINE_FLAVOR}
       image: ${OPENSTACK_IMAGE_NAME}
       sshKeyName: ${OPENSTACK_SSH_KEY_NAME}
@@ -150,6 +154,8 @@ metadata:
 spec:
   template:
     spec:
+      tags:
+      - machine
       cloudName: ${OPENSTACK_CLOUD}
       identityRef:
         name: ${CLUSTER_NAME}-cloud-config

--- a/test/e2e/shared/openstack.go
+++ b/test/e2e/shared/openstack.go
@@ -37,6 +37,8 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
@@ -133,6 +135,132 @@ func dumpOpenStackImages(providerClient *gophercloud.ProviderClient, clientOpts 
 		return fmt.Errorf("error writing seversJSON %s: %s", imagesJSON, err)
 	}
 	return nil
+}
+
+func DumpOpenStackServers(e2eCtx *E2EContext, filter servers.ListOpts) ([]servers.Server, error) {
+	providerClient, clientOpts, err := getProviderClient(e2eCtx)
+	if err != nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "error creating provider client: %s\n", err)
+		return nil, nil
+	}
+
+	computeClient, err := openstack.NewComputeV2(providerClient, gophercloud.EndpointOpts{Region: clientOpts.RegionName})
+	if err != nil {
+		return nil, fmt.Errorf("error creating compute client: %v", err)
+	}
+
+	computeClient.Microversion = compute.NovaMinimumMicroversion
+	allPages, err := servers.List(computeClient, filter).AllPages()
+	if err != nil {
+		return nil, fmt.Errorf("error listing servers: %v", err)
+	}
+
+	allServers, err := servers.ExtractServers(allPages)
+	if err != nil {
+		return nil, fmt.Errorf("error extracting server: %v", err)
+	}
+
+	return allServers, nil
+}
+
+func DumpOpenStackNetworks(e2eCtx *E2EContext, filter networks.ListOpts) ([]networks.Network, error) {
+	providerClient, clientOpts, err := getProviderClient(e2eCtx)
+	if err != nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "error creating provider client: %s\n", err)
+		return nil, nil
+	}
+
+	networkClient, err := openstack.NewNetworkV2(providerClient, gophercloud.EndpointOpts{
+		Region: clientOpts.RegionName,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error creating network client: %s", err)
+	}
+
+	allPages, err := networks.List(networkClient, filter).AllPages()
+	if err != nil {
+		return nil, fmt.Errorf("error listing networks: %s", err)
+	}
+	networksList, err := networks.ExtractNetworks(allPages)
+	if err != nil {
+		return nil, fmt.Errorf("error extracting networks: %s", err)
+	}
+	return networksList, nil
+}
+
+func DumpOpenStackSubnets(e2eCtx *E2EContext, filter subnets.ListOpts) ([]subnets.Subnet, error) {
+	providerClient, clientOpts, err := getProviderClient(e2eCtx)
+	if err != nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "error creating provider client: %s\n", err)
+		return nil, nil
+	}
+
+	networkClient, err := openstack.NewNetworkV2(providerClient, gophercloud.EndpointOpts{
+		Region: clientOpts.RegionName,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error creating network client: %s", err)
+	}
+
+	allPages, err := subnets.List(networkClient, filter).AllPages()
+	if err != nil {
+		return nil, fmt.Errorf("error listing subnets: %s", err)
+	}
+	subnetsList, err := subnets.ExtractSubnets(allPages)
+	if err != nil {
+		return nil, fmt.Errorf("error extracting subnets: %s", err)
+	}
+	return subnetsList, nil
+}
+
+func DumpOpenStackRouters(e2eCtx *E2EContext, filter routers.ListOpts) ([]routers.Router, error) {
+	providerClient, clientOpts, err := getProviderClient(e2eCtx)
+	if err != nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "error creating provider client: %s\n", err)
+		return nil, nil
+	}
+
+	networkClient, err := openstack.NewNetworkV2(providerClient, gophercloud.EndpointOpts{
+		Region: clientOpts.RegionName,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error creating network client: %s", err)
+	}
+
+	allPages, err := routers.List(networkClient, filter).AllPages()
+	if err != nil {
+		return nil, fmt.Errorf("error listing routers: %s", err)
+	}
+	routersList, err := routers.ExtractRouters(allPages)
+	if err != nil {
+		return nil, fmt.Errorf("error extracting routers: %s", err)
+	}
+	return routersList, nil
+}
+
+func DumpOpenStackSecurityGroups(e2eCtx *E2EContext, filter groups.ListOpts) ([]groups.SecGroup, error) {
+	providerClient, clientOpts, err := getProviderClient(e2eCtx)
+	if err != nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "error creating provider client: %s\n", err)
+		return nil, nil
+	}
+
+	networkClient, err := openstack.NewNetworkV2(providerClient, gophercloud.EndpointOpts{
+		Region: clientOpts.RegionName,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error creating network client: %s", err)
+	}
+
+	allPages, err := groups.List(networkClient, filter).AllPages()
+	if err != nil {
+		return nil, fmt.Errorf("error listing security groups: %s", err)
+	}
+	groupsList, err := groups.ExtractGroups(allPages)
+	if err != nil {
+		return nil, fmt.Errorf("error extracting security groups: %s", err)
+	}
+	return groupsList, nil
 }
 
 func DumpOpenStackPorts(e2eCtx *E2EContext, filter ports.ListOpts) ([]ports.Port, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
When ManagedSecurityGroups: true, security groups created by CAPO
are tagged with the tags on OpenStackCluster.spec.tags. Update
e2e tests to include tests for various resources that are tagged.


**Which issue(s) this PR fixes**:
Fixes #1044 

**Special notes for your reviewer**:

1. Tags on SG are only added on creation, they are not propagated to cluster.status nor reconciled. Please let me know if you think any of the 2 needs to be added.
1. I didn't find any unit tests for the securitygroups but i updated the e2e tests. I used an existing test scenario as creating a new one seemed like an overkill. Also added tests for other resources that are also tagged

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [x] includes documentation
  - [x] adds unit tests

/hold
