### PR TITLE
🐛  Avoid replacing tags when no tags are provided.

### DIFF
--- a/pkg/cloud/services/networking/service.go
+++ b/pkg/cloud/services/networking/service.go
@@ -81,6 +81,10 @@ func NewTestService(projectID string, client NetworkClient, logger logr.Logger) 
 // replaceAllAttributesTags replaces all tags on a neworking resource.
 // the value of resourceType must match one of the allowed constants: trunkResource or portResource.
 func (s *Service) replaceAllAttributesTags(eventObject runtime.Object, resourceType string, resourceID string, tags []string) error {
+	if len(tags) == 0 {
+		s.logger.Info("IgnoreReplaceAllAttributesTags", "no tags provided: , %s", resourceID)
+		return nil
+	}
 	if resourceType != trunkResource && resourceType != portResource {
 		record.Warnf(eventObject, "FailedReplaceAllAttributesTags", "Invalid resourceType argument in function call")
 		panic(fmt.Errorf("invalid argument: resourceType, %s, does not match allowed arguments: %s or %s", resourceType, trunkResource, portResource))


### PR DESCRIPTION
When trunk is enabled at Port or Instance level and no tags are provided at either level, deployment fails. 
This PRs fixes this issue by avoiding performing the ReplaceAllAttributesTags when no tags are provided.

Fixes https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/1106