### PR TITLE
🐛 Clean up removed AvailabilityZones from `OpenStackCluster.status.failureDomains` 

### DIFF
--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -268,9 +268,9 @@ func reconcileNormal(ctx context.Context, log logr.Logger, client client.Client,
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	if openStackCluster.Status.FailureDomains == nil {
-		openStackCluster.Status.FailureDomains = make(clusterv1.FailureDomains)
-	}
+	// Create a new list to remove any Availability
+	// Zones that have been removed from OpenStack
+	openStackCluster.Status.FailureDomains = make(clusterv1.FailureDomains)
 	for _, az := range availabilityZones {
 		// I'm actually not sure if that's just my local devstack,
 		// but we probably shouldn't use the "internal" AZ


### PR DESCRIPTION
**What this PR does / why we need it**:

Cherry pick of #1165 onto `release-0.5` as discussed in #1166 



**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.
