### PR TITLE
🐛Fix conversion of boot from volume images

### DIFF
--- a/api/v1alpha4/conversion.go
+++ b/api/v1alpha4/conversion.go
@@ -250,7 +250,7 @@ func Convert_v1alpha4_Instance_To_v1alpha5_Instance(in *Instance, out *infrav1.I
 		return err
 	}
 	if in.RootVolume != nil && in.RootVolume.Size > 0 {
-		out.Image = in.RootVolume.SourceUUID
+		out.ImageUUID = in.RootVolume.SourceUUID
 	}
 	return nil
 }
@@ -260,7 +260,7 @@ func Convert_v1alpha5_Instance_To_v1alpha4_Instance(in *infrav1.Instance, out *I
 		return err
 	}
 	if in.RootVolume != nil && in.RootVolume.Size > 0 {
-		out.RootVolume.SourceUUID = in.Image
+		out.RootVolume.SourceUUID = in.ImageUUID
 		out.Image = ""
 	}
 	return nil
@@ -271,7 +271,7 @@ func Convert_v1alpha4_OpenStackMachineSpec_To_v1alpha5_OpenStackMachineSpec(in *
 		return err
 	}
 	if in.RootVolume != nil && in.RootVolume.Size > 0 {
-		out.Image = in.RootVolume.SourceUUID
+		out.ImageUUID = in.RootVolume.SourceUUID
 	}
 	return nil
 }
@@ -281,7 +281,7 @@ func Convert_v1alpha5_OpenStackMachineSpec_To_v1alpha4_OpenStackMachineSpec(in *
 		return err
 	}
 	if in.RootVolume != nil && in.RootVolume.Size > 0 {
-		out.RootVolume.SourceUUID = in.Image
+		out.RootVolume.SourceUUID = in.ImageUUID
 		out.Image = ""
 	}
 	return nil

--- a/api/v1alpha4/conversion_test.go
+++ b/api/v1alpha4/conversion_test.go
@@ -270,7 +270,26 @@ func TestFuzzyConversion(t *testing.T) {
 			func(v1alpha5MachineSpec *infrav1.OpenStackMachineSpec, c fuzz.Continue) {
 				c.FuzzNoCustom(v1alpha5MachineSpec)
 
-				v1alpha5MachineSpec.ImageUUID = ""
+				// In v1alpha4 boot from volume only supports
+				// image by UUID, and boot from local only
+				// suppots image by name
+				if v1alpha5MachineSpec.RootVolume != nil && v1alpha5MachineSpec.RootVolume.Size > 0 {
+					v1alpha5MachineSpec.Image = ""
+				} else {
+					v1alpha5MachineSpec.ImageUUID = ""
+				}
+			},
+			func(v1alpha5Instance *infrav1.Instance, c fuzz.Continue) {
+				c.FuzzNoCustom(v1alpha5Instance)
+
+				// In v1alpha4 boot from volume only supports
+				// image by UUID, and boot from local only
+				// suppots image by name
+				if v1alpha5Instance.RootVolume != nil && v1alpha5Instance.RootVolume.Size > 0 {
+					v1alpha5Instance.Image = ""
+				} else {
+					v1alpha5Instance.ImageUUID = ""
+				}
 			},
 			func(v1alpha5RootVolume *infrav1.RootVolume, c fuzz.Continue) {
 				c.FuzzNoCustom(v1alpha5RootVolume)


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Root volumes in v1alpha4 can only specify root volume image by UUID. We were
translating this to use Image from the parent, which requires a name,
not a UUID. In v1alpha5 we can also have the ImageUUID field, so we
translate to that instead.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/1220

/hold
