### PR TITLE
Fail fast without create port at all

### DIFF
--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -194,6 +194,20 @@ func (s *Service) createInstance(eventObject runtime.Object, clusterName string,
 	accessIPv4 := ""
 	portList := []servers.Network{}
 
+	if instanceSpec.Subnet != "" && accessIPv4 == "" {
+		return nil, fmt.Errorf("no ports with fixed IPs found on Subnet %q", instanceSpec.Subnet)
+	}
+
+	imageID, err := s.getImageID(instanceSpec.Image)
+	if err != nil {
+		return nil, fmt.Errorf("error getting image ID: %v", err)
+	}
+
+	flavorID, err := s.computeService.GetFlavorIDFromName(instanceSpec.Flavor)
+	if err != nil {
+		return nil, fmt.Errorf("error getting flavor id from flavor name %s: %v", instanceSpec.Flavor, err)
+	}
+
 	// Ensure we delete the ports we created if we haven't created the server.
 	defer func() {
 		if server != nil {
@@ -228,20 +242,6 @@ func (s *Service) createInstance(eventObject runtime.Object, clusterName string,
 		portList = append(portList, servers.Network{
 			Port: port.ID,
 		})
-	}
-
-	if instanceSpec.Subnet != "" && accessIPv4 == "" {
-		return nil, fmt.Errorf("no ports with fixed IPs found on Subnet %q", instanceSpec.Subnet)
-	}
-
-	imageID, err := s.getImageID(instanceSpec.Image)
-	if err != nil {
-		return nil, fmt.Errorf("create new server: %v", err)
-	}
-
-	flavorID, err := s.computeService.GetFlavorIDFromName(instanceSpec.Flavor)
-	if err != nil {
-		return nil, fmt.Errorf("error getting flavor id from flavor name %s: %v", instanceSpec.Flavor, err)
 	}
 
 	var serverCreateOpts servers.CreateOptsBuilder = servers.CreateOpts{

--- a/pkg/cloud/services/compute/instance_test.go
+++ b/pkg/cloud/services/compute/instance_test.go
@@ -658,35 +658,6 @@ func TestService_CreateInstance(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:                "Delete ports on image error",
-			getMachine:          getDefaultMachine,
-			getOpenStackCluster: getDefaultOpenStackCluster,
-			getOpenStackMachine: getDefaultOpenStackMachine,
-			expect: func(computeRecorder *MockClientMockRecorder, networkRecorder *mock_networking.MockNetworkClientMockRecorder) {
-				expectCreateDefaultPort(networkRecorder)
-
-				computeRecorder.ListImages(images.ListOpts{Name: imageName}).Return(nil, fmt.Errorf("test error"))
-
-				expectCleanupDefaultPort(networkRecorder)
-			},
-			wantErr: true,
-		},
-		{
-			name:                "Delete ports on flavor error",
-			getMachine:          getDefaultMachine,
-			getOpenStackCluster: getDefaultOpenStackCluster,
-			getOpenStackMachine: getDefaultOpenStackMachine,
-			expect: func(computeRecorder *MockClientMockRecorder, networkRecorder *mock_networking.MockNetworkClientMockRecorder) {
-				expectCreateDefaultPort(networkRecorder)
-
-				computeRecorder.ListImages(images.ListOpts{Name: imageName}).Return([]images.Image{{ID: imageUUID}}, nil)
-				computeRecorder.GetFlavorIDFromName(flavorName).Return("", fmt.Errorf("test error"))
-
-				expectCleanupDefaultPort(networkRecorder)
-			},
-			wantErr: true,
-		},
-		{
 			name:                "Delete ports on server create error",
 			getMachine:          getDefaultMachine,
 			getOpenStackCluster: getDefaultOpenStackCluster,
@@ -715,6 +686,9 @@ func TestService_CreateInstance(t *testing.T) {
 				return m
 			},
 			expect: func(computeRecorder *MockClientMockRecorder, networkRecorder *mock_networking.MockNetworkClientMockRecorder) {
+				computeRecorder.ListImages(images.ListOpts{Name: imageName}).Return([]images.Image{{ID: imageUUID}}, nil)
+				computeRecorder.GetFlavorIDFromName(flavorName).Return(flavorUUID, nil)
+
 				expectCreateDefaultPort(networkRecorder)
 
 				// Looking up the second port fails


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

fail fast, inspired by recent discussion in port leak 
for those kind of error handling, we can fail fast without go to create port then delete port stage
if we know it's definitely will fail...

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
