### PR TITLE
🐛Remove v1.0.x as CAPO don't have that version until now

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -10,6 +10,3 @@ releaseSeries:
 - major: 0
   minor: 5
   contract: v1beta1
-- major: 1
-  minor: 0
-  contract: v1beta1


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

during release v0.5.1 found issue https://github.com/kubernetes-sigs/cluster-api/issues/6076
turn out to be our own problem
I manually updated this file in release manifest 
https://github.com/kubernetes-sigs/cluster-api-provider-openstack/releases/download/v0.5.1/metadata.yaml
and with this PR we should remove those definitions

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related: #1129 
Fixes: #1134

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
