### PR TITLE
✨  Improve failing events with Error logs

### DIFF
--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -320,7 +320,7 @@ func (s *Service) createInstance(eventObject runtime.Object, clusterName string,
 		return createdInstance.State() == infrav1.InstanceStateActive, nil
 	})
 	if err != nil {
-		record.Warnf(eventObject, "FailedCreateServer", "Failed to create server %s: %v", createdInstance.Name(), err)
+		record.Errorf(eventObject, "FailedCreateServer", "Failed to create server %s: %v", createdInstance.Name(), err)
 		return nil, err
 	}
 
@@ -670,7 +670,7 @@ func (s *Service) deleteAttachInterface(eventObject runtime.Object, instance *In
 			// due to instance must be paused/active/shutoff in order to detach interface
 			return nil
 		}
-		record.Warnf(eventObject, "FailedDeleteAttachInterface", "Failed to delete attach interface: instance %s, port %s: %v", instance.ID, portID, err)
+		record.Errorf(eventObject, "FailedDeleteAttachInterface", "Failed to delete attach interface: instance %s, port %s: %v", instance.ID, portID, err)
 		return err
 	}
 
@@ -685,7 +685,7 @@ func (s *Service) deleteInstance(eventObject runtime.Object, instance *InstanceI
 			record.Eventf(eventObject, "SuccessfulDeleteServer", "Server %s with id %s did not exist", instance.Name, instance.ID)
 			return nil
 		}
-		record.Warnf(eventObject, "FailedDeleteServer", "Failed to delete server %s with id %s: %v", instance.Name, instance.ID, err)
+		record.Errorf(eventObject, "FailedDeleteServer", "Failed to delete server %s with id %s: %v", instance.Name, instance.ID, err)
 		return err
 	}
 
@@ -700,7 +700,7 @@ func (s *Service) deleteInstance(eventObject runtime.Object, instance *InstanceI
 		return true, nil
 	})
 	if err != nil {
-		record.Warnf(eventObject, "FailedDeleteServer", "Failed to delete server %s with id %s: %v", instance.Name, instance.ID, err)
+		record.Errorf(eventObject, "FailedDeleteServer", "Failed to delete server %s with id %s: %v", instance.Name, instance.ID, err)
 		return err
 	}
 
@@ -743,7 +743,7 @@ func (s *Service) GetInstanceStatusByName(eventObject runtime.Object, name strin
 	}
 
 	if len(serverList) > 1 {
-		record.Warnf(eventObject, "DuplicateServerNames", "Found %d servers with name '%s'. This is likely to cause errors.", len(serverList), name)
+		record.Errorf(eventObject, "DuplicateServerNames", "Found %d servers with name '%s'. This is likely to cause errors.", len(serverList), name)
 	}
 
 	// Return the first returned server, if any

