### PR TITLE
move CI to xena

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ This provider's versions are able to install and manage the following versions o
 
 This provider's versions are able to install Kubernetes to the following versions of OpenStack:
 
-|                                    | Pike | Queens | Rocky | Stein | Train | Ussuri | Victoria | Wallaby |
-| ---------------------------------- | ---- | ------ | ----- | ----- | ----- | ------ | -------- | ------- |
-| OpenStack Provider v1alpha3 (v0.3) | +    | +      | +     | ✓     | ✓     | ✓      | ✓        |         |
-| OpenStack Provider v1alpha4 (v0.4) | +    | +      | +     | +     | +     | +      | ✓        |         |
-| OpenStack Provider v1alpha4 (v0.5) | +    | +      | +     | +     | +     | +      | ✓        |         |
-| OpenStack Provider v1beta1         | +    | +      | +     | +     | +     | +      | ✓        | ✓       |
+|                                    | Pike | Queens | Rocky | Stein | Train | Ussuri | Victoria | Wallaby | Xena |
+| ---------------------------------- | ---- | ------ | ----- | ----- | ----- | ------ | -------- | ------- | ---- |
+| OpenStack Provider v1alpha3 (v0.3) | +    | +      | +     | ✓     | ✓     | ✓      | ✓        |         |      |
+| OpenStack Provider v1alpha4 (v0.4) | +    | +      | +     | +     | +     | +      | ✓        |         |      |
+| OpenStack Provider v1alpha4 (v0.5) | +    | +      | +     | +     | +     | +      | ✓        |         |      |
+| OpenStack Provider v1beta1         | +    | +      | +     | +     | +     | +      | ✓        | ✓       | ✓    |
 
 Test status:
 

--- a/hack/ci/cloud-init/controller.yaml.tpl
+++ b/hack/ci/cloud-init/controller.yaml.tpl
@@ -130,8 +130,10 @@
     source /opt/stack/devstack/openrc admin admin
 
     # Upload the images so we don't have to upload them from Prow
-    /opt/stack/devstack/tools/upload_image.sh https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/ubuntu/2021-03-27/ubuntu-2004-kube-v1.18.15.qcow2
+    # Upload cirros image first in order to avoid reach limit of project
+    # https://docs.openstack.org/glance/latest/admin/quotas.html 
     /opt/stack/devstack/tools/upload_image.sh https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/cirros/2021-03-27/cirros-0.5.1-x86_64-disk.img
+    /opt/stack/devstack/tools/upload_image.sh https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/ubuntu/2021-03-27/ubuntu-2004-kube-v1.18.15.qcow2
 
     # Add the controller to its own host aggregate and availability zone
     aggregateid=$(openstack aggregate create --zone "${PRIMARY_AZ}" "${PRIMARY_AZ}" -f value -c id)

--- a/hack/ci/create_devstack.sh
+++ b/hack/ci/create_devstack.sh
@@ -30,7 +30,7 @@ source "${scriptdir}/${RESOURCE_TYPE}.sh"
 
 CLUSTER_NAME=${CLUSTER_NAME:-"capo-e2e"}
 
-OPENSTACK_RELEASE=${OPENSTACK_RELEASE:-"wallaby"}
+OPENSTACK_RELEASE=${OPENSTACK_RELEASE:-"xena"}
 OPENSTACK_ENABLE_HORIZON=${OPENSTACK_ENABLE_HORIZON:-"false"}
 
 # Devstack will create a provider network using this range


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

part of this steal from https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1098
but I can't update that PR so created a new one

the main change to that PR is the sequence of upload ubuntu and cirros image
the reason is https://docs.openstack.org/glance/latest/admin/quotas.html 
introduced a limit and if ubuntu is uploaded first then cirros will not be able to upload due to limit introduced in x release, on the contrary , ubuntu is able to be uploaded because at time of upload
the limit is not reached  (yet)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
