### PR TITLE
✨ Support Application Credential auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ policy may be made to more closely aligned with other providers in the Cluster A
 
 **NOTE:** The minimum microversion of CAPI using nova is `2.53` now due to `server tags` support, see [code](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/c052e7e600f0e5ebddc839c08746bb636e79be87/pkg/cloud/services/compute/service.go#L38) for additional information.
 
+**NOTE:** We require Keystone v3 for authentication.
+
 ------
 
 ## Development versions

--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -107,7 +107,7 @@ func (r *OpenStackClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 	}()
 
-	osProviderClient, clientOpts, err := provider.NewClientFromCluster(ctx, r.Client, openStackCluster)
+	osProviderClient, clientOpts, projectID, err := provider.NewClientFromCluster(ctx, r.Client, openStackCluster)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -115,6 +115,7 @@ func (r *OpenStackClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	scope := &scope.Scope{
 		ProviderClient:     osProviderClient,
 		ProviderClientOpts: clientOpts,
+		ProjectID:          projectID,
 		Logger:             log,
 	}
 

--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -140,7 +140,7 @@ func (r *OpenStackMachineReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 	}()
 
-	osProviderClient, clientOpts, err := provider.NewClientFromMachine(ctx, r.Client, openStackMachine)
+	osProviderClient, clientOpts, projectID, err := provider.NewClientFromMachine(ctx, r.Client, openStackMachine)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -148,6 +148,7 @@ func (r *OpenStackMachineReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	scope := &scope.Scope{
 		ProviderClient:     osProviderClient,
 		ProviderClientOpts: clientOpts,
+		ProjectID:          projectID,
 		Logger:             log,
 	}
 

--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -290,7 +290,7 @@ func (s *Service) getVolumeByName(name string) (*volumes.Volume, error) {
 	listOpts := volumes.ListOpts{
 		AllTenants: false,
 		Name:       name,
-		TenantID:   s.projectID,
+		TenantID:   s.scope.ProjectID,
 	}
 	volumeList, err := s.computeService.ListVolumes(listOpts)
 	if err != nil {

--- a/pkg/cloud/services/compute/instance_test.go
+++ b/pkg/cloud/services/compute/instance_test.go
@@ -494,9 +494,9 @@ func TestService_getImageID(t *testing.T) {
 			tt.expect(mockComputeClient.EXPECT())
 
 			s := Service{
-				projectID: "",
 				scope: &scope.Scope{
-					Logger: logr.Discard(),
+					ProjectID: "",
+					Logger:    logr.Discard(),
 				},
 				computeService:    mockComputeClient,
 				networkingService: &networking.Service{},
@@ -997,9 +997,9 @@ func TestService_ReconcileInstance(t *testing.T) {
 			tt.expect(computeRecorder, networkRecorder)
 
 			s := Service{
-				projectID: "",
 				scope: &scope.Scope{
-					Logger: logr.Discard(),
+					Logger:    logr.Discard(),
+					ProjectID: "",
 				},
 				computeService: mockComputeClient,
 				networkingService: networking.NewTestService(
@@ -1108,9 +1108,9 @@ func TestService_DeleteInstance(t *testing.T) {
 			tt.expect(computeRecorder, networkRecorder)
 
 			s := Service{
-				projectID: "",
 				scope: &scope.Scope{
-					Logger: logr.Discard(),
+					ProjectID: "",
+					Logger:    logr.Discard(),
 				},
 				computeService: mockComputeClient,
 				networkingService: networking.NewTestService(

--- a/pkg/cloud/services/compute/service.go
+++ b/pkg/cloud/services/compute/service.go
@@ -23,12 +23,10 @@ import (
 	"github.com/gophercloud/gophercloud/openstack"
 
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/networking"
-	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/provider"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
 )
 
 type Service struct {
-	projectID         string
 	scope             *scope.Scope
 	computeService    Client
 	networkingService *networking.Service
@@ -75,18 +73,12 @@ func NewService(scope *scope.Scope) (*Service, error) {
 		return nil, fmt.Errorf("authInfo must be set")
 	}
 
-	projectID, err := provider.GetProjectID(scope.ProviderClient, scope.ProviderClientOpts)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieveing project id: %v", err)
-	}
-
 	networkingService, err := networking.NewService(scope)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create networking service: %v", err)
 	}
 
 	return &Service{
-		projectID:         projectID,
 		scope:             scope,
 		computeService:    computeService,
 		networkingService: networkingService,

--- a/pkg/cloud/services/networking/securitygroups.go
+++ b/pkg/cloud/services/networking/securitygroups.go
@@ -404,7 +404,7 @@ func (s *Service) GetSecurityGroups(securityGroupParams []infrav1.SecurityGroupP
 
 		listOpts := groups.ListOpts(sg.Filter)
 		if listOpts.ProjectID == "" {
-			listOpts.ProjectID = s.projectID
+			listOpts.ProjectID = s.scope.ProjectID
 		}
 		listOpts.Name = sg.Name
 		listOpts.ID = sg.UUID

--- a/pkg/cloud/services/networking/service.go
+++ b/pkg/cloud/services/networking/service.go
@@ -26,7 +26,6 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/provider"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/record"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
 )
@@ -40,9 +39,8 @@ const (
 // Service interfaces with the OpenStack Networking API.
 // It will create a network related infrastructure for the cluster, like network, subnet, router, security groups.
 type Service struct {
-	projectID string
-	scope     *scope.Scope
-	client    NetworkClient
+	scope  *scope.Scope
+	client NetworkClient
 }
 
 // NewService returns an instance of the networking service.
@@ -58,24 +56,18 @@ func NewService(scope *scope.Scope) (*Service, error) {
 		return nil, fmt.Errorf("failed to get project id: authInfo must be set")
 	}
 
-	projectID, err := provider.GetProjectID(scope.ProviderClient, scope.ProviderClientOpts)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieveing project id: %v", err)
-	}
-
 	return &Service{
-		projectID: projectID,
-		scope:     scope,
-		client:    networkClient{serviceClient},
+		scope:  scope,
+		client: networkClient{serviceClient},
 	}, nil
 }
 
 // NewTestService returns a Service with no initialisation. It should only be used by tests.
 func NewTestService(projectID string, client NetworkClient, logger logr.Logger) *Service {
 	return &Service{
-		projectID: projectID,
 		scope: &scope.Scope{
-			Logger: logger,
+			ProjectID: projectID,
+			Logger:    logger,
 		},
 		client: client,
 	}

--- a/pkg/scope/scope.go
+++ b/pkg/scope/scope.go
@@ -32,6 +32,7 @@ import (
 type Scope struct {
 	ProviderClient     *gophercloud.ProviderClient
 	ProviderClientOpts *clientconfig.ClientOpts
+	ProjectID          string
 
 	Logger logr.Logger
 }

--- a/test/e2e/shared/openstack.go
+++ b/test/e2e/shared/openstack.go
@@ -64,7 +64,7 @@ type ServerExtWithIP struct {
 func ensureSSHKeyPair(e2eCtx *E2EContext) {
 	Byf("Ensuring presence of SSH key %q in OpenStack", DefaultSSHKeyPairName)
 
-	providerClient, clientOpts, err := GetTenantProviderClient(e2eCtx)
+	providerClient, clientOpts, _, err := GetTenantProviderClient(e2eCtx)
 	Expect(err).NotTo(HaveOccurred())
 
 	computeClient, err := openstack.NewComputeV2(providerClient, gophercloud.EndpointOpts{Region: clientOpts.RegionName})
@@ -103,7 +103,7 @@ func dumpOpenStack(_ context.Context, e2eCtx *E2EContext, bootstrapClusterProxyN
 	}
 	_, _ = fmt.Fprintf(GinkgoWriter, "folder created for OpenStack clusters: %s\n", logPath)
 
-	providerClient, clientOpts, err := GetTenantProviderClient(e2eCtx)
+	providerClient, clientOpts, _, err := GetTenantProviderClient(e2eCtx)
 	if err != nil {
 		_, _ = fmt.Fprintf(GinkgoWriter, "error creating provider client: %s\n", err)
 		return
@@ -141,7 +141,7 @@ func dumpOpenStackImages(providerClient *gophercloud.ProviderClient, clientOpts 
 }
 
 func DumpOpenStackServers(e2eCtx *E2EContext, filter servers.ListOpts) ([]servers.Server, error) {
-	providerClient, clientOpts, err := GetTenantProviderClient(e2eCtx)
+	providerClient, clientOpts, _, err := GetTenantProviderClient(e2eCtx)
 	if err != nil {
 		_, _ = fmt.Fprintf(GinkgoWriter, "error creating provider client: %s\n", err)
 		return nil, nil
@@ -167,7 +167,7 @@ func DumpOpenStackServers(e2eCtx *E2EContext, filter servers.ListOpts) ([]server
 }
 
 func DumpOpenStackNetworks(e2eCtx *E2EContext, filter networks.ListOpts) ([]networks.Network, error) {
-	providerClient, clientOpts, err := GetTenantProviderClient(e2eCtx)
+	providerClient, clientOpts, _, err := GetTenantProviderClient(e2eCtx)
 	if err != nil {
 		_, _ = fmt.Fprintf(GinkgoWriter, "error creating provider client: %s\n", err)
 		return nil, nil
@@ -192,7 +192,7 @@ func DumpOpenStackNetworks(e2eCtx *E2EContext, filter networks.ListOpts) ([]netw
 }
 
 func DumpOpenStackSubnets(e2eCtx *E2EContext, filter subnets.ListOpts) ([]subnets.Subnet, error) {
-	providerClient, clientOpts, err := GetTenantProviderClient(e2eCtx)
+	providerClient, clientOpts, _, err := GetTenantProviderClient(e2eCtx)
 	if err != nil {
 		_, _ = fmt.Fprintf(GinkgoWriter, "error creating provider client: %s\n", err)
 		return nil, nil
@@ -217,7 +217,7 @@ func DumpOpenStackSubnets(e2eCtx *E2EContext, filter subnets.ListOpts) ([]subnet
 }
 
 func DumpOpenStackRouters(e2eCtx *E2EContext, filter routers.ListOpts) ([]routers.Router, error) {
-	providerClient, clientOpts, err := GetTenantProviderClient(e2eCtx)
+	providerClient, clientOpts, _, err := GetTenantProviderClient(e2eCtx)
 	if err != nil {
 		_, _ = fmt.Fprintf(GinkgoWriter, "error creating provider client: %s\n", err)
 		return nil, nil
@@ -242,7 +242,7 @@ func DumpOpenStackRouters(e2eCtx *E2EContext, filter routers.ListOpts) ([]router
 }
 
 func DumpOpenStackSecurityGroups(e2eCtx *E2EContext, filter groups.ListOpts) ([]groups.SecGroup, error) {
-	providerClient, clientOpts, err := GetTenantProviderClient(e2eCtx)
+	providerClient, clientOpts, _, err := GetTenantProviderClient(e2eCtx)
 	if err != nil {
 		_, _ = fmt.Fprintf(GinkgoWriter, "error creating provider client: %s\n", err)
 		return nil, nil
@@ -267,7 +267,7 @@ func DumpOpenStackSecurityGroups(e2eCtx *E2EContext, filter groups.ListOpts) ([]
 }
 
 func DumpOpenStackPorts(e2eCtx *E2EContext, filter ports.ListOpts) ([]ports.Port, error) {
-	providerClient, clientOpts, err := GetTenantProviderClient(e2eCtx)
+	providerClient, clientOpts, _, err := GetTenantProviderClient(e2eCtx)
 	if err != nil {
 		_, _ = fmt.Fprintf(GinkgoWriter, "error creating provider client: %s\n", err)
 		return nil, err
@@ -293,7 +293,7 @@ func DumpOpenStackPorts(e2eCtx *E2EContext, filter ports.ListOpts) ([]ports.Port
 
 // DumpOpenStackTrunks trunks for a given port.
 func DumpOpenStackTrunks(e2eCtx *E2EContext, portID string) (*trunks.Trunk, error) {
-	providerClient, clientOpts, err := GetTenantProviderClient(e2eCtx)
+	providerClient, clientOpts, _, err := GetTenantProviderClient(e2eCtx)
 	if err != nil {
 		_, _ = fmt.Fprintf(GinkgoWriter, "error creating provider client: %s\n", err)
 		return nil, err
@@ -325,7 +325,7 @@ func DumpOpenStackTrunks(e2eCtx *E2EContext, portID string) (*trunks.Trunk, erro
 // GetOpenStackServers gets all OpenStack servers at once, to save on DescribeInstances
 // calls.
 func GetOpenStackServers(e2eCtx *E2EContext, openStackCluster *infrav1.OpenStackCluster) (map[string]ServerExtWithIP, error) {
-	providerClient, clientOpts, err := GetTenantProviderClient(e2eCtx)
+	providerClient, clientOpts, _, err := GetTenantProviderClient(e2eCtx)
 	if err != nil {
 		_, _ = fmt.Fprintf(GinkgoWriter, "error creating provider client: %s\n", err)
 		return nil, nil
@@ -371,28 +371,28 @@ func GetOpenStackServers(e2eCtx *E2EContext, openStackCluster *infrav1.OpenStack
 	return srvs, nil
 }
 
-func GetTenantProviderClient(e2eCtx *E2EContext) (*gophercloud.ProviderClient, *clientconfig.ClientOpts, error) {
+func GetTenantProviderClient(e2eCtx *E2EContext) (*gophercloud.ProviderClient, *clientconfig.ClientOpts, *string, error) {
 	openstackCloud := e2eCtx.E2EConfig.GetVariable(OpenStackCloud)
 	return getProviderClient(e2eCtx, openstackCloud)
 }
 
-func GetAdminProviderClient(e2eCtx *E2EContext) (*gophercloud.ProviderClient, *clientconfig.ClientOpts, error) {
+func GetAdminProviderClient(e2eCtx *E2EContext) (*gophercloud.ProviderClient, *clientconfig.ClientOpts, *string, error) {
 	openstackCloud := e2eCtx.E2EConfig.GetVariable(OpenStackCloudAdmin)
 	return getProviderClient(e2eCtx, openstackCloud)
 }
 
-func getProviderClient(e2eCtx *E2EContext, openstackCloud string) (*gophercloud.ProviderClient, *clientconfig.ClientOpts, error) {
+func getProviderClient(e2eCtx *E2EContext, openstackCloud string) (*gophercloud.ProviderClient, *clientconfig.ClientOpts, *string, error) {
 	openStackCloudYAMLFile := e2eCtx.E2EConfig.GetVariable(OpenStackCloudYAMLFile)
 
 	clouds := getParsedOpenStackCloudYAML(openStackCloudYAMLFile)
 	cloud := clouds.Clouds[openstackCloud]
 
-	providerClient, clientOpts, err := provider.NewClient(cloud, nil)
+	providerClient, clientOpts, projectID, err := provider.NewClient(cloud, nil)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	return providerClient, clientOpts, nil
+	return providerClient, clientOpts, &projectID, nil
 }
 
 // Config is used to read and store information from the cloud configuration file
@@ -503,7 +503,7 @@ func getOpenStackCloudYAML(cloudYAML string) []byte {
 }
 
 func GetComputeAvailabilityZones(e2eCtx *E2EContext) []string {
-	providerClient, clientOpts, err := GetTenantProviderClient(e2eCtx)
+	providerClient, clientOpts, _, err := GetTenantProviderClient(e2eCtx)
 	Expect(err).NotTo(HaveOccurred())
 
 	computeClient, err := openstack.NewComputeV2(providerClient, gophercloud.EndpointOpts{Region: clientOpts.RegionName})
@@ -525,7 +525,7 @@ func GetComputeAvailabilityZones(e2eCtx *E2EContext) []string {
 }
 
 func CreateOpenStackNetwork(e2eCtx *E2EContext, name, cidr string) (*networks.Network, error) {
-	providerClient, clientOpts, err := GetTenantProviderClient(e2eCtx)
+	providerClient, clientOpts, _, err := GetTenantProviderClient(e2eCtx)
 	if err != nil {
 		_, _ = fmt.Fprintf(GinkgoWriter, "error creating provider client: %s\n", err)
 		return nil, err
@@ -562,7 +562,7 @@ func CreateOpenStackNetwork(e2eCtx *E2EContext, name, cidr string) (*networks.Ne
 }
 
 func DeleteOpenStackNetwork(e2eCtx *E2EContext, id string) error {
-	providerClient, clientOpts, err := GetTenantProviderClient(e2eCtx)
+	providerClient, clientOpts, _, err := GetTenantProviderClient(e2eCtx)
 	if err != nil {
 		_, _ = fmt.Fprintf(GinkgoWriter, "error creating provider client: %s\n", err)
 		return err
@@ -579,7 +579,7 @@ func DeleteOpenStackNetwork(e2eCtx *E2EContext, id string) error {
 }
 
 func GetOpenStackVolume(e2eCtx *E2EContext, name string) (*volumes.Volume, error) {
-	providerClient, clientOpts, err := GetTenantProviderClient(e2eCtx)
+	providerClient, clientOpts, _, err := GetTenantProviderClient(e2eCtx)
 	if err != nil {
 		_, _ = fmt.Fprintf(GinkgoWriter, "error creating provider client: %s\n", err)
 		return nil, err

--- a/test/e2e/suites/e2e/e2e_test.go
+++ b/test/e2e/suites/e2e/e2e_test.go
@@ -833,7 +833,7 @@ func isCloudProviderInitialized(taints []corev1.Taint) bool {
 }
 
 func createTestVolumeType(e2eCtx *shared.E2EContext) {
-	providerClient, clientOpts, err := shared.GetAdminProviderClient(e2eCtx)
+	providerClient, clientOpts, _, err := shared.GetAdminProviderClient(e2eCtx)
 	Expect(err).NotTo(HaveOccurred())
 
 	volumeClient, err := openstack.NewBlockStorageV3(providerClient, gophercloud.EndpointOpts{Region: clientOpts.RegionName})


### PR DESCRIPTION

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

We currently require an explicit `project_id` field in the clouds.yaml. This conflicts with the usual fields for Application Credentials, as they already include a scope, and setting another conflicts with that.

In this commit, we instead save the returned `project_id` from the initial auth api call, and pass it around to all services using the `Scope` struct.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1146 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

/hold
