### PR TITLE
🐛Don't set ImageRef on server when booting from volume

### DIFF
--- a/pkg/cloud/services/compute/instance_test.go
+++ b/pkg/cloud/services/compute/instance_test.go
@@ -834,6 +834,7 @@ func TestService_ReconcileInstance(t *testing.T) {
 
 				createMap := getDefaultServerMap()
 				serverMap := createMap["server"].(map[string]interface{})
+				serverMap["imageRef"] = ""
 				serverMap["block_device_mapping_v2"] = []map[string]interface{}{
 					{
 						"delete_on_termination": true,
@@ -880,6 +881,7 @@ func TestService_ReconcileInstance(t *testing.T) {
 
 				createMap := getDefaultServerMap()
 				serverMap := createMap["server"].(map[string]interface{})
+				serverMap["imageRef"] = ""
 				serverMap["block_device_mapping_v2"] = []map[string]interface{}{
 					{
 						"delete_on_termination": true,


### PR DESCRIPTION
**What this PR does / why we need it**:
We were setting image ID on the server when booting from volume. While this appears to work correctly, it doesn't appear to be the intended use of the Nova API.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/1222

/hold
