### PR TITLE
🐛Fix conversion of IdentityRef converting between v1alpha4 and v1beta1

### DIFF
--- a/api/v1alpha3/conversion.go
+++ b/api/v1alpha3/conversion.go
@@ -111,6 +111,12 @@ func (r *OpenStackMachineTemplateList) ConvertFrom(srcRaw ctrlconversion.Hub) er
 // Convert_v1alpha3_OpenStackClusterSpec_To_v1beta1_OpenStackClusterSpec has to be added by us because we dropped
 // the useOctavia parameter. We don't have to migrate this parameter to v1beta1 so there is nothing to do.
 func Convert_v1alpha3_OpenStackClusterSpec_To_v1beta1_OpenStackClusterSpec(in *OpenStackClusterSpec, out *v1beta1.OpenStackClusterSpec, s conversion.Scope) error {
+	if in.CloudsSecret != nil {
+		out.IdentityRef = &v1beta1.OpenStackIdentityReference{
+			Kind: "Secret",
+			Name: in.CloudsSecret.Name,
+		}
+	}
 	return autoConvert_v1alpha3_OpenStackClusterSpec_To_v1beta1_OpenStackClusterSpec(in, out, s)
 }
 
@@ -120,6 +126,17 @@ func Convert_v1beta1_OpenStackClusterSpec_To_v1alpha3_OpenStackClusterSpec(in *v
 	if in.IdentityRef != nil {
 		out.CloudsSecret = &corev1.SecretReference{
 			Name: in.IdentityRef.Name,
+		}
+	}
+
+	if in.Bastion != nil && in.Bastion.Instance.IdentityRef != nil {
+		outBastion := out.Bastion
+		if outBastion == nil {
+			outBastion = &Bastion{}
+		}
+
+		outBastion.Instance.CloudsSecret = &corev1.SecretReference{
+			Name: in.Bastion.Instance.IdentityRef.Name,
 		}
 	}
 	return autoConvert_v1beta1_OpenStackClusterSpec_To_v1alpha3_OpenStackClusterSpec(in, out, s)
@@ -147,6 +164,11 @@ func Convert_v1beta1_Network_To_v1alpha3_Network(in *v1beta1.Network, out *Netwo
 // parameter in v1beta1. There is no intention to support this parameter in v1alpha3, so the field is just dropped.
 // Further, we want to convert the Type of CloudsSecret from SecretReference to string.
 func Convert_v1beta1_OpenStackMachineSpec_To_v1alpha3_OpenStackMachineSpec(in *v1beta1.OpenStackMachineSpec, out *OpenStackMachineSpec, s conversion.Scope) error {
+	if in.IdentityRef != nil {
+		out.CloudsSecret = &corev1.SecretReference{
+			Name: in.IdentityRef.Name,
+		}
+	}
 	return autoConvert_v1beta1_OpenStackMachineSpec_To_v1alpha3_OpenStackMachineSpec(in, out, s)
 }
 

--- a/api/v1alpha3/conversion_test.go
+++ b/api/v1alpha3/conversion_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"testing"
+
+	fuzz "github.com/google/gofuzz"
+	"github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	v1beta1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1"
+	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
+)
+
+func TestFuzzyConversion(t *testing.T) {
+	g := gomega.NewWithT(t)
+	scheme := runtime.NewScheme()
+	g.Expect(AddToScheme(scheme)).To(gomega.Succeed())
+	g.Expect(v1beta1.AddToScheme(scheme)).To(gomega.Succeed())
+
+	fuzzerFuncs := func(_ runtimeserializer.CodecFactory) []interface{} {
+		return []interface{}{
+			// Don't test spoke-hub-spoke conversion of v1alpha3 fields which are not in v1beta1
+			func(v1alpha3ClusterSpec *OpenStackClusterSpec, c fuzz.Continue) {
+				c.FuzzNoCustom(v1alpha3ClusterSpec)
+
+				v1alpha3ClusterSpec.UseOctavia = false
+
+				if v1alpha3ClusterSpec.CloudsSecret != nil {
+					// In switching to IdentityRef, fetching the cloud secret
+					// from a different namespace is no longer supported
+					v1alpha3ClusterSpec.CloudsSecret.Namespace = ""
+				}
+			},
+			func(v1alpha3MachineSpec *OpenStackMachineSpec, c fuzz.Continue) {
+				c.FuzzNoCustom(v1alpha3MachineSpec)
+
+				v1alpha3MachineSpec.UserDataSecret = nil
+
+				if v1alpha3MachineSpec.CloudsSecret != nil {
+					// In switching to IdentityRef, fetching the cloud secret
+					// from a different namespace is no longer supported
+					v1alpha3MachineSpec.CloudsSecret.Namespace = ""
+				}
+			},
+
+			// Don't test hub-spoke-hub conversion of v1beta1 fields which are not in v1alpha3
+			func(v1beta1ClusterSpec *v1beta1.OpenStackClusterSpec, c fuzz.Continue) {
+				c.FuzzNoCustom(v1beta1ClusterSpec)
+
+				v1beta1ClusterSpec.APIServerFixedIP = ""
+				v1beta1ClusterSpec.AllowAllInClusterTraffic = false
+				v1beta1ClusterSpec.DisableAPIServerFloatingIP = false
+			},
+			func(v1beta1MachineSpec *v1beta1.OpenStackMachineSpec, c fuzz.Continue) {
+				c.FuzzNoCustom(v1beta1MachineSpec)
+
+				v1beta1MachineSpec.Ports = nil
+			},
+			func(v1beta1Network *v1beta1.Network, c fuzz.Continue) {
+				c.FuzzNoCustom(v1beta1Network)
+
+				v1beta1Network.PortOpts = nil
+			},
+			func(v1beta1ClusterStatus *v1beta1.OpenStackClusterStatus, c fuzz.Continue) {
+				c.FuzzNoCustom(v1beta1ClusterStatus)
+
+				v1beta1ClusterStatus.FailureMessage = nil
+				v1beta1ClusterStatus.FailureReason = nil
+			},
+			func(v1beta1OpenStackIdentityRef *v1beta1.OpenStackIdentityReference, c fuzz.Continue) {
+				c.FuzzNoCustom(v1beta1OpenStackIdentityRef)
+
+				// IdentityRef was assumed to be a Secret in v1alpha3
+				v1beta1OpenStackIdentityRef.Kind = "Secret"
+			},
+		}
+	}
+
+	t.Run("for OpenStackCluster", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
+		Scheme:      scheme,
+		Hub:         &v1beta1.OpenStackCluster{},
+		Spoke:       &OpenStackCluster{},
+		FuzzerFuncs: []fuzzer.FuzzerFuncs{fuzzerFuncs},
+	}))
+
+	t.Run("for OpenStackMachine", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
+		Scheme:      scheme,
+		Hub:         &v1beta1.OpenStackMachine{},
+		Spoke:       &OpenStackMachine{},
+		FuzzerFuncs: []fuzzer.FuzzerFuncs{fuzzerFuncs},
+	}))
+
+	t.Run("for OpenStackMachineTemplate", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
+		Scheme:      scheme,
+		Hub:         &v1beta1.OpenStackMachineTemplate{},
+		Spoke:       &OpenStackMachineTemplate{},
+		FuzzerFuncs: []fuzzer.FuzzerFuncs{fuzzerFuncs},
+	}))
+}