--- a/pkg/cloud/services/loadbalancer/loadbalancer.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer.go
@@ -130,12 +130,12 @@ func (s *Service) getOrCreateLoadBalancer(openStackCluster *infrav1.OpenStackClu
 	mc := metrics.NewMetricPrometheusContext("loadbalancer", "create")
 	lb, err = loadbalancers.Create(s.loadbalancerClient, lbCreateOpts).Extract()
 	if mc.ObserveRequest(err) != nil {
-		record.Warnf(openStackCluster, "FailedCreateLoadBalancer", "Failed to create load balancer %s: %v", loadBalancerName, err)
+		record.Errorf(openStackCluster, "FailedCreateLoadBalancer", "Failed to create load balancer %s: %v", loadBalancerName, err)
 		return nil, err
 	}
 
 	if err := s.waitForLoadBalancerActive(lb.ID); err != nil {
-		record.Warnf(openStackCluster, "FailedCreateLoadBalancer", "Failed to create load balancer %s with id %s: wait for load balancer active: %v", loadBalancerName, lb.ID, err)
+		record.Errorf(openStackCluster, "FailedCreateLoadBalancer", "Failed to create load balancer %s with id %s: wait for load balancer active: %v", loadBalancerName, lb.ID, err)
 		return nil, err
 	}
 
@@ -164,17 +164,17 @@ func (s *Service) getOrCreateListener(openStackCluster *infrav1.OpenStackCluster
 	mc := metrics.NewMetricPrometheusContext("loadbalancer_listener", "create")
 	listener, err = listeners.Create(s.loadbalancerClient, listenerCreateOpts).Extract()
 	if mc.ObserveRequest(err) != nil {
-		record.Warnf(openStackCluster, "FailedCreateListener", "Failed to create listener %s: %v", listenerName, err)
+		record.Errorf(openStackCluster, "FailedCreateListener", "Failed to create listener %s: %v", listenerName, err)
 		return nil, err
 	}
 
 	if err := s.waitForLoadBalancerActive(lbID); err != nil {
-		record.Warnf(openStackCluster, "FailedCreateListener", "Failed to create listener %s with id %s: wait for load balancer active %s: %v", listenerName, listener.ID, lbID, err)
+		record.Errorf(openStackCluster, "FailedCreateListener", "Failed to create listener %s with id %s: wait for load balancer active %s: %v", listenerName, listener.ID, lbID, err)
 		return nil, err
 	}
 
 	if err := s.waitForListener(listener.ID, "ACTIVE"); err != nil {
-		record.Warnf(openStackCluster, "FailedCreateListener", "Failed to create listener %s with id %s: wait for listener active: %v", listenerName, listener.ID, err)
+		record.Errorf(openStackCluster, "FailedCreateListener", "Failed to create listener %s with id %s: wait for listener active: %v", listenerName, listener.ID, err)
 		return nil, err
 	}
 
@@ -203,12 +203,12 @@ func (s *Service) getOrCreatePool(openStackCluster *infrav1.OpenStackCluster, po
 	mc := metrics.NewMetricPrometheusContext("loadbalancer_pool", "create")
 	pool, err = pools.Create(s.loadbalancerClient, poolCreateOpts).Extract()
 	if mc.ObserveRequest(err) != nil {
-		record.Warnf(openStackCluster, "FailedCreatePool", "Failed to create pool %s: %v", poolName, err)
+		record.Errorf(openStackCluster, "FailedCreatePool", "Failed to create pool %s: %v", poolName, err)
 		return nil, err
 	}
 
 	if err := s.waitForLoadBalancerActive(lbID); err != nil {
-		record.Warnf(openStackCluster, "FailedCreatePool", "Failed to create pool %s with id %s: wait for load balancer active %s: %v", poolName, pool.ID, lbID, err)
+		record.Errorf(openStackCluster, "FailedCreatePool", "Failed to create pool %s with id %s: wait for load balancer active %s: %v", poolName, pool.ID, lbID, err)
 		return nil, err
 	}
 
@@ -239,12 +239,12 @@ func (s *Service) getOrCreateMonitor(openStackCluster *infrav1.OpenStackCluster,
 	mc := metrics.NewMetricPrometheusContext("loadbalancer_healthmonitor", "create")
 	monitor, err = monitors.Create(s.loadbalancerClient, monitorCreateOpts).Extract()
 	if mc.ObserveRequest(err) != nil {
-		record.Warnf(openStackCluster, "FailedCreateMonitor", "Failed to create monitor %s: %v", monitorName, err)
+		record.Errorf(openStackCluster, "FailedCreateMonitor", "Failed to create monitor %s: %v", monitorName, err)
 		return err
 	}
 
 	if err = s.waitForLoadBalancerActive(lbID); err != nil {
-		record.Warnf(openStackCluster, "FailedCreateMonitor", "Failed to create monitor %s with id %s: wait for load balancer active %s: %v", monitorName, monitor.ID, lbID, err)
+		record.Errorf(openStackCluster, "FailedCreateMonitor", "Failed to create monitor %s with id %s: wait for load balancer active %s: %v", monitorName, monitor.ID, lbID, err)
 		return err
 	}
 
@@ -373,7 +373,7 @@ func (s *Service) DeleteLoadBalancer(openStackCluster *infrav1.OpenStackCluster,
 	mc := metrics.NewMetricPrometheusContext("loadbalancer", "delete")
 	err = loadbalancers.Delete(s.loadbalancerClient, lb.ID, deleteOpts).ExtractErr()
 	if mc.ObserveRequest(err) != nil {
-		record.Warnf(openStackCluster, "FailedDeleteLoadBalancer", "Failed to delete load balancer %s with id %s: %v", lb.Name, lb.ID, err)
+		record.Errorf(openStackCluster, "FailedDeleteLoadBalancer", "Failed to delete load balancer %s with id %s: %v", lb.Name, lb.ID, err)
 		return err
 	}
 

--- a/pkg/cloud/services/networking/floatingip.go
+++ b/pkg/cloud/services/networking/floatingip.go
@@ -51,7 +51,7 @@ func (s *Service) GetOrCreateFloatingIP(openStackCluster *infrav1.OpenStackClust
 
 	fp, err = s.client.CreateFloatingIP(fpCreateOpts)
 	if err != nil {
-		record.Warnf(openStackCluster, "FailedCreateFloatingIP", "Failed to create floating IP %s: %v", ip, err)
+		record.Errorf(openStackCluster, "FailedCreateFloatingIP", "Failed to create floating IP %s: %v", ip, err)
 		return nil, err
 	}
 
@@ -103,7 +103,7 @@ func (s *Service) DeleteFloatingIP(openStackCluster *infrav1.OpenStackCluster, i
 
 	err = s.client.DeleteFloatingIP(fip.ID)
 	if err != nil {
-		record.Warnf(openStackCluster, "FailedDeleteFloatingIP", "Failed to delete floating IP %s: %v", ip, err)
+		record.Errorf(openStackCluster, "FailedDeleteFloatingIP", "Failed to delete floating IP %s: %v", ip, err)
 		return err
 	}
 
@@ -132,12 +132,12 @@ func (s *Service) AssociateFloatingIP(openStackCluster *infrav1.OpenStackCluster
 
 	_, err := s.client.UpdateFloatingIP(fp.ID, fpUpdateOpts)
 	if err != nil {
-		record.Warnf(openStackCluster, "FailedAssociateFloatingIP", "Failed to associate floating IP %s with port %s: %v", fp.FloatingIP, portID, err)
+		record.Errorf(openStackCluster, "FailedAssociateFloatingIP", "Failed to associate floating IP %s with port %s: %v", fp.FloatingIP, portID, err)
 		return err
 	}
 
 	if err = s.waitForFloatingIP(fp.ID, "ACTIVE"); err != nil {
-		record.Warnf(openStackCluster, "FailedAssociateFloatingIP", "Failed to associate floating IP %s with port %s: wait for floating IP ACTIVE: %v", fp.FloatingIP, portID, err)
+		record.Errorf(openStackCluster, "FailedAssociateFloatingIP", "Failed to associate floating IP %s with port %s: wait for floating IP ACTIVE: %v", fp.FloatingIP, portID, err)
 		return err
 	}
 
@@ -163,12 +163,12 @@ func (s *Service) DisassociateFloatingIP(openStackCluster *infrav1.OpenStackClus
 
 	_, err = s.client.UpdateFloatingIP(fip.ID, fpUpdateOpts)
 	if err != nil {
-		record.Warnf(openStackCluster, "FailedDisassociateFloatingIP", "Failed to disassociate floating IP %s: %v", fip.FloatingIP, err)
+		record.Errorf(openStackCluster, "FailedDisassociateFloatingIP", "Failed to disassociate floating IP %s: %v", fip.FloatingIP, err)
 		return err
 	}
 
 	if err = s.waitForFloatingIP(fip.ID, "DOWN"); err != nil {
-		record.Warnf(openStackCluster, "FailedDisassociateFloatingIP", "Failed to disassociate floating IP: wait for floating IP DOWN: %v", fip.FloatingIP, err)
+		record.Errorf(openStackCluster, "FailedDisassociateFloatingIP", "Failed to disassociate floating IP: wait for floating IP DOWN: %v", fip.FloatingIP, err)
 		return err
 	}
 

--- a/pkg/cloud/services/networking/network.go
+++ b/pkg/cloud/services/networking/network.go
@@ -125,7 +125,7 @@ func (s *Service) ReconcileNetwork(openStackCluster *infrav1.OpenStackCluster, c
 
 	network, err := s.client.CreateNetwork(opts)
 	if err != nil {
-		record.Warnf(openStackCluster, "FailedCreateNetwork", "Failed to create network %s: %v", networkName, err)
+		record.Errorf(openStackCluster, "FailedCreateNetwork", "Failed to create network %s: %v", networkName, err)
 		return err
 	}
 	record.Eventf(openStackCluster, "SuccessfulCreateNetwork", "Created network %s with id %s", networkName, network.ID)
@@ -159,7 +159,7 @@ func (s *Service) DeleteNetwork(openStackCluster *infrav1.OpenStackCluster, clus
 
 	err = s.client.DeleteNetwork(network.ID)
 	if err != nil {
-		record.Warnf(openStackCluster, "FailedDeleteNetwork", "Failed to delete network %s with id %s: %v", network.Name, network.ID, err)
+		record.Errorf(openStackCluster, "FailedDeleteNetwork", "Failed to delete network %s with id %s: %v", network.Name, network.ID, err)
 		return err
 	}
 
@@ -221,7 +221,7 @@ func (s *Service) createSubnet(openStackCluster *infrav1.OpenStackCluster, clust
 
 	subnet, err := s.client.CreateSubnet(opts)
 	if err != nil {
-		record.Warnf(openStackCluster, "FailedCreateSubnet", "Failed to create subnet %s: %v", name, err)
+		record.Errorf(openStackCluster, "FailedCreateSubnet", "Failed to create subnet %s: %v", name, err)
 		return nil, err
 	}
 	record.Eventf(openStackCluster, "SuccessfulCreateSubnet", "Created subnet %s with id %s", name, subnet.ID)

--- a/pkg/cloud/services/networking/port.go
+++ b/pkg/cloud/services/networking/port.go
@@ -162,7 +162,7 @@ func (s *Service) GetOrCreatePort(eventObject runtime.Object, clusterName string
 
 	port, err := s.client.CreatePort(createOpts)
 	if err != nil {
-		record.Warnf(eventObject, "FailedCreatePort", "Failed to create port %s: %v", portName, err)
+		record.Errorf(eventObject, "FailedCreatePort", "Failed to create port %s: %v", portName, err)
 		return nil, err
 	}
 
@@ -171,7 +171,7 @@ func (s *Service) GetOrCreatePort(eventObject runtime.Object, clusterName string
 	tags = append(tags, portOpts.Tags...)
 	if len(tags) > 0 {
 		if err = s.replaceAllAttributesTags(eventObject, portResource, port.ID, tags); err != nil {
-			record.Warnf(eventObject, "FailedReplaceTags", "Failed to replace port tags %s: %v", portName, err)
+			record.Errorf(eventObject, "FailedReplaceTags", "Failed to replace port tags %s: %v", portName, err)
 			return nil, err
 		}
 	}
@@ -179,11 +179,11 @@ func (s *Service) GetOrCreatePort(eventObject runtime.Object, clusterName string
 	if portOpts.Trunk != nil && *portOpts.Trunk {
 		trunk, err := s.getOrCreateTrunk(eventObject, clusterName, port.Name, port.ID)
 		if err != nil {
-			record.Warnf(eventObject, "FailedCreateTrunk", "Failed to create trunk for port %s: %v", portName, err)
+			record.Errorf(eventObject, "FailedCreateTrunk", "Failed to create trunk for port %s: %v", portName, err)
 			return nil, err
 		}
 		if err = s.replaceAllAttributesTags(eventObject, trunkResource, trunk.ID, tags); err != nil {
-			record.Warnf(eventObject, "FailedReplaceTags", "Failed to replace trunk tags %s: %v", portName, err)
+			record.Errorf(eventObject, "FailedReplaceTags", "Failed to replace trunk tags %s: %v", portName, err)
 			return nil, err
 		}
 	}
@@ -255,7 +255,7 @@ func (s *Service) DeletePort(eventObject runtime.Object, portID string) error {
 		return true, nil
 	})
 	if err != nil {
-		record.Warnf(eventObject, "FailedDeletePort", "Failed to delete port %s with id %s: %v", port.Name, port.ID, err)
+		record.Errorf(eventObject, "FailedDeletePort", "Failed to delete port %s with id %s: %v", port.Name, port.ID, err)
 		return err
 	}
 

--- a/pkg/cloud/services/networking/router.go
+++ b/pkg/cloud/services/networking/router.go
@@ -130,7 +130,7 @@ func (s *Service) createRouter(openStackCluster *infrav1.OpenStackCluster, clust
 
 	router, err := s.client.CreateRouter(opts)
 	if err != nil {
-		record.Warnf(openStackCluster, "FailedCreateRouter", "Failed to create router %s: %v", name, err)
+		record.Errorf(openStackCluster, "FailedCreateRouter", "Failed to create router %s: %v", name, err)
 		return nil, err
 	}
 	record.Eventf(openStackCluster, "SuccessfulCreateRouter", "Created router %s with id %s", name, router.ID)
@@ -175,7 +175,7 @@ func (s *Service) setRouterExternalIPs(openStackCluster *infrav1.OpenStackCluste
 
 	_, err := s.client.UpdateRouter(router.ID, updateOpts)
 	if err != nil {
-		record.Warnf(openStackCluster, "FailedUpdateRouter", "Failed to update router %s with id %s: %v", router.Name, router.ID, err)
+		record.Errorf(openStackCluster, "FailedUpdateRouter", "Failed to update router %s with id %s: %v", router.Name, router.ID, err)
 		return err
 	}
 
@@ -209,7 +209,7 @@ func (s *Service) DeleteRouter(openStackCluster *infrav1.OpenStackCluster, clust
 
 	err = s.client.DeleteRouter(router.ID)
 	if err != nil {
-		record.Warnf(openStackCluster, "FailedDeleteRouter", "Failed to delete router %s with id %s: %v", router.Name, router.ID, err)
+		record.Errorf(openStackCluster, "FailedDeleteRouter", "Failed to delete router %s with id %s: %v", router.Name, router.ID, err)
 		return err
 	}
 

--- a/pkg/cloud/services/networking/securitygroups.go
+++ b/pkg/cloud/services/networking/securitygroups.go
@@ -448,7 +448,7 @@ func (s *Service) deleteSecurityGroup(openStackCluster *infrav1.OpenStackCluster
 	}
 	err = s.client.DeleteSecGroup(group.ID)
 	if err != nil {
-		record.Warnf(openStackCluster, "FailedDeleteSecurityGroup", "Failed to delete security group %s with id %s: %v", group.Name, group.ID, err)
+		record.Errorf(openStackCluster, "FailedDeleteSecurityGroup", "Failed to delete security group %s with id %s: %v", group.Name, group.ID, err)
 		return err
 	}
 
@@ -544,7 +544,7 @@ func (s *Service) createSecurityGroupIfNotExists(openStackCluster *infrav1.OpenS
 
 		group, err := s.client.CreateSecGroup(createOpts)
 		if err != nil {
-			record.Warnf(openStackCluster, "FailedCreateSecurityGroup", "Failed to create security group %s: %v", groupName, err)
+			record.Errorf(openStackCluster, "FailedCreateSecurityGroup", "Failed to create security group %s: %v", groupName, err)
 			return err
 		}
 

--- a/pkg/cloud/services/networking/service.go
+++ b/pkg/cloud/services/networking/service.go
@@ -86,7 +86,7 @@ func (s *Service) replaceAllAttributesTags(eventObject runtime.Object, resourceT
 		return nil
 	}
 	if resourceType != trunkResource && resourceType != portResource {
-		record.Warnf(eventObject, "FailedReplaceAllAttributesTags", "Invalid resourceType argument in function call")
+		record.Error(eventObject, "FailedReplaceAllAttributesTags", "Invalid resourceType argument in function call")
 		panic(fmt.Errorf("invalid argument: resourceType, %s, does not match allowed arguments: %s or %s", resourceType, trunkResource, portResource))
 	}
 	// remove duplicate values from tags
@@ -104,7 +104,7 @@ func (s *Service) replaceAllAttributesTags(eventObject runtime.Object, resourceT
 		Tags: uniqueTags,
 	})
 	if err != nil {
-		record.Warnf(eventObject, "FailedReplaceAllAttributesTags", "Failed to replace all attributestags, %s: %v", resourceID, err)
+		record.Errorf(eventObject, "FailedReplaceAllAttributesTags", "Failed to replace all attributestags, %s: %v", resourceID, err)
 		return err
 	}
 

--- a/pkg/cloud/services/networking/trunk.go
+++ b/pkg/cloud/services/networking/trunk.go
@@ -69,7 +69,7 @@ func (s *Service) getOrCreateTrunk(eventObject runtime.Object, clusterName, trun
 
 	trunk, err := s.client.CreateTrunk(trunkCreateOpts)
 	if err != nil {
-		record.Warnf(eventObject, "FailedCreateTrunk", "Failed to create trunk %s: %v", trunkName, err)
+		record.Errorf(eventObject, "FailedCreateTrunk", "Failed to create trunk %s: %v", trunkName, err)
 		return nil, err
 	}
 
@@ -103,7 +103,7 @@ func (s *Service) DeleteTrunk(eventObject runtime.Object, portID string) error {
 		return true, nil
 	})
 	if err != nil {
-		record.Warnf(eventObject, "FailedDeleteTrunk", "Failed to delete trunk %s with id %s: %v", trunkInfo[0].Name, trunkInfo[0].ID, err)
+		record.Errorf(eventObject, "FailedDeleteTrunk", "Failed to delete trunk %s with id %s: %v", trunkInfo[0].Name, trunkInfo[0].ID, err)
 		return err
 	}
 

--- a/pkg/record/recorder.go
+++ b/pkg/record/recorder.go
@@ -31,6 +31,10 @@ var (
 	defaultRecorder record.EventRecorder
 )
 
+const (
+	EventTypeError string = "Error"
+)
+
 func init() {
 	defaultRecorder = new(record.FakeRecorder)
 }
@@ -61,4 +65,14 @@ func Warn(object runtime.Object, reason, message string) {
 // Warnf is just like Warn, but with Sprintf for the message field.
 func Warnf(object runtime.Object, reason, message string, args ...interface{}) {
 	defaultRecorder.Eventf(object, corev1.EventTypeWarning, strings.Title(reason), message, args...)
+}
+
+// Error constructs an Error event from the given information and puts it in the queue for sending.
+func Error(object runtime.Object, reason, message string) {
+	defaultRecorder.Event(object, EventTypeError, strings.Title(reason), message)
+}
+
+// Errorf is just like Error, but with Sprintf for the message field.
+func Errorf(object runtime.Object, reason, message string, args ...interface{}) {
+	defaultRecorder.Eventf(object, EventTypeError, strings.Title(reason), message, args...)
 }


### PR DESCRIPTION
Due to the absence of [EventTypeError](https://github.com/kubernetes/api/blob/bfe324c0d64befbab416bd4063c0a38a6cda9334/core/v1/types.go#L5650-L5655), some part of the CAPO code is using `EventTypeWarning`  for failing events. 

This PR introduces `EventTypeError` constant and changes log entries of failing events to the correct type.



Fixes: #1121