### PR TITLE
:runner: Migrate CI to Xena

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,29 +39,29 @@ This provider's versions are compatible with the following versions of Cluster A
 
 |                                    | v1alpha3 (v0.3) | v1alpha4 (v0.4) | v1beta1 (v1.0) |
 | ---------------------------------- | --------------- | --------------- | -------------- |
-| OpenStack Provider v1alpha3 (v0.3) | ✓              |                 |                |
-| OpenStack Provider v1alpha4 (v0.4) |                 | ✓              |                |
-| OpenStack Provider v1alpha4 (v0.5) |                 |                 | ✓             |
-| OpenStack Provider v1beta1         |                 |                 | ✓             |
+| OpenStack Provider v1alpha3 (v0.3) | ✓               |                 |                |
+| OpenStack Provider v1alpha4 (v0.4) |                 | ✓               |                |
+| OpenStack Provider v1alpha4 (v0.5) |                 |                 | ✓              |
+| OpenStack Provider v1beta1         |                 |                 | ✓              |
 
 
 This provider's versions are able to install and manage the following versions of Kubernetes:
 
 |                                    | v1.16 | v1.17 | v1.18 | v1.19 | v1.20 | v1.21 |
 | ---------------------------------- | ----- | ----- | ----- | ----- | ----- | ----- |
-| OpenStack Provider v1alpha3 (v0.3) | ✓    | ✓    | ✓     | ✓    | ✓    |       |
-| OpenStack Provider v1alpha4 (v0.4) |       |       |       |       | ✓    | ✓     |
-| OpenStack Provider v1alpha4 (v0.5) |       |       |       |       | ✓    | ✓     |
+| OpenStack Provider v1alpha3 (v0.3) | ✓     | ✓     | ✓     | ✓     | ✓     |       |
+| OpenStack Provider v1alpha4 (v0.4) |       |       |       |       | ✓     | ✓     |
+| OpenStack Provider v1alpha4 (v0.5) |       |       |       |       | ✓     | ✓     |
 | OpenStack Provider v1beta1         |       |       |       |       |       | ✓     |
 
 This provider's versions are able to install Kubernetes to the following versions of OpenStack:
 
-|                                    | Pike | Queens | Rocky | Stein | Train | Ussuri | Victoria | Wallaby |
-| ---------------------------------- | ---- | ------ | ----- | ----- | ----- | ------ | -------- | ------- |
-| OpenStack Provider v1alpha3 (v0.3) | +    | +      | +     | ✓     | ✓     | ✓      | ✓        |         |
-| OpenStack Provider v1alpha4 (v0.4) | +    | +      | +     | +     | +     | +      | ✓        |         |
-| OpenStack Provider v1alpha4 (v0.5) | +    | +      | +     | +     | +     | +      | ✓        |         |
-| OpenStack Provider v1beta1         | +    | +      | +     | +     | +     | +      | ✓        | ✓       |
+|                                    | Pike | Queens | Rocky | Stein | Train | Ussuri | Victoria | Wallaby | Xena |
+| ---------------------------------- | ---- | ------ | ----- | ----- | ----- | ------ | -------- | ------- | ---- |
+| OpenStack Provider v1alpha3 (v0.3) | +    | +      | +     | ✓     | ✓     | ✓      | ✓        |         |      |
+| OpenStack Provider v1alpha4 (v0.4) | +    | +      | +     | +     | +     | +      | ✓        |         |      |
+| OpenStack Provider v1alpha4 (v0.5) | +    | +      | +     | +     | +     | +      | ✓        |         |      |
+| OpenStack Provider v1beta1         | +    | +      | +     | +     | +     | +      | ✓        | ✓       | ✓    |
 
 Test status:
 

--- a/hack/ci/create_devstack.sh
+++ b/hack/ci/create_devstack.sh
@@ -30,7 +30,7 @@ source "${scriptdir}/${RESOURCE_TYPE}.sh"
 
 CLUSTER_NAME=${CLUSTER_NAME:-"capo-e2e"}
 
-OPENSTACK_RELEASE=${OPENSTACK_RELEASE:-"wallaby"}
+OPENSTACK_RELEASE=${OPENSTACK_RELEASE:-"xena"}
 OPENSTACK_ENABLE_HORIZON=${OPENSTACK_ENABLE_HORIZON:-"false"}
 
 # Devstack will create a provider network using this range


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

Migrate the CI to use the Xena release. This builds upon the work started in #1092, where we migrated the CI to Wallaby, and bumps things to Xena.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1092

**Special notes for your reviewer**:

No image version changes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
