### PR TITLE
Document running CI devstack on CentOS

### DIFF
--- a/docs/book/src/development/ci.md
+++ b/docs/book/src/development/ci.md
@@ -25,6 +25,12 @@ The E2E tests require an OpenStack cloud to run against, which we provision duri
 
 The entry point for the creation of the test DevStack is `hack/ci/create_devstack.sh`, which is executed by `scripts/ci-e2e.sh`. We create 2 instances: `controller` and `worker`. Each will provision itself via cloud-init using config defined in `hack/ci/cloud-init`.
 
+## DevStack OS
+
+In GCE, DevStack is installed on a community-maintained Ubuntu 20.04 LTS cloud image. The cloud-init config is also intended to work on CentOS 8, and this is known to work as of 2021-01-12. However, note that this is not regularly tested. See the comment in `hack/ci/gce-project.sh` for how to deploy on CentOS.
+
+It is convenient to the project to have a viable second OS option as it gives us an option to work around issues which only affect one or the other. This is most likely when enabling new DevStack features, but may also include infrastructure issues. Consequently, when making changes to cloud-init, try not to use features specific to Ubuntu or CentOS. DevStack already supports both operating systems, so we just need to be careful in our periferal configuration, for example by using cloud-init's `packages` module rather than manually invoking `apt-get` or `yum`. Fortunately package names tend to be consistent across the two distributions.
+
 ### Configuration
 
 We configure a 2 node DevStack. `controller` is running:

--- a/hack/ci/gce-project.sh
+++ b/hack/ci/gce-project.sh
@@ -92,6 +92,11 @@ function create_vm {
   local diskname="${CLUSTER_NAME}-disk"
   local imagename="${servername}-image"
 
+  # Create the base disk image based on the public Ubuntu 20.04 LTS cloud image
+  # Note that this has also been verified to work with CentOS 8 as of
+  # 2021-01-12, but this is not tested regularly.
+  # To use CentOS 8:
+  #   --image-project centos-cloud --image-family centos-stream-8
   if ! gcloud compute disks describe "$diskname" --project "$GCP_PROJECT" --zone "$GCP_ZONE" > /dev/null;
   then
     gcloud compute disks create "$diskname" \


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

#1109 pointed out that it's useful to have an alternative OS option, albeit for a reason I didn't think of when I originally made it possible to use CentOS in addition to Ubuntu. This simply documents the alternative and encourages developers to keep the option open.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1109 

/hold
