### PR TITLE
🏃 Move sbueringer to emeritus maintainers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -18,6 +18,7 @@ emeritus_maintainers:
   - gyliu513
   - Lion-Wei
   - m1093782566
+  - sbueringer
 
 emeritus_reviewers:
   - iamemilio

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -20,7 +20,6 @@ aliases:
     - CecileRobertMichon
   cluster-api-openstack-maintainers:
     - jichenjc
-    - sbueringer
     - hidekazuna
   cluster-api-openstack-reviewers:
     - chrischdi


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

**What this PR does / why we need it**:

Hey folks,
I think it's time to reflect reality in the OWNERS files ;)

