### PR TITLE
🏃 Migrate CI to Wallaby

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ previous cluster managers such as [kops][kops] and
 
 ## Launching a Kubernetes cluster on OpenStack
 
-- Check out the [Cluster API Quick Start](https://cluster-api.sigs.k8s.io/user/quick-start.html) to create your first Kubernetes cluster on OpenStack using Cluster API. If you wish to use the external cloud provider, check out the [External Cloud Provider](docs/book/src/topics/external-cloud-provider.md) as well. 
+- Check out the [Cluster API Quick Start](https://cluster-api.sigs.k8s.io/user/quick-start.html) to create your first Kubernetes cluster on OpenStack using Cluster API. If you wish to use the external cloud provider, check out the [External Cloud Provider](docs/book/src/topics/external-cloud-provider.md) as well.
 
 ## Features
 
@@ -58,14 +58,15 @@ This provider's versions are able to install Kubernetes to the following version
 
 |                                    | Pike | Queens | Rocky | Stein | Train | Ussuri | Victoria |
 | ---------------------------------- | ---- | ------ | ----- | ----- | ----- | ------ | -------- |
-| OpenStack Provider v1alpha3 (v0.3) | +    | +      | +     | ✓    | ✓    | ✓     | ✓        |
+| OpenStack Provider v1alpha3 (v0.3) | +    | +      | +     | ✓     | ✓     | ✓      | ✓        |
 | OpenStack Provider v1alpha4 (v0.4) | +    | +      | +     | +     | +     | +      | ✓        |
 | OpenStack Provider v1alpha4 (v0.5) | +    | +      | +     | +     | +     | +      | ✓        |
 | OpenStack Provider v1beta1         | +    | +      | +     | +     | +     | +      | ✓        |
 
 Test status:
-* `✓` tested
-* `+` should work, but we weren't able to test it
+
+- `✓` tested
+- `+` should work, but we weren't able to test it
 
 Each version of Cluster API for OpenStack will attempt to support two Kubernetes versions.
 
@@ -77,13 +78,14 @@ policy may be made to more closely aligned with other providers in the Cluster A
 ## Development versions
 
 ClusterAPI provider OpenStack images and manifests are published after every PR merge and once every day:
+
 * With a Google Cloud account you can get a quick overview [here](https://console.cloud.google.com/storage/browser/artifacts.k8s-staging-capi-openstack.appspot.com/components)
 * The manifests are available under:
-  * [master/infrastructure-components.yaml](https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/components/master/infrastructure-components.yaml): 
+  * [master/infrastructure-components.yaml](https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/components/master/infrastructure-components.yaml):
     latest build from the main branch, overwritten after every merge
   * e.g. [nightly_master_20210407/infrastructure-components.yaml](https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/components/nightly_master_20210407/infrastructure-components.yaml): build of the main branch from 7th April
-    
-These artifacts are published via Prow and Google Cloud Build. The corresponding job definitions can 
+
+These artifacts are published via Prow and Google Cloud Build. The corresponding job definitions can
 be found [here](https://github.com/kubernetes/test-infra/blob/4d146721aaec27a3c93299956f8d64af2357d64a/config/jobs/image-pushing/k8s-staging-cluster-api.yaml).
 
 ------
@@ -93,8 +95,8 @@ be found [here](https://github.com/kubernetes/test-infra/blob/4d146721aaec27a3c9
 Note: Cluster API Provider OpenStack relies on a few prerequisites which have to be already
 installed in the used operating system images, e.g. a container runtime, kubelet, kubeadm,.. .
 Reference images can be found in [kubernetes-sigs/image-builder](https://github.com/kubernetes-sigs/image-builder/tree/master/images/capi). If it isn't possible to pre-install those
- prerequisites in the image, you can always deploy and execute some custom scripts 
- through the [KubeadmConfig](https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm).  
+ prerequisites in the image, you can always deploy and execute some custom scripts
+ through the [KubeadmConfig](https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm).
 
 ------
 

--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ This provider's versions are able to install and manage the following versions o
 
 This provider's versions are able to install Kubernetes to the following versions of OpenStack:
 
-|                                    | Pike | Queens | Rocky | Stein | Train | Ussuri | Victoria |
-| ---------------------------------- | ---- | ------ | ----- | ----- | ----- | ------ | -------- |
-| OpenStack Provider v1alpha3 (v0.3) | +    | +      | +     | ✓     | ✓     | ✓      | ✓        |
-| OpenStack Provider v1alpha4 (v0.4) | +    | +      | +     | +     | +     | +      | ✓        |
-| OpenStack Provider v1alpha4 (v0.5) | +    | +      | +     | +     | +     | +      | ✓        |
-| OpenStack Provider v1beta1         | +    | +      | +     | +     | +     | +      | ✓        |
+|                                    | Pike | Queens | Rocky | Stein | Train | Ussuri | Victoria | Wallaby |
+| ---------------------------------- | ---- | ------ | ----- | ----- | ----- | ------ | -------- | ------- |
+| OpenStack Provider v1alpha3 (v0.3) | +    | +      | +     | ✓     | ✓     | ✓      | ✓        |         |
+| OpenStack Provider v1alpha4 (v0.4) | +    | +      | +     | +     | +     | +      | ✓        |         |
+| OpenStack Provider v1alpha4 (v0.5) | +    | +      | +     | +     | +     | +      | ✓        |         |
+| OpenStack Provider v1beta1         | +    | +      | +     | +     | +     | +      | ✓        | ✓       |
 
 Test status:
 

--- a/hack/ci/cloud-init/controller.yaml.tpl
+++ b/hack/ci/cloud-init/controller.yaml.tpl
@@ -28,11 +28,11 @@
     # Pre-requisite
     ENABLED_SERVICES=key,rabbit,mysql
     # Nova
-    ENABLED_SERVICES+=,n-api,n-obj,n-cpu,n-cond,n-sch,n-novnc,n-api-meta
+    ENABLED_SERVICES+=,n-api,n-cpu,n-cond,n-sch,n-novnc,n-api-meta
     # Placement service needed for Nova
     ENABLED_SERVICES+=,placement-api,placement-client
     # Glance
-    ENABLED_SERVICES+=,g-api,g-reg
+    ENABLED_SERVICES+=,g-api
 
     # Octavia-Neutron
     ENABLED_SERVICES+=,neutron-api,neutron-agent,neutron-dhcp,neutron-l3

--- a/hack/ci/cloud-init/controller.yaml.tpl
+++ b/hack/ci/cloud-init/controller.yaml.tpl
@@ -34,7 +34,7 @@
     # Glance
     ENABLED_SERVICES+=,g-api
 
-    # Octavia-Neutron
+    # Neutron
     ENABLED_SERVICES+=,neutron-api,neutron-agent,neutron-dhcp,neutron-l3
     ENABLED_SERVICES+=,neutron-metadata-agent,neutron-qos
     # Octavia
@@ -48,8 +48,6 @@
 
     # Additional services
     ENABLED_SERVICES+=${OPENSTACK_ADDITIONAL_SERVICES}
-
-    LIBVIRT_TYPE=kvm
 
     # Don't download default images, just our test images
     DOWNLOAD_DEFAULT_IMAGES=False
@@ -93,7 +91,7 @@
     done
 
     nova-manage cell_v2 discover_hosts
-    
+
     # Look for hypervisors other than the current host and add them to a
     # secondary AZ
     if ! openstack aggregate show ${SECONDARY_AZ} > /dev/null 2>&1; then
@@ -160,7 +158,7 @@
 
     source /tmp/devstack-common.sh
 
-    ensure_kvm    
+    ensure_kvm
 
     # from https://raw.githubusercontent.com/openstack/octavia/master/devstack/contrib/new-octavia-devstack.sh
     git clone -b stable/${OPENSTACK_RELEASE} https://github.com/openstack/devstack.git /tmp/devstack

--- a/hack/ci/cloud-init/worker.yaml.tpl
+++ b/hack/ci/cloud-init/worker.yaml.tpl
@@ -34,8 +34,6 @@
     # Additional services
     ENABLED_SERVICES+=${OPENSTACK_ADDITIONAL_SERVICES}
 
-    LIBVIRT_TYPE=kvm
-
     [[post-config|$NOVA_CONF]]
     [DEFAULT]
     cpu_allocation_ratio = 2.0

--- a/hack/ci/create_devstack.sh
+++ b/hack/ci/create_devstack.sh
@@ -30,7 +30,7 @@ source "${scriptdir}/${RESOURCE_TYPE}.sh"
 
 CLUSTER_NAME=${CLUSTER_NAME:-"capo-e2e"}
 
-OPENSTACK_RELEASE=${OPENSTACK_RELEASE:-"victoria"}
+OPENSTACK_RELEASE=${OPENSTACK_RELEASE:-"wallaby"}
 OPENSTACK_ENABLE_HORIZON=${OPENSTACK_ENABLE_HORIZON:-"false"}
 
 # Devstack will create a provider network using this range


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

Migrate the CI to use the Wallaby release. This is an incremental change to get
us up to the latest stable release, Xena.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes: #1092

**Special notes for your reviewer**:

No image version changes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
