### PR TITLE
🏃 Add Scopes to pass data to services

### DIFF
--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -217,7 +217,7 @@ func (s *Service) createInstance(eventObject runtime.Object, clusterName string,
 		}
 
 		if err := s.deletePorts(eventObject, portList); err != nil {
-			s.logger.V(4).Error(err, "failed to clean up ports after failure", "cluster", clusterName, "machine", instanceSpec.Name)
+			s.scope.Logger.V(4).Error(err, "failed to clean up ports after failure", "cluster", clusterName, "machine", instanceSpec.Name)
 		}
 	}()
 
@@ -381,7 +381,7 @@ func (s *Service) getOrCreateRootVolume(eventObject runtime.Object, instanceSpec
 			return nil, fmt.Errorf("exected to find volume %s with size %d; found size %d", name, size, volume.Size)
 		}
 
-		s.logger.Info("using existing root volume %s", name)
+		s.scope.Logger.Info("using existing root volume %s", name)
 		return volume, nil
 	}
 
@@ -596,7 +596,7 @@ func (s *Service) DeleteInstance(eventObject runtime.Object, openStackMachineSpe
 				return nil
 			}
 
-			s.logger.Info("deleting dangling root volume %s(%s)", volume.Name, volume.ID)
+			s.scope.Logger.Info("deleting dangling root volume %s(%s)", volume.Name, volume.ID)
 			return s.computeService.DeleteVolume(volume.ID, volumes.DeleteOpts{})
 		}
 
@@ -721,7 +721,7 @@ func (s *Service) GetInstanceStatus(resourceID string) (instance *InstanceStatus
 		return nil, fmt.Errorf("get server %q detail failed: %v", resourceID, err)
 	}
 
