### PR TITLE
🏃 Enable controller tests

### DIFF
--- a/scripts/go_install.sh
+++ b/scripts/go_install.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [ -z "${1}" ]; then
+  echo "must provide module as first parameter"
+  exit 1
+fi
+
+if [ -z "${2}" ]; then
+  echo "must provide binary name as second parameter"
+  exit 1
+fi
+
+if [ -z "${3}" ]; then
+  echo "must provide version as third parameter"
+  exit 1
+fi
+
+if [ -z "${GOBIN}" ]; then
+  echo "GOBIN is not set. Must set GOBIN to install the bin in a specified directory."
+  exit 1
+fi
+
+rm "${GOBIN}/${2}"* || true
+
+# install the golang module specified as the first argument
+go install -tags tools "${1}@${3}"
+mv "${GOBIN}/${2}" "${GOBIN}/${2}-${3}"
+ln -sf "${GOBIN}/${2}-${3}" "${GOBIN}/${2}"


### PR DESCRIPTION
**What this PR does / why we need it**:

The controller test suite was disabled due to missing kubebuilder
assets. These are now installed before running the tests. There are no
tests yet but now it is possible to add some.

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests
