### PR TITLE
🐛 containerfile: Bump Go version

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -24,7 +24,7 @@
 #         media type: "application/vnd.oci.image.layer.v1.tar+gzip"
 
 # Build the manager binary
-FROM golang:1.16.0 as builder
+FROM golang:1.17.6 as builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg goproxy=$(go env GOPROXY) to override the goproxy


### PR DESCRIPTION
Keep in sync with Dockerfile.

**What this PR does / why we need it**:
Aligns Containerfile's Go version to Dockerfile's.

**Which issue(s) this PR fixes**:
Fixes #1155

**Notes for the reviewer**:
This patch should only impact local development environments, and not affect any release image.

**TODOs**:

- [x] squashed commits