-	return &InstanceStatus{server, s.logger}, nil
+	return &InstanceStatus{server, s.scope.Logger}, nil
 }
 
 func (s *Service) GetInstanceStatusByName(eventObject runtime.Object, name string) (instance *InstanceStatus, err error) {
@@ -748,7 +748,7 @@ func (s *Service) GetInstanceStatusByName(eventObject runtime.Object, name strin
 
 	// Return the first returned server, if any
 	for i := range serverList {
-		return &InstanceStatus{&serverList[i], s.logger}, nil
+		return &InstanceStatus{&serverList[i], s.scope.Logger}, nil
 	}
 	return nil, nil
 }

--- a/pkg/cloud/services/compute/instance_test.go
+++ b/pkg/cloud/services/compute/instance_test.go
@@ -49,6 +49,7 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/networking"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/networking/mock_networking"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
 )
 
 type gomegaMockMatcher struct {
@@ -496,10 +497,12 @@ func TestService_getImageID(t *testing.T) {
 			tt.expect(mockComputeClient.EXPECT())
 
 			s := Service{
-				projectID:         "",
+				projectID: "",
+				scope: &scope.Scope{
+					Logger: logr.Discard(),
+				},
 				computeService:    mockComputeClient,
 				networkingService: &networking.Service{},
-				logger:            logr.Discard(),
 			}
 
 			got, err := s.getImageID(tt.imageUUID, tt.imageName)
@@ -1116,12 +1119,14 @@ func TestService_CreateInstance(t *testing.T) {
 			tt.expect(computeRecorder, networkRecorder)
 
 			s := Service{
-				projectID:      "",
+				projectID: "",
+				scope: &scope.Scope{
+					Logger: logr.Discard(),
+				},
 				computeService: mockComputeClient,
 				networkingService: networking.NewTestService(
 					"", mockNetworkClient, logr.Discard(),
 				),
-				logger: logr.Discard(),
 			}
 			// Call CreateInstance with a reduced retry interval to speed up the test
 			_, err := s.createInstanceImpl(tt.getOpenStackCluster(), tt.getMachine(), tt.getOpenStackMachine(), "cluster-name", "user-data", time.Second)
@@ -1238,12 +1243,14 @@ func TestService_DeleteInstance(t *testing.T) {
 			tt.expect(computeRecorder, networkRecorder)
 
 			s := Service{
-				projectID:      "",
+				projectID: "",
+				scope: &scope.Scope{
+					Logger: logr.Discard(),
+				},
 				computeService: mockComputeClient,
 				networkingService: networking.NewTestService(
 					"", mockNetworkClient, logr.Discard(),
 				),
-				logger: logr.Discard(),
 			}
 			if err := s.DeleteInstance(tt.eventObject, tt.getOpenStackMachineSpec(), instanceName, tt.getInstanceStatus()); (err != nil) != tt.wantErr {
 				t.Errorf("Service.DeleteInstance() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/cloud/services/loadbalancer/loadbalancer.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer.go
@@ -44,7 +44,7 @@ const loadBalancerProvisioningStatusActive = "ACTIVE"
 
 func (s *Service) ReconcileLoadBalancer(openStackCluster *infrav1.OpenStackCluster, clusterName string, apiServerPort int) error {
 	loadBalancerName := getLoadBalancerName(clusterName)
-	s.logger.Info("Reconciling load balancer", "name", loadBalancerName)
+	s.scope.Logger.Info("Reconciling load balancer", "name", loadBalancerName)
 
 	var fixedIPAddress string
 	switch {
@@ -119,7 +119,7 @@ func (s *Service) getOrCreateLoadBalancer(openStackCluster *infrav1.OpenStackClu
 		return lb, nil
 	}
 
-	s.logger.Info(fmt.Sprintf("Creating load balancer in subnet: %q", subnetID), "name", loadBalancerName)
+	s.scope.Logger.Info(fmt.Sprintf("Creating load balancer in subnet: %q", subnetID), "name", loadBalancerName)
 
 	lbCreateOpts := loadbalancers.CreateOpts{
 		Name:        loadBalancerName,
@@ -152,7 +152,7 @@ func (s *Service) getOrCreateListener(openStackCluster *infrav1.OpenStackCluster
 		return listener, nil
 	}
 
-	s.logger.Info("Creating load balancer listener", "name", listenerName, "lb-id", lbID)
+	s.scope.Logger.Info("Creating load balancer listener", "name", listenerName, "lb-id", lbID)
 
 	listenerCreateOpts := listeners.CreateOpts{
 		Name:           listenerName,
@@ -190,7 +190,7 @@ func (s *Service) getOrCreatePool(openStackCluster *infrav1.OpenStackCluster, po
 		return pool, nil
 	}
 
-	s.logger.Info(fmt.Sprintf("Creating load balancer pool for listener %q", listenerID), "name", poolName, "lb-id", lbID)
+	s.scope.Logger.Info(fmt.Sprintf("Creating load balancer pool for listener %q", listenerID), "name", poolName, "lb-id", lbID)
 
 	poolCreateOpts := pools.CreateOpts{
 		Name:       poolName,
@@ -223,7 +223,7 @@ func (s *Service) getOrCreateMonitor(openStackCluster *infrav1.OpenStackCluster,
 		return nil
 	}
 
-	s.logger.Info(fmt.Sprintf("Creating load balancer monitor for pool %q", poolID), "name", monitorName, "lb-id", lbID)
+	s.scope.Logger.Info(fmt.Sprintf("Creating load balancer monitor for pool %q", poolID), "name", monitorName, "lb-id", lbID)
 
 	monitorCreateOpts := monitors.CreateOpts{
 		Name:       monitorName,
@@ -264,7 +264,7 @@ func (s *Service) ReconcileLoadBalancerMember(openStackCluster *infrav1.OpenStac
 	}
 
 	loadBalancerName := getLoadBalancerName(clusterName)
-	s.logger.Info("Reconciling load balancer member", "name", loadBalancerName)
+	s.scope.Logger.Info("Reconciling load balancer member", "name", loadBalancerName)
 
 	lbID := openStackCluster.Status.Network.APIServerLoadBalancer.ID
 	portList := []int{int(openStackCluster.Spec.ControlPlaneEndpoint.Port)}
@@ -293,7 +293,7 @@ func (s *Service) ReconcileLoadBalancerMember(openStackCluster *infrav1.OpenStac
 				continue
 			}
 
-			s.logger.Info("Deleting load balancer member (because the IP of the machine changed)", "name", name)
+			s.scope.Logger.Info("Deleting load balancer member (because the IP of the machine changed)", "name", name)
 
 			// lb member changed so let's delete it so we can create it again with the correct IP
 			err = s.waitForLoadBalancerActive(lbID)
@@ -309,7 +309,7 @@ func (s *Service) ReconcileLoadBalancerMember(openStackCluster *infrav1.OpenStac
 			}
 		}
 
-		s.logger.Info("Creating load balancer member", "name", name)
+		s.scope.Logger.Info("Creating load balancer member", "name", name)
 
 		// if we got to this point we should either create or re-create the lb member
 		lbMemberOpts := pools.CreateMemberOpts{
@@ -363,7 +363,7 @@ func (s *Service) DeleteLoadBalancer(openStackCluster *infrav1.OpenStackCluster,
 	deleteOpts := loadbalancers.DeleteOpts{
 		Cascade: true,
 	}
-	s.logger.Info("Deleting load balancer", "name", loadBalancerName, "cascade", deleteOpts.Cascade)
+	s.scope.Logger.Info("Deleting load balancer", "name", loadBalancerName, "cascade", deleteOpts.Cascade)
 	err = s.loadbalancerClient.DeleteLoadBalancer(lb.ID, deleteOpts)
 	if err != nil && !capoerrors.IsNotFound(err) {
 		record.Warnf(openStackCluster, "FailedDeleteLoadBalancer", "Failed to delete load balancer %s with id %s: %v", lb.Name, lb.ID, err)
@@ -402,7 +402,7 @@ func (s *Service) DeleteLoadBalancerMember(openStackCluster *infrav1.OpenStackCl
 			return err
 		}
 		if pool == nil {
-			s.logger.Info("Load balancer pool does not exist", "name", lbPortObjectsName)
+			s.scope.Logger.Info("Load balancer pool does not exist", "name", lbPortObjectsName)
 			continue
 		}
 
@@ -497,7 +497,7 @@ var backoff = wait.Backoff{
 
 // Possible LoadBalancer states are documented here: https://docs.openstack.org/api-ref/load-balancer/v2/index.html#prov-status
 func (s *Service) waitForLoadBalancerActive(id string) error {
-	s.logger.Info("Waiting for load balancer", "id", id, "targetStatus", "ACTIVE")
+	s.scope.Logger.Info("Waiting for load balancer", "id", id, "targetStatus", "ACTIVE")
 	return wait.ExponentialBackoff(backoff, func() (bool, error) {
 		lb, err := s.loadbalancerClient.GetLoadBalancer(id)
 		if err != nil {
@@ -508,7 +508,7 @@ func (s *Service) waitForLoadBalancerActive(id string) error {
 }
 
 func (s *Service) waitForListener(id, target string) error {
-	s.logger.Info("Waiting for load balancer listener", "id", id, "targetStatus", target)
+	s.scope.Logger.Info("Waiting for load balancer listener", "id", id, "targetStatus", target)
 	return wait.ExponentialBackoff(backoff, func() (bool, error) {
 		_, err := s.loadbalancerClient.GetListener(id)
 		if err != nil {

--- a/pkg/cloud/services/networking/floatingip.go
+++ b/pkg/cloud/services/networking/floatingip.go
@@ -120,7 +120,7 @@ var backoff = wait.Backoff{
 }
 
 func (s *Service) AssociateFloatingIP(eventObject runtime.Object, fp *floatingips.FloatingIP, portID string) error {
-	s.logger.Info("Associating floating IP", "id", fp.ID, "ip", fp.FloatingIP)
+	s.scope.Logger.Info("Associating floating IP", "id", fp.ID, "ip", fp.FloatingIP)
 
 	if fp.PortID == portID {
 		record.Eventf(eventObject, "SuccessfulAssociateFloatingIP", "Floating IP %s already associated with port %s", fp.FloatingIP, portID)
@@ -152,11 +152,11 @@ func (s *Service) DisassociateFloatingIP(eventObject runtime.Object, ip string) 
 		return err
 	}
 	if fip == nil || fip.FloatingIP == "" {
-		s.logger.Info("Floating IP not associated", "ip", ip)
+		s.scope.Logger.Info("Floating IP not associated", "ip", ip)
 		return nil
 	}
 
-	s.logger.Info("Disassociating floating IP", "id", fip.ID, "ip", fip.FloatingIP)
+	s.scope.Logger.Info("Disassociating floating IP", "id", fip.ID, "ip", fip.FloatingIP)
 
 	fpUpdateOpts := &floatingips.UpdateOpts{
 		PortID: nil,
@@ -178,7 +178,7 @@ func (s *Service) DisassociateFloatingIP(eventObject runtime.Object, ip string) 
 }
 
 func (s *Service) waitForFloatingIP(id, target string) error {
-	s.logger.Info("Waiting for floating IP", "id", id, "targetStatus", target)
+	s.scope.Logger.Info("Waiting for floating IP", "id", id, "targetStatus", target)
 	return wait.ExponentialBackoff(backoff, func() (bool, error) {
 		fip, err := s.client.GetFloatingIP(id)
 		if err != nil {

--- a/pkg/cloud/services/networking/network.go
+++ b/pkg/cloud/services/networking/network.go
@@ -74,7 +74,7 @@ func (s *Service) ReconcileExternalNetwork(openStackCluster *infrav1.OpenStackCl
 	case 0:
 		// Not finding an external network is fine
 		openStackCluster.Status.ExternalNetwork = &infrav1.Network{}
-		s.logger.Info("No external network found - proceeding with internal network only")
+		s.scope.Logger.Info("No external network found - proceeding with internal network only")
 		return nil
 	case 1:
 		openStackCluster.Status.ExternalNetwork = &infrav1.Network{
@@ -82,7 +82,7 @@ func (s *Service) ReconcileExternalNetwork(openStackCluster *infrav1.OpenStackCl
 			Name: networkList[0].Name,
 			Tags: networkList[0].Tags,
 		}
-		s.logger.Info("External network found", "network id", networkList[0].ID)
+		s.scope.Logger.Info("External network found", "network id", networkList[0].ID)
 		return nil
 	}
 	return fmt.Errorf("found %d external networks, which should not happen", len(networkList))
@@ -90,7 +90,7 @@ func (s *Service) ReconcileExternalNetwork(openStackCluster *infrav1.OpenStackCl
 
 func (s *Service) ReconcileNetwork(openStackCluster *infrav1.OpenStackCluster, clusterName string) error {
 	networkName := getNetworkName(clusterName)
-	s.logger.Info("Reconciling network", "name", networkName)
+	s.scope.Logger.Info("Reconciling network", "name", networkName)
 
 	res, err := s.getNetworkByName(networkName)
 	if err != nil {
@@ -105,7 +105,7 @@ func (s *Service) ReconcileNetwork(openStackCluster *infrav1.OpenStackCluster, c
 			Tags: res.Tags,
 		}
 		sInfo := fmt.Sprintf("Reuse Existing Network %s with id %s", res.Name, res.ID)
-		s.logger.V(6).Info(sInfo)
+		s.scope.Logger.V(6).Info(sInfo)
 		return nil
 	}
 
@@ -169,12 +169,12 @@ func (s *Service) DeleteNetwork(openStackCluster *infrav1.OpenStackCluster, clus
 
 func (s *Service) ReconcileSubnet(openStackCluster *infrav1.OpenStackCluster, clusterName string) error {
 	if openStackCluster.Status.Network == nil || openStackCluster.Status.Network.ID == "" {
-		s.logger.V(4).Info("No need to reconcile network components since no network exists.")
+		s.scope.Logger.V(4).Info("No need to reconcile network components since no network exists.")
 		return nil
 	}
 
 	subnetName := getSubnetName(clusterName)
-	s.logger.Info("Reconciling subnet", "name", subnetName)
+	s.scope.Logger.Info("Reconciling subnet", "name", subnetName)
 
 	subnetList, err := s.client.ListSubnet(subnets.ListOpts{
 		NetworkID: openStackCluster.Status.Network.ID,
@@ -197,7 +197,7 @@ func (s *Service) ReconcileSubnet(openStackCluster *infrav1.OpenStackCluster, cl
 		}
 	} else if len(subnetList) == 1 {
 		subnet = &subnetList[0]
-		s.logger.V(6).Info(fmt.Sprintf("Reuse existing subnet %s with id %s", subnetName, subnet.ID))
+		s.scope.Logger.V(6).Info(fmt.Sprintf("Reuse existing subnet %s with id %s", subnetName, subnet.ID))
 	}
 
 	openStackCluster.Status.Network.Subnet = &infrav1.Subnet{

--- a/pkg/cloud/services/networking/router.go
+++ b/pkg/cloud/services/networking/router.go
@@ -32,20 +32,20 @@ import (
 
 func (s *Service) ReconcileRouter(openStackCluster *infrav1.OpenStackCluster, clusterName string) error {
 	if openStackCluster.Status.Network == nil || openStackCluster.Status.Network.ID == "" {
-		s.logger.V(3).Info("No need to reconcile router since no network exists.")
+		s.scope.Logger.V(3).Info("No need to reconcile router since no network exists.")
 		return nil
 	}
 	if openStackCluster.Status.Network.Subnet == nil || openStackCluster.Status.Network.Subnet.ID == "" {
-		s.logger.V(4).Info("No need to reconcile router since no subnet exists.")
+		s.scope.Logger.V(4).Info("No need to reconcile router since no subnet exists.")
 		return nil
 	}
 	if openStackCluster.Status.ExternalNetwork == nil || openStackCluster.Status.ExternalNetwork.ID == "" {
-		s.logger.V(3).Info("No need to create router, due to missing ExternalNetworkID.")
+		s.scope.Logger.V(3).Info("No need to create router, due to missing ExternalNetworkID.")
 		return nil
 	}
 
 	routerName := getRouterName(clusterName)
-	s.logger.Info("Reconciling router", "name", routerName)
+	s.scope.Logger.Info("Reconciling router", "name", routerName)
 
 	routerList, err := s.client.ListRouter(routers.ListOpts{
 		Name: routerName,
@@ -67,7 +67,7 @@ func (s *Service) ReconcileRouter(openStackCluster *infrav1.OpenStackCluster, cl
 		}
 	} else {
 		router = &routerList[0]
-		s.logger.V(6).Info(fmt.Sprintf("Reuse existing Router %s with id %s", routerName, router.ID))
+		s.scope.Logger.V(6).Info(fmt.Sprintf("Reuse existing Router %s with id %s", routerName, router.ID))
 	}
 
 	openStackCluster.Status.Network.Router = &infrav1.Router{
@@ -101,14 +101,14 @@ INTERFACE_LOOP:
 
 	// ... and create a router interface for our subnet.
 	if createInterface {
-		s.logger.V(4).Info("Creating RouterInterface", "routerID", router.ID, "subnetID", openStackCluster.Status.Network.Subnet.ID)
+		s.scope.Logger.V(4).Info("Creating RouterInterface", "routerID", router.ID, "subnetID", openStackCluster.Status.Network.Subnet.ID)
 		routerInterface, err := s.client.AddRouterInterface(router.ID, routers.AddInterfaceOpts{
 			SubnetID: openStackCluster.Status.Network.Subnet.ID,
 		})
 		if err != nil {
 			return fmt.Errorf("unable to create router interface: %v", err)
 		}
-		s.logger.V(4).Info("Created RouterInterface", "id", routerInterface.ID)
+		s.scope.Logger.V(4).Info("Created RouterInterface", "id", routerInterface.ID)
 	}
 	return nil
 }
@@ -201,9 +201,9 @@ func (s *Service) DeleteRouter(openStackCluster *infrav1.OpenStackCluster, clust
 			if !capoerrors.IsNotFound(err) {
 				return fmt.Errorf("unable to remove router interface: %v", err)
 			}
-			s.logger.V(4).Info("Router Interface already removed, nothing to do", "id", router.ID)
+			s.scope.Logger.V(4).Info("Router Interface already removed, nothing to do", "id", router.ID)
 		} else {
-			s.logger.V(4).Info("Removed RouterInterface of Router", "id", router.ID)
+			s.scope.Logger.V(4).Info("Removed RouterInterface of Router", "id", router.ID)
 		}
 	}
 

--- a/pkg/cloud/services/networking/securitygroups.go
+++ b/pkg/cloud/services/networking/securitygroups.go
@@ -58,9 +58,9 @@ var defaultRules = []infrav1.SecurityGroupRule{
 
 // ReconcileSecurityGroups reconcile the security groups.
 func (s *Service) ReconcileSecurityGroups(openStackCluster *infrav1.OpenStackCluster, clusterName string) error {
-	s.logger.Info("Reconciling security groups", "cluster", clusterName)
+	s.scope.Logger.Info("Reconciling security groups", "cluster", clusterName)
 	if !openStackCluster.Spec.ManagedSecurityGroups {
-		s.logger.V(4).Info("No need to reconcile security groups", "cluster", clusterName)
+		s.scope.Logger.V(4).Info("No need to reconcile security groups", "cluster", clusterName)
 		return nil
 	}
 
@@ -501,16 +501,16 @@ func (s *Service) reconcileGroupRules(desired, observed infrav1.SecurityGroup) (
 		}
 	}
 
-	s.logger.V(4).Info("Deleting rules not needed anymore for group", "name", observed.Name, "amount", len(rulesToDelete))
+	s.scope.Logger.V(4).Info("Deleting rules not needed anymore for group", "name", observed.Name, "amount", len(rulesToDelete))
 	for _, rule := range rulesToDelete {
-		s.logger.V(6).Info("Deleting rule", "ruleID", rule.ID, "groupName", observed.Name)
+		s.scope.Logger.V(6).Info("Deleting rule", "ruleID", rule.ID, "groupName", observed.Name)
 		err := s.client.DeleteSecGroupRule(rule.ID)
 		if err != nil {
 			return infrav1.SecurityGroup{}, err
 		}
 	}
 
-	s.logger.V(4).Info("Creating new rules needed for group", "name", observed.Name, "amount", len(rulesToCreate))
+	s.scope.Logger.V(4).Info("Creating new rules needed for group", "name", observed.Name, "amount", len(rulesToCreate))
 	for _, rule := range rulesToCreate {
 		r := rule
 		r.SecurityGroupID = observed.ID
@@ -534,13 +534,13 @@ func (s *Service) createSecurityGroupIfNotExists(openStackCluster *infrav1.OpenS
 		return err
 	}
 	if secGroup == nil || secGroup.ID == "" {
-		s.logger.V(6).Info("Group doesn't exist, creating it.", "name", groupName)
+		s.scope.Logger.V(6).Info("Group doesn't exist, creating it.", "name", groupName)
 
 		createOpts := groups.CreateOpts{
 			Name:        groupName,
 			Description: "Cluster API managed group",
 		}
-		s.logger.V(6).Info("Creating group", "name", groupName)
+		s.scope.Logger.V(6).Info("Creating group", "name", groupName)
 
 		group, err := s.client.CreateSecGroup(createOpts)
 		if err != nil {
@@ -562,7 +562,7 @@ func (s *Service) createSecurityGroupIfNotExists(openStackCluster *infrav1.OpenS
 	}
 
 	sInfo := fmt.Sprintf("Reuse Existing SecurityGroup %s with %s", groupName, secGroup.ID)
-	s.logger.V(6).Info(sInfo)
+	s.scope.Logger.V(6).Info(sInfo)
 
 	return nil
 }
@@ -572,7 +572,7 @@ func (s *Service) getSecurityGroupByName(name string) (*infrav1.SecurityGroup, e
 		Name: name,
 	}
 
-	s.logger.V(6).Info("Attempting to fetch security group with", "name", name)
+	s.scope.Logger.V(6).Info("Attempting to fetch security group with", "name", name)
 	allGroups, err := s.client.ListSecGroup(opts)
 	if err != nil {
 		return &infrav1.SecurityGroup{}, err
@@ -604,7 +604,7 @@ func (s *Service) createRule(r infrav1.SecurityGroupRule) (infrav1.SecurityGroup
 		RemoteIPPrefix: r.RemoteIPPrefix,
 		SecGroupID:     r.SecurityGroupID,
 	}
-	s.logger.V(6).Info("Creating rule", "Description", r.Description, "Direction", dir, "PortRangeMin", r.PortRangeMin, "PortRangeMax", r.PortRangeMax, "Proto", proto, "etherType", etherType, "RemoteGroupID", r.RemoteGroupID, "RemoteIPPrefix", r.RemoteIPPrefix, "SecurityGroupID", r.SecurityGroupID)
+	s.scope.Logger.V(6).Info("Creating rule", "Description", r.Description, "Direction", dir, "PortRangeMin", r.PortRangeMin, "PortRangeMax", r.PortRangeMax, "Proto", proto, "etherType", etherType, "RemoteGroupID", r.RemoteGroupID, "RemoteIPPrefix", r.RemoteIPPrefix, "SecurityGroupID", r.SecurityGroupID)
 	rule, err := s.client.CreateSecGroupRule(createOpts)
 	if err != nil {
 		return infrav1.SecurityGroupRule{}, err

--- a/pkg/scope/scope.go
+++ b/pkg/scope/scope.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scope
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/utils/openstack/clientconfig"
+)
+
+// Scope is used to initialize Services from Controllers and includes the
+// common objects required for this.
+//
+// The Gophercloud ProviderClient and ClientOpts are required to create new
+// Gophercloud API Clients (e.g. for Networking/Neutron).
+//
+// The Logger includes context values such as the cluster name.
+type Scope struct {
+	ProviderClient     *gophercloud.ProviderClient
+	ProviderClientOpts *clientconfig.ClientOpts
+
+	Logger logr.Logger
+}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

This refactoring will make it easier to pass the `ProjectID` into the services that need it (see #1146). The Scopes pattern is also used by other CAPI Providers:

- CAPA: https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/pkg/cloud/scope/cluster.go
- CAPG: https://github.com/kubernetes-sigs/cluster-api-provider-gcp/blob/main/cloud/scope/cluster.go
- CAPV (Called `Context`): https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/main/pkg/context/cluster_context.go

/hold
