### PR TITLE
🐛 controllers/openstackcluster_controller.go fix nil pointer and dump openstack ports

### DIFF
--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -372,9 +372,11 @@ func bastionToInstanceSpec(openStackCluster *infrav1.OpenStackCluster, clusterNa
 
 	instanceSpec.SecurityGroups = openStackCluster.Spec.Bastion.Instance.SecurityGroups
 	if openStackCluster.Spec.ManagedSecurityGroups {
-		instanceSpec.SecurityGroups = append(instanceSpec.SecurityGroups, infrav1.SecurityGroupParam{
-			UUID: openStackCluster.Status.BastionSecurityGroup.ID,
-		})
+		if openStackCluster.Status.BastionSecurityGroup != nil {
+			instanceSpec.SecurityGroups = append(instanceSpec.SecurityGroups, infrav1.SecurityGroupParam{
+				UUID: openStackCluster.Status.BastionSecurityGroup.ID,
+			})
+		}
 	}
 
 	instanceSpec.Networks = openStackCluster.Spec.Bastion.Instance.Networks

--- a/test/e2e/shared/openstack.go
+++ b/test/e2e/shared/openstack.go
@@ -112,6 +112,10 @@ func dumpOpenStack(_ context.Context, e2eCtx *E2EContext, bootstrapClusterProxyN
 	if err := dumpOpenStackImages(providerClient, clientOpts, logPath); err != nil {
 		_, _ = fmt.Fprintf(GinkgoWriter, "error dumping OpenStack images: %s\n", err)
 	}
+
+	if err := dumpOpenStackPorts(e2eCtx, logPath); err != nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "error dumping OpenStack ports: %s\n", err)
+	}
 }
 
 func dumpOpenStackImages(providerClient *gophercloud.ProviderClient, clientOpts *clientconfig.ClientOpts, logPath string) error {
@@ -134,9 +138,25 @@ func dumpOpenStackImages(providerClient *gophercloud.ProviderClient, clientOpts 
 	if err != nil {
 		return fmt.Errorf("error marshalling images %v: %s", imagesList, err)
 	}
-	if err := os.WriteFile(path.Join(logPath, "images.txt"), imagesJSON, 0o600); err != nil {
-		return fmt.Errorf("error writing seversJSON %s: %s", imagesJSON, err)
+	if err := os.WriteFile(path.Join(logPath, "images.json"), imagesJSON, 0o600); err != nil {
+		return fmt.Errorf("error writing images.json %s: %s", imagesJSON, err)
 	}
+	return nil
+}
+
+func dumpOpenStackPorts(e2eCtx *E2EContext, logPath string) error {
+	portsList, err := DumpOpenStackPorts(e2eCtx, ports.ListOpts{})
+	if err != nil {
+		return err
+	}
+	portsJSON, err := json.MarshalIndent(portsList, "", "    ")
+	if err != nil {
+		return fmt.Errorf("error marshalling ports %v: %s", portsList, err)
+	}
+	if err := os.WriteFile(path.Join(logPath, "ports.json"), portsJSON, 0o600); err != nil {
+		return fmt.Errorf("error writing ports.json %s: %s", portsJSON, err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions),  (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

* fixes nil pointer when reconcileDelete gets executed a second time and security groups already got deleted
	* ```
		I0425 01:06:29.568971       1 openstackcluster_controller.go:132] controller/openstackcluster "msg"="Reconciling Cluster delete" "cluster"="cluster-conformance-tn6axt" "name"="cluster-conformance-tn6axt" "namespace"="conformance-tn6axt" "reconciler group"="infrastructure.cluster.x-k8s.io" "reconciler kind"="OpenStackCluster" 
		panic: runtime error: invalid memory address or nil pointer dereference
		[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x14e6d9a]

		goroutine 419 [running]:
		sigs.k8s.io/cluster-api-provider-openstack/controllers.bastionToInstanceSpec(0xc000069000, {0xc0006300c0, 0xc000069000})
			/workspace/controllers/openstackcluster_controller.go:376 +0x25a
		sigs.k8s.io/cluster-api-provider-openstack/controllers.deleteBastion(0x1a8d7a0, 0xc0009e2000, 0xc000069000)
			/workspace/controllers/openstackcluster_controller.go:226 +0x18b
		sigs.k8s.io/cluster-api-provider-openstack/controllers.reconcileDelete({0x1a6fe18, 0xc00083c030}, 0xc000dd0e80, 0xc00059dae0, 0xc0009e2000, 0xc000069000)
			/workspace/controllers/openstackcluster_controller.go:134 +0xa5
		sigs.k8s.io/cluster-api-provider-openstack/controllers.(*OpenStackClusterReconciler).Reconcile(0xc0007f67b0, {0x1a6fe18, 0xc00083c030}, {{{0xc0007bc3c0, 0x1769dc0}, {0xc00093c3e0, 0x30}}})
			/workspace/controllers/openstackcluster_controller.go:124 +0x72a
		sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0xc000690bb0, {0x1a6fe18, 0xc00083c000}, {{{0xc0007bc3c0, 0x1769dc0}, {0xc00093c3e0, 0x413c34}}})
			/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:114 +0x26f
		sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000690bb0, {0x1a6fd70, 0xc0007fa080}, {0x16a7c00, 0xc00007e000})
			/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:311 +0x33e
		sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000690bb0, {0x1a6fd70, 0xc0007fa080})
			/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:266 +0x205
		sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
			/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:227 +0x85
		created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
			/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:223 +0x357
		```
    
    [[0](https://storage.googleapis.com/kubernetes-jenkins/logs/periodic-cluster-api-provider-openstack-conformance-test-main-with-k8s-ci-artifacts/1518375702510964736/artifacts/clusters/bootstrap/controllers/capo-controller-manager/capo-controller-manager-579b86d9c6-85ds9/manager.log)]
* adds dump of existing ports at e2e tests so we could debug further the following if it happens again:
	* ```
		failed to delete network: Expected HTTP response code [] when accessing [DELETE http://10.0.3.15:9696/v2.0/networks/d5988cfd-6b2b-456f-a174-7c7c42040c72], but got 409 instead
		{"NeutronError": {"type": "NetworkInUse", "message": "Unable to complete operation on network d5988cfd-6b2b-456f-a174-7c7c42040c72. There are one or more ports still in use on the network.", "detail": ""}}
		```
		[[1](https://storage.googleapis.com/kubernetes-jenkins/logs/periodic-cluster-api-provider-openstack-conformance-test-main-with-k8s-ci-artifacts/1518375702510964736/artifacts/clusters/bootstrap/resources/conformance-tn6axt/OpenStackCluster/cluster-conformance-tn6axt.yaml)]

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Maybe fixes the at cleanup still broken e2e conformance periodics test: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-openstack#periodic-conformance-test-main&show-stale-tests=

At fixes a potential nil pointer when using bastions and at least provides more information for debugging as I was not able to reproduce the issue locally.

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
