### PR TITLE
🐛 Install sshuttle using pip instead of from source

### DIFF
--- a/hack/ci/create_devstack.sh
+++ b/hack/ci/create_devstack.sh
@@ -94,14 +94,7 @@ function wait_for_ssh {
 function start_sshuttle {
     if ! command -v sshuttle;
     then
-        # Install sshuttle from source because we need: https://github.com/sshuttle/sshuttle/pull/661
-        # TODO(sbueringer) install via pip after the next release after 1.0.5 via:
-        # pip3 install sshuttle
-        pushd /tmp
-        git clone https://github.com/sshuttle/sshuttle.git
-        cd sshuttle
-        pip3 install .
-        popd || exit 1
+        pip3 install sshuttle
     fi
 
     kill_sshuttle


### PR DESCRIPTION
**What this PR does / why we need it**:

We used to install sshuttle from source because we needed a commit that was not in the latest release. There is however a new release now that includes the commit. Upstream sshuttle also [dropped support for python 3.6 and 3.7 recently](https://github.com/sshuttle/sshuttle/commit/6d36916f48ae69abe175682f111f505923aba339) which means we can no longer install that, since we use python 3.7.

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests
