### PR TITLE
🐛 Address CVE-2022-21698

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus/client_golang v1.11.0
+	github.com/prometheus/client_golang v1.11.1
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
 	gopkg.in/ini.v1 v1.63.2

--- a/go.sum
+++ b/go.sum
@@ -770,8 +770,9 @@ github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDf
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
-github.com/prometheus/client_golang v1.11.0 h1:HNkLOAEQMIDv/K+04rukrLx6ch7msSRwf3/SASFAGtQ=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
+github.com/prometheus/client_golang v1.11.1 h1:+4eQaD7vAZ6DsfsxB15hbE0odUjGI5ARs9yskGu1v4s=
+github.com/prometheus/client_golang v1.11.1/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
 github.com/prometheus/client_model v0.0.0-20171117100541-99fa1f4be8e5/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=


### PR DESCRIPTION
Upgrade the Prometheus client to v1.11.1.

This commit is the result of running:

```
go get github.com/prometheus/client_golang@v1.11.1 \
	&& go mod tidy
```

See https://github.com/prometheus/client_golang/security/advisories/GHSA-cg3q-j54f-5p7p

**What this PR does / why we need it**:
Upgrades `github.com/prometheus/client_golang` to v1.11.1, where the vulnerability has been fixed.

**Which issue(s) this PR fixes**:
Fixes #1181

**Special notes for your reviewer**:
One handy way to check that the version of `client_go` used for compiling contains the security patch, is to run `go mod vendor` and check that the `InstrumentRoundTripperCounter` method [contains a variadic `options` argument](https://github.com/prometheus/client_golang/compare/v1.11.0...v1.11.1#diff-7871a83741d29b5f29e3c47d1c284f948c258a0c6fc18895f0c2d4204cc46054R63).

```
$ grep InstrumentRoundTripperCounter vendor/github.com/prometheus/client_golang/prometheus/promhttp/instrument_client.go
// InstrumentRoundTripperCounter is a middleware that wraps the provided
func InstrumentRoundTripperCounter(counter *prometheus.CounterVec, next http.RoundTripper, opts ...Option) RoundTripperFunc {
```
**TODOs**:

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests