### PR TITLE
🐛 Fix event target of floating ip operations

### DIFF
--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -331,7 +331,7 @@ func reconcileBastion(log logr.Logger, osProviderClient *gophercloud.ProviderCli
 		return err
 	}
 	clusterName := fmt.Sprintf("%s-%s", cluster.Namespace, cluster.Name)
-	fp, err := networkingService.GetOrCreateFloatingIP(openStackCluster, clusterName, openStackCluster.Spec.Bastion.Instance.FloatingIP)
+	fp, err := networkingService.GetOrCreateFloatingIP(openStackCluster, openStackCluster, clusterName, openStackCluster.Spec.Bastion.Instance.FloatingIP)
 	if err != nil {
 		handleUpdateOSCError(openStackCluster, errors.Errorf("failed to get or create floating IP for bastion: %v", err))
 		return errors.Errorf("failed to get or create floating IP for bastion: %v", err)
@@ -474,7 +474,7 @@ func reconcileNetworkComponents(log logr.Logger, osProviderClient *gophercloud.P
 			}
 		case !openStackCluster.Spec.DisableAPIServerFloatingIP:
 			// If floating IPs are not disabled, get one to use as the VIP for the control plane
-			fp, err := networkingService.GetOrCreateFloatingIP(openStackCluster, clusterName, openStackCluster.Spec.APIServerFloatingIP)
+			fp, err := networkingService.GetOrCreateFloatingIP(openStackCluster, openStackCluster, clusterName, openStackCluster.Spec.APIServerFloatingIP)
 			if err != nil {
 				handleUpdateOSCError(openStackCluster, errors.Errorf("Floating IP cannot be got or created: %v", err))
 				return errors.Errorf("Floating IP cannot be got or created: %v", err)

--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -233,7 +233,7 @@ func (r *OpenStackMachineReconciler) reconcileDelete(ctx context.Context, logger
 			addresses := instanceNS.Addresses()
 			for _, address := range addresses {
 				if address.Type == corev1.NodeExternalIP {
-					if err = networkingService.DeleteFloatingIP(openStackCluster, address.Address); err != nil {
+					if err = networkingService.DeleteFloatingIP(openStackMachine, address.Address); err != nil {
 						handleUpdateMachineError(logger, openStackMachine, errors.Errorf("error deleting Openstack floating IP: %v", err))
 						return ctrl.Result{}, nil
 					}
@@ -361,7 +361,7 @@ func (r *OpenStackMachineReconciler) reconcileNormal(ctx context.Context, logger
 		if openStackCluster.Spec.APIServerFloatingIP != "" {
 			floatingIPAddress = openStackCluster.Spec.APIServerFloatingIP
 		}
-		fp, err := networkingService.GetOrCreateFloatingIP(openStackCluster, clusterName, floatingIPAddress)
+		fp, err := networkingService.GetOrCreateFloatingIP(openStackMachine, openStackCluster, clusterName, floatingIPAddress)
 		if err != nil {
 			handleUpdateMachineError(logger, openStackMachine, errors.Errorf("Floating IP cannot be got or created: %v", err))
 			return ctrl.Result{}, nil
@@ -372,7 +372,7 @@ func (r *OpenStackMachineReconciler) reconcileNormal(ctx context.Context, logger
 			handleUpdateMachineError(logger, openStackMachine, err)
 			return ctrl.Result{}, nil
 		}
-		err = networkingService.AssociateFloatingIP(openStackCluster, fp, port.ID)
+		err = networkingService.AssociateFloatingIP(openStackMachine, fp, port.ID)
 		if err != nil {
 			handleUpdateMachineError(logger, openStackMachine, errors.Errorf("Floating IP cannot be associated: %v", err))
 			return ctrl.Result{}, nil

--- a/pkg/cloud/services/loadbalancer/loadbalancer.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer.go
@@ -71,7 +71,7 @@ func (s *Service) ReconcileLoadBalancer(openStackCluster *infrav1.OpenStackClust
 		case openStackCluster.Spec.ControlPlaneEndpoint.IsValid():
 			floatingIPAddress = openStackCluster.Spec.ControlPlaneEndpoint.Host
 		}
-		fp, err := s.networkingService.GetOrCreateFloatingIP(openStackCluster, clusterName, floatingIPAddress)
+		fp, err := s.networkingService.GetOrCreateFloatingIP(openStackCluster, openStackCluster, clusterName, floatingIPAddress)
 		if err != nil {
 			return err
 		}

--- a/pkg/cloud/services/networking/floatingip_test.go
+++ b/pkg/cloud/services/networking/floatingip_test.go
@@ -77,7 +77,8 @@ func Test_GetOrCreateFloatingIP(t *testing.T) {
 			s := Service{
 				client: mockClient,
 			}
-			got, err := s.GetOrCreateFloatingIP(openStackCluster, "test-cluster", tt.ip)
+			eventObject := infrav1.OpenStackMachine{}
+			got, err := s.GetOrCreateFloatingIP(&eventObject, openStackCluster, "test-cluster", tt.ip)
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(got).To(Equal(tt.want))
 		})


### PR DESCRIPTION
Floating IP operations were always reporting events against the cluster,
even when creating a floating IP on behalf of a machine.

Fixes: #1176 

/hold
