### PR TITLE
:bug: Fix nil pointer reference during bastion deletion

### DIFF
--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -221,12 +221,12 @@ func deleteBastion(scope *scope.Scope, cluster *clusterv1.Cluster, openStackClus
 				}
 			}
 		}
-	}
 
-	instanceSpec := bastionToInstanceSpec(openStackCluster, cluster.Name)
-	if err = computeService.DeleteInstance(openStackCluster, instanceSpec, instanceStatus); err != nil {
-		handleUpdateOSCError(openStackCluster, errors.Errorf("failed to delete bastion: %v", err))
-		return errors.Errorf("failed to delete bastion: %v", err)
+		instanceSpec := bastionToInstanceSpec(openStackCluster, cluster.Name)
+		if err = computeService.DeleteInstance(openStackCluster, instanceSpec, instanceStatus); err != nil {
+			handleUpdateOSCError(openStackCluster, errors.Errorf("failed to delete bastion: %v", err))
+			return errors.Errorf("failed to delete bastion: %v", err)
+		}
 	}
 
 	openStackCluster.Status.Bastion = nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a nil pointer reference when a cluster does not have a bastion configured.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1230

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