--- a/api/v1alpha3/zz_generated.conversion.go
+++ b/api/v1alpha3/zz_generated.conversion.go
@@ -747,7 +747,7 @@ func autoConvert_v1beta1_OpenStackClusterSpec_To_v1alpha3_OpenStackClusterSpec(i
 	} else {
 		out.Bastion = nil
 	}
-	// INFO: in.IdentityRef opted out of conversion generation
+	// WARNING: in.IdentityRef requires manual conversion: does not exist in peer-type
 	return nil
 }
 
@@ -944,7 +944,7 @@ func autoConvert_v1beta1_OpenStackMachineSpec_To_v1alpha3_OpenStackMachineSpec(i
 	out.ConfigDrive = (*bool)(unsafe.Pointer(in.ConfigDrive))
 	out.RootVolume = (*RootVolume)(unsafe.Pointer(in.RootVolume))
 	out.ServerGroupID = in.ServerGroupID
-	// INFO: in.IdentityRef opted out of conversion generation
+	// WARNING: in.IdentityRef requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/api/v1alpha4/conversion_test.go
+++ b/api/v1alpha4/conversion_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha4
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	v1beta1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1"
+	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
+)
+
+func TestFuzzyConversion(t *testing.T) {
+	g := gomega.NewWithT(t)
+	scheme := runtime.NewScheme()
+	g.Expect(AddToScheme(scheme)).To(gomega.Succeed())
+	g.Expect(v1beta1.AddToScheme(scheme)).To(gomega.Succeed())
+
+	t.Run("for OpenStackCluster", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
+		Scheme: scheme,
+		Hub:    &v1beta1.OpenStackCluster{},
+		Spoke:  &OpenStackCluster{},
+	}))
+
+	t.Run("for OpenStackMachine", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
+		Scheme: scheme,
+		Hub:    &v1beta1.OpenStackMachine{},
+		Spoke:  &OpenStackMachine{},
+	}))
+
+	t.Run("for OpenStackMachineTemplate", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
+		Scheme: scheme,
+		Hub:    &v1beta1.OpenStackMachineTemplate{},
+		Spoke:  &OpenStackMachineTemplate{},
+	}))
+}

