### PR TITLE
Update OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -21,5 +21,4 @@ emeritus_maintainers:
   - sbueringer
 
 emeritus_reviewers:
-  - iamemilio
   - YorikSar


### PR DESCRIPTION
As @iamemilio is back as an active reviewer we should remove him from the emeritus reviewers.
follow-up to #1083