### PR TITLE
✨  Ensure trunk deletion

### DIFF
--- a/hack/ci/cloud-init/controller.yaml.tpl
+++ b/hack/ci/cloud-init/controller.yaml.tpl
@@ -35,7 +35,8 @@
     ENABLED_SERVICES+=,g-api
 
     # Neutron
-    ENABLED_SERVICES+=,neutron-api,neutron-agent,neutron-dhcp,neutron-l3
+    ENABLED_SERVICES+=,neutron-api,neutron-agent,neutron-dhcp,neutron-l3,neutron-trunk
+
     ENABLED_SERVICES+=,neutron-metadata-agent,neutron-qos
     # Octavia
     ENABLED_SERVICES+=,octavia,o-api,o-cw,o-hm,o-hk,o-da

--- a/pkg/cloud/services/networking/trunk.go
+++ b/pkg/cloud/services/networking/trunk.go
@@ -95,6 +95,9 @@ func (s *Service) DeleteTrunk(eventObject runtime.Object, portID string) error {
 				record.Eventf(eventObject, "SuccessfulDeleteTrunk", "Trunk %s with id %s did not exist", trunkInfo[0].Name, trunkInfo[0].ID)
 				return true, nil
 			}
+			if capoerrors.IsConflict(err) {
+				return false, nil
+			}
 			if capoerrors.IsRetryable(err) {
 				return false, nil
 			}


### PR DESCRIPTION
This PR has two purposes:
- Enabling trunk support on the e2e infra
- fixing issue related to trunk deletion


Port deletion involves three steps.

1. Detaching port
2. Deleting trunk
3. Deleting port

The `Openstack api call` to `Detaching port` (1), returns immediately without waiting for the operation to complete. Due to this, it is possible that the `Deleting trunk `(2) be execute first, resulting in error.

This PR ensures `Deleting trunk` (2) is executed after a successful `Detaching port` (1). 

fixed #1124