### PR TITLE
🏃Fix generated clouds.yaml for local e2e tests

### DIFF
--- a/hack/ci/create_devstack.sh
+++ b/hack/ci/create_devstack.sh
@@ -262,7 +262,7 @@ function main() {
     public_ip=$(get_public_ip)
     cat << EOF > "${REPO_ROOT_ABSOLUTE}/clouds.yaml"
 clouds:
-  ${CLUSTER_NAME}:
+  capo-e2e:
     auth:
       username: demo
       password: secretadmin
@@ -272,7 +272,7 @@ clouds:
       project_name: demo
     verify: false
     region_name: RegionOne
-  ${CLUSTER_NAME}-admin:
+  capo-e2e-admin:
     auth:
       username: admin
       password: secretadmin
@@ -284,7 +284,7 @@ clouds:
     region_name: RegionOne
 EOF
 
-    export OS_CLOUD="${CLUSTER_NAME}-admin"
+    export OS_CLOUD="capo-e2e-admin"
 
     # Wait until the OpenStack API is reachable
     retry 5 30 "openstack versions show"


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
When creating multiple capo-e2e devstacks on the same shared cloud you will need to give them different names. We were also using this name when writing the local clouds.yaml. However, that requires also modifying the local e2e_conf.yaml. As there is no naming conflict between developers' local clouds.yaml copies these can safely be the same everywhere, which is easier to work with.