### PR TITLE
🐛 Clean up removed AvailabilityZones from `OpenStackCluster.status.failureDomains`

### DIFF
--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -268,9 +268,9 @@ func reconcileNormal(ctx context.Context, log logr.Logger, client client.Client,
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	if openStackCluster.Status.FailureDomains == nil {
-		openStackCluster.Status.FailureDomains = make(clusterv1.FailureDomains)
-	}
+	// Create a new list to remove any Availability
+	// Zones that have been removed from OpenStack
+	openStackCluster.Status.FailureDomains = make(clusterv1.FailureDomains)
 	for _, az := range availabilityZones {
 		// I'm actually not sure if that's just my local devstack,
 		// but we probably shouldn't use the "internal" AZ


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

Previously we only added to the List of `FailureDomains`, but this can cause issue in case any Availability Zone is removed in OpenStack, as that AZ will still be used by CAPI to deploy Control Plane machines. With this PR, the list of available FailureDomains/AZs is recreated on every reconcile and outdated entries are removed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1163

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
