### PR TITLE
🏃 Add tests for cluster controller

### DIFF
--- a/controllers/openstackcluster_controller_test.go
+++ b/controllers/openstackcluster_controller_test.go
@@ -1,0 +1,224 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/utils/openstack/clientconfig"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/util/annotations"
+	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha5"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
+)
+
+var (
+	reconciler    OpenStackClusterReconciler
+	ctx           context.Context
+	testCluster   *infrav1.OpenStackCluster
+	capiCluster   *clusterv1.Cluster
+	testNamespace string
+)
+
+var _ = Describe("OpenStackCluster controller", func() {
+	capiClusterName := "capi-cluster"
+	testClusterName := "test-cluster"
+	testNum := 0
+
+	BeforeEach(func() {
+		ctx = context.TODO()
+		reconciler = OpenStackClusterReconciler{
+			Client: k8sClient,
+		}
+		testNum++
+		testNamespace = fmt.Sprintf("test-%d", testNum)
+
+		testCluster = &infrav1.OpenStackCluster{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: infrav1.GroupVersion.Group + "/" + infrav1.GroupVersion.Version,
+				Kind:       "OpenStackCluster",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testClusterName,
+				Namespace: testNamespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: clusterv1.GroupVersion.Group + "/" + clusterv1.GroupVersion.Version,
+						Kind:       "Cluster",
+						Name:       capiClusterName,
+						UID:        types.UID("cluster-uid"),
+					},
+				},
+			},
+			Spec:   infrav1.OpenStackClusterSpec{},
+			Status: infrav1.OpenStackClusterStatus{},
+		}
+		capiCluster = &clusterv1.Cluster{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: clusterv1.GroupVersion.Group + "/" + clusterv1.GroupVersion.Version,
+				Kind:       "Cluster",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      capiClusterName,
+				Namespace: testNamespace,
+			},
+		}
+
+		input := framework.CreateNamespaceInput{
+			Creator: k8sClient,
+			Name:    testNamespace,
+		}
+		framework.CreateNamespace(ctx, input)
+	})
+
+	AfterEach(func() {
+		orphan := metav1.DeletePropagationOrphan
+		deleteOptions := client.DeleteOptions{
+			PropagationPolicy: &orphan,
+		}
+
+		// Remove finalizers and delete openstackcluster
+		patchHelper, err := patch.NewHelper(testCluster, k8sClient)
+		Expect(err).To(BeNil())
+		testCluster.SetFinalizers([]string{})
+		err = patchHelper.Patch(ctx, testCluster)
+		Expect(err).To(BeNil())
+		err = k8sClient.Delete(ctx, testCluster, &deleteOptions)
+		Expect(err).To(BeNil())
+		// Remove finalizers and delete cluster
+		patchHelper, err = patch.NewHelper(capiCluster, k8sClient)
+		Expect(err).To(BeNil())
+		capiCluster.SetFinalizers([]string{})
+		err = patchHelper.Patch(ctx, capiCluster)
+		Expect(err).To(BeNil())
+		err = k8sClient.Delete(ctx, capiCluster, &deleteOptions)
+		Expect(err).To(BeNil())
+		input := framework.DeleteNamespaceInput{
+			Deleter: k8sClient,
+			Name:    testNamespace,
+		}
+		framework.DeleteNamespace(ctx, input)
+	})
+
+	It("should do nothing when owner is missing", func() {
+		testCluster.SetName("missing-owner")
+		testCluster.SetOwnerReferences([]metav1.OwnerReference{})
+
+		err := k8sClient.Create(ctx, testCluster)
+		Expect(err).To(BeNil())
+		err = k8sClient.Create(ctx, capiCluster)
+		Expect(err).To(BeNil())
+		req := createRequestFromOSCluster(testCluster)
+
+		result, err := reconciler.Reconcile(ctx, req)
+		// Expect no error and empty result
+		Expect(err).To(BeNil())
+		Expect(result).To(Equal(reconcile.Result{}))
+	})
+	It("should do nothing when paused", func() {
+		testCluster.SetName("paused")
+		annotations.AddAnnotations(testCluster, map[string]string{clusterv1.PausedAnnotation: "true"})
+
+		err := k8sClient.Create(ctx, testCluster)
+		Expect(err).To(BeNil())
+		err = k8sClient.Create(ctx, capiCluster)
+		Expect(err).To(BeNil())
+		req := createRequestFromOSCluster(testCluster)
+
+		result, err := reconciler.Reconcile(ctx, req)
+		// Expect no error and empty result
+		Expect(err).To(BeNil())
+		Expect(result).To(Equal(reconcile.Result{}))
+	})
+	It("should do nothing when unable to get OS client", func() {
+		testCluster.SetName("no-openstack-client")
+		err := k8sClient.Create(ctx, testCluster)
+		Expect(err).To(BeNil())
+		err = k8sClient.Create(ctx, capiCluster)
+		Expect(err).To(BeNil())
+		req := createRequestFromOSCluster(testCluster)
+
+		result, err := reconciler.Reconcile(ctx, req)
+		// Expect error for getting OS clinet and empty result
+		Expect(err).ToNot(BeNil())
+		Expect(result).To(Equal(reconcile.Result{}))
+	})
+
+	// TODO: This test is set to pending (PIt instead of It) since it is not working.
+	PIt("should be able to reconcile when basition disabled", func() {
+		// verify := false
+		// cloud := clientconfig.Cloud{
+		// 	Cloud:      "test",
+		// 	RegionName: "test",
+		// 	Verify:     &verify,
+		// 	AuthInfo: &clientconfig.AuthInfo{
+		// 		AuthURL:        "https://example.com:5000",
+		// 		Username:       "testuser",
+		// 		Password:       "secret",
+		// 		ProjectName:    "test",
+		// 		DomainName:     "test",
+		// 		UserDomainName: "test",
+		// 	},
+		// }
+		// // TODO: Can we fake the client in some way?
+		// providerClient, clientOpts, _, err := provider.NewClient(cloud, nil)
+		// Expect(err).To(BeNil())
+		// scope := &scope.Scope{
+		// 	ProviderClient:     providerClient,
+		// 	ProviderClientOpts: clientOpts,
+		// }
+
+		// TODO: This won't work without filling in proper values.
+		scope := &scope.Scope{
+			ProviderClient:     &gophercloud.ProviderClient{},
+			ProviderClientOpts: &clientconfig.ClientOpts{},
+		}
+		testCluster.SetName("no-bastion")
+		testCluster.Spec = infrav1.OpenStackClusterSpec{
+			Bastion: &infrav1.Bastion{
+				Enabled: false,
+			},
+		}
+		err := k8sClient.Create(ctx, testCluster)
+		Expect(err).To(BeNil())
+		err = k8sClient.Create(ctx, capiCluster)
+		Expect(err).To(BeNil())
+
+		err = deleteBastion(scope, capiCluster, testCluster)
+		Expect(err).To(BeNil())
+	})
+})
+
+func createRequestFromOSCluster(openStackCluster *infrav1.OpenStackCluster) reconcile.Request {
+	return reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      openStackCluster.GetName(),
+			Namespace: openStackCluster.GetNamespace(),
+		},
+	}
+}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -33,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha5"
+	"sigs.k8s.io/cluster-api-provider-openstack/test/helpers/external"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -56,6 +58,11 @@ var _ = BeforeSuite(func() {
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{
 			filepath.Join("..", "config", "crd", "bases"),
+		},
+		// Add fake CAPI CRDs that we reference
+		CRDs: []*apiextensionsv1.CustomResourceDefinition{
+			external.TestClusterCRD.DeepCopy(),
+			external.TestMachineCRD.DeepCopy(),
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	golang.org/x/text v0.3.7
 	gopkg.in/ini.v1 v1.63.2
 	k8s.io/api v0.23.0
+	k8s.io/apiextensions-apiserver v0.23.0
 	k8s.io/apimachinery v0.23.0
 	k8s.io/client-go v0.23.0
 	k8s.io/component-base v0.23.0
@@ -115,7 +116,6 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
-	k8s.io/apiextensions-apiserver v0.23.0 // indirect
 	k8s.io/apiserver v0.23.0 // indirect
 	k8s.io/cluster-bootstrap v0.23.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect

--- a/test/helpers/external/cluster.go
+++ b/test/helpers/external/cluster.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package external
+
+import (
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+)
+
+const (
+	clusterAPIGroup       = "cluster.x-k8s.io"
+	clusterAPITestVersion = "v1beta1"
+)
+
+var (
+	// TestClusterCRD will generate a test cluster CustomResourceDefinition.
+	TestClusterCRD = generateTestClusterAPICRD("cluster", "clusters")
+
+	// TestMachineCRD will generate a test machine CustomResourceDefinition.
+	TestMachineCRD = generateTestClusterAPICRD("machine", "machines")
+)
+
+func generateTestClusterAPICRD(kind, pluralKind string) *apiextensionsv1.CustomResourceDefinition {
+	return &apiextensionsv1.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apiextensionsv1.SchemeGroupVersion.String(),
+			Kind:       "CustomResourceDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: pluralKind + "." + clusterAPIGroup,
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "cluster.x-k8s.io",
+			Scope: apiextensionsv1.NamespaceScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Kind:   cases.Title(language.English).String(kind),
+				Plural: pluralKind,
+			},
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name:    clusterAPITestVersion,
+					Served:  true,
+					Storage: true,
+					Subresources: &apiextensionsv1.CustomResourceSubresources{
+						Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
+					},
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type: "object",
+							Properties: map[string]apiextensionsv1.JSONSchemaProps{
+								"spec": {
+									Type:                   "object",
+									XPreserveUnknownFields: pointer.BoolPtr(true),
+								},
+								"status": {
+									Type:                   "object",
+									XPreserveUnknownFields: pointer.BoolPtr(true),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds some simple tests for the OpenStackCluster controller.

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.
2. Note that there are 3 commit. I can make separate PRs for them or remove some of them if needed.
3. [This file](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1199/files#diff-9da8f7e78e11f549d7ff45cd4706d6946b664816033d9a29a518017b98a06a7a) was copied almost verbatim from CAPA. We could alternatively import the relevant package. What do you think would be better?
4. Please note the pending test. I'm not sure how to move forward with this and would appreciate any hints. If there are no obvious solutions I think maybe we should have an issue to discuss this further?

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [x] adds unit tests

/hold
