### PR TITLE
🏃 Delete unused annotation

### DIFF
--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -333,12 +333,6 @@ func (r *OpenStackMachineReconciler) reconcileNormal(ctx context.Context, logger
 	addresses := instanceNS.Addresses()
 	openStackMachine.Status.Addresses = addresses
 
-	// TODO(sbueringer) From CAPA: TODO(vincepri): Remove this annotation when clusterctl is no longer relevant.
-	if openStackMachine.Annotations == nil {
-		openStackMachine.Annotations = map[string]string{}
-	}
-	openStackMachine.Annotations["cluster-api-provider-openstack"] = "true"
-
 	switch instanceStatus.State() {
 	case infrav1.InstanceStateActive:
 		logger.Info("Machine instance is ACTIVE", "instance-id", instanceStatus.ID())


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit deletes unused annotation `cluster-api-provider-openstack: true`. It is not used since Cluster API v1alpha3.
CAPA already removed: https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/1881

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

/hold
