### PR TITLE
🐛 Delete trunk on failure

### DIFF
--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -486,7 +486,17 @@ func (s *Service) DeleteInstance(eventObject runtime.Object, instance *InstanceS
 }
 
 func (s *Service) deletePorts(eventObject runtime.Object, nets []servers.Network) error {
+	trunkSupported, err := s.isTrunkExtSupported()
+	if err != nil {
+		return err
+	}
+
 	for _, n := range nets {
+		if trunkSupported {
+			if err = s.networkingService.DeleteTrunk(eventObject, n.Port); err != nil {
+				return err
+			}
+		}
 		if err := s.networkingService.DeletePort(eventObject, n.Port); err != nil {
 			return err
 		}


### PR DESCRIPTION
Conflicts:
  pkg/cloud/services/compute/instance_test.go

  Unit tests have not been backported because they added test cases to
  unit tests which don't exist in release-0.5.

(cherry picked from commit 28f820b3580ac901864b169560ab89b325f323bd)

/hold
