### PR TITLE
Avoid set failMessage when bastion creation failed

### DIFF
--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -328,7 +328,6 @@ func reconcileBastion(log logr.Logger, osProviderClient *gophercloud.ProviderCli
 
 	instanceStatus, err = computeService.CreateBastion(openStackCluster, cluster.Name)
 	if err != nil {
-		handleUpdateOSCError(openStackCluster, errors.Errorf("failed to reconcile bastion: %v", err))
 		return errors.Errorf("failed to reconcile bastion: %v", err)
 	}
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

Avoid set failMessage if create bastion failed (which we will not reconcile again)
instead, give some chance to re-create or customer might do some manual changes in order to
make cluster able to create again

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related: #1131 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