--- a/api/v1alpha4/openstackcluster_types.go
+++ b/api/v1alpha4/openstackcluster_types.go
@@ -135,7 +135,6 @@ type OpenStackClusterSpec struct {
 
 	// IdentityRef is a reference to a identity to be used when reconciling this cluster
 	// +optional
-	// +k8s:conversion-gen=false
 	IdentityRef *OpenStackIdentityReference `json:"identityRef,omitempty"`
 }
 

--- a/api/v1alpha4/openstackmachine_types.go
+++ b/api/v1alpha4/openstackmachine_types.go
@@ -89,7 +89,6 @@ type OpenStackMachineSpec struct {
 
 	// IdentityRef is a reference to a identity to be used when reconciling this cluster
 	// +optional
-	// +k8s:conversion-gen=false
 	IdentityRef *OpenStackIdentityReference `json:"identityRef,omitempty"`
 }
 

--- a/api/v1alpha4/zz_generated.conversion.go
+++ b/api/v1alpha4/zz_generated.conversion.go
@@ -784,7 +784,7 @@ func autoConvert_v1alpha4_OpenStackClusterSpec_To_v1beta1_OpenStackClusterSpec(i
 	out.ControlPlaneEndpoint = in.ControlPlaneEndpoint
 	out.ControlPlaneAvailabilityZones = *(*[]string)(unsafe.Pointer(&in.ControlPlaneAvailabilityZones))
 	out.Bastion = (*v1beta1.Bastion)(unsafe.Pointer(in.Bastion))
-	// INFO: in.IdentityRef opted out of conversion generation
+	out.IdentityRef = (*v1beta1.OpenStackIdentityReference)(unsafe.Pointer(in.IdentityRef))
 	return nil
 }
 
@@ -818,7 +818,7 @@ func autoConvert_v1beta1_OpenStackClusterSpec_To_v1alpha4_OpenStackClusterSpec(i
 	out.ControlPlaneEndpoint = in.ControlPlaneEndpoint
 	out.ControlPlaneAvailabilityZones = *(*[]string)(unsafe.Pointer(&in.ControlPlaneAvailabilityZones))
 	out.Bastion = (*Bastion)(unsafe.Pointer(in.Bastion))
-	// INFO: in.IdentityRef opted out of conversion generation
+	out.IdentityRef = (*OpenStackIdentityReference)(unsafe.Pointer(in.IdentityRef))
 	return nil
 }
 
@@ -1055,7 +1055,7 @@ func autoConvert_v1alpha4_OpenStackMachineSpec_To_v1beta1_OpenStackMachineSpec(i
 	out.ConfigDrive = (*bool)(unsafe.Pointer(in.ConfigDrive))
 	out.RootVolume = (*v1beta1.RootVolume)(unsafe.Pointer(in.RootVolume))
 	out.ServerGroupID = in.ServerGroupID
-	// INFO: in.IdentityRef opted out of conversion generation
+	out.IdentityRef = (*v1beta1.OpenStackIdentityReference)(unsafe.Pointer(in.IdentityRef))
 	return nil
 }
 
@@ -1082,7 +1082,7 @@ func autoConvert_v1beta1_OpenStackMachineSpec_To_v1alpha4_OpenStackMachineSpec(i
 	out.ConfigDrive = (*bool)(unsafe.Pointer(in.ConfigDrive))
 	out.RootVolume = (*RootVolume)(unsafe.Pointer(in.RootVolume))
 	out.ServerGroupID = in.ServerGroupID
-	// INFO: in.IdentityRef opted out of conversion generation
+	out.IdentityRef = (*OpenStackIdentityReference)(unsafe.Pointer(in.IdentityRef))
 	return nil
 }
 

--- a/api/v1beta1/openstackcluster_types.go
+++ b/api/v1beta1/openstackcluster_types.go
@@ -135,7 +135,6 @@ type OpenStackClusterSpec struct {
 
 	// IdentityRef is a reference to a identity to be used when reconciling this cluster
 	// +optional
-	// +k8s:conversion-gen=false
 	IdentityRef *OpenStackIdentityReference `json:"identityRef,omitempty"`
 }
 

--- a/api/v1beta1/openstackmachine_types.go
+++ b/api/v1beta1/openstackmachine_types.go
@@ -89,7 +89,6 @@ type OpenStackMachineSpec struct {
 
 	// IdentityRef is a reference to a identity to be used when reconciling this cluster
 	// +optional
-	// +k8s:conversion-gen=false
 	IdentityRef *OpenStackIdentityReference `json:"identityRef,omitempty"`
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/go-logr/logr v0.4.0
 	github.com/golang/mock v1.6.0
+	github.com/google/gofuzz v1.2.0
 	github.com/gophercloud/gophercloud v0.16.0
 	github.com/gophercloud/utils v0.0.0-20210323225332-7b186010c04f
 	github.com/onsi/ginkgo v1.16.4


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
The most interesting parts of this PR are the new unit tests. The tests are little more than a 'do the fields line up' test, but they did highlight that we were missing conversion of IdentityRef.

I will be adding to these tests in #1030

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1065 #1060 