### PR TITLE
Envtest mocks

### DIFF
--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -47,7 +47,6 @@ import (
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/compute"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/loadbalancer"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/networking"
-	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/provider"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
 )
 
@@ -112,7 +111,7 @@ func (r *OpenStackClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 	}()
 
-	osProviderClient, clientOpts, projectID, err := provider.NewClientFromCluster(ctx, r.Client, openStackCluster, r.CaCertificates)
+	osProviderClient, clientOpts, projectID, err := scope.NewClientFromCluster(ctx, r.Client, openStackCluster, r.CaCertificates)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/controllers/openstackcluster_controller_test.go
+++ b/controllers/openstackcluster_controller_test.go
@@ -186,7 +186,7 @@ var _ = Describe("OpenStackCluster controller", func() {
 		// 	},
 		// }
 		// // TODO: Can we fake the client in some way?
-		// providerClient, clientOpts, _, err := provider.NewClient(cloud, nil)
+		// providerClient, clientOpts, _, err := scope.NewProviderClient(cloud, nil)
 		// Expect(err).To(BeNil())
 		// scope := &scope.Scope{
 		// 	ProviderClient:     providerClient,

--- a/controllers/openstackcluster_controller_test.go
+++ b/controllers/openstackcluster_controller_test.go
@@ -178,7 +178,7 @@ var _ = Describe("OpenStackCluster controller", func() {
 		mockScopeFactory.SetClientScopeCreateError(clientCreateErr)
 
 		result, err := reconciler.Reconcile(ctx, req)
-		// Expect error for getting OS clinet and empty result
+		// Expect error for getting OS client and empty result
 		Expect(err).To(MatchError(clientCreateErr))
 		Expect(result).To(Equal(reconcile.Result{}))
 	})

--- a/controllers/openstackcluster_controller_test.go
+++ b/controllers/openstackcluster_controller_test.go
@@ -98,7 +98,7 @@ var _ = Describe("OpenStackCluster controller", func() {
 		framework.CreateNamespace(ctx, input)
 
 		mockCtrl = gomock.NewController(GinkgoT())
-		mockScopeFactory = scope.NewMockScopeFactory(mockCtrl)
+		mockScopeFactory = scope.NewMockScopeFactory(mockCtrl, "", logr.Discard())
 		reconciler = func() *OpenStackClusterReconciler {
 			return &OpenStackClusterReconciler{
 				Client:       k8sClient,

--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -53,7 +53,6 @@ import (
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/compute"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/loadbalancer"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/networking"
-	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/provider"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
 )
 
@@ -141,7 +140,7 @@ func (r *OpenStackMachineReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 	}()
 
-	osProviderClient, clientOpts, projectID, err := provider.NewClientFromMachine(ctx, r.Client, openStackMachine, r.CaCertificates)
+	osProviderClient, clientOpts, projectID, err := scope.NewClientFromMachine(ctx, r.Client, openStackMachine, r.CaCertificates)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-openstack/controllers"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/metrics"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/record"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
 	"sigs.k8s.io/cluster-api-provider-openstack/version"
 )
 
@@ -231,6 +232,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager, caCerts []byte) {
 		Client:           mgr.GetClient(),
 		Recorder:         mgr.GetEventRecorderFor("openstackcluster-controller"),
 		WatchFilterValue: watchFilterValue,
+		ScopeFactory:     scope.ScopeFactory,
 		CaCertificates:   caCerts,
 	}).SetupWithManager(ctx, mgr, concurrency(openStackClusterConcurrency)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpenStackCluster")
@@ -240,6 +242,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager, caCerts []byte) {
 		Client:           mgr.GetClient(),
 		Recorder:         mgr.GetEventRecorderFor("openstackmachine-controller"),
 		WatchFilterValue: watchFilterValue,
+		ScopeFactory:     scope.ScopeFactory,
 		CaCertificates:   caCerts,
 	}).SetupWithManager(ctx, mgr, concurrency(openStackMachineConcurrency)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpenStackMachine")

--- a/pkg/clients/compute.go
+++ b/pkg/clients/compute.go
@@ -25,10 +25,10 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"github.com/gophercloud/utils/openstack/clientconfig"
 	uflavors "github.com/gophercloud/utils/openstack/compute/v2/flavors"
 
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/metrics"
-	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
 )
 
 /*
@@ -64,9 +64,9 @@ type ComputeClient interface {
 type computeClient struct{ client *gophercloud.ServiceClient }
 
 // NewComputeClient returns a new compute client.
-func NewComputeClient(scope *scope.Scope) (ComputeClient, error) {
-	compute, err := openstack.NewComputeV2(scope.ProviderClient, gophercloud.EndpointOpts{
-		Region: scope.ProviderClientOpts.RegionName,
+func NewComputeClient(providerClient *gophercloud.ProviderClient, providerClientOpts *clientconfig.ClientOpts) (ComputeClient, error) {
+	compute, err := openstack.NewComputeV2(providerClient, gophercloud.EndpointOpts{
+		Region: providerClientOpts.RegionName,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create compute service client: %v", err)

--- a/pkg/clients/image.go
+++ b/pkg/clients/image.go
@@ -22,9 +22,9 @@ import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
+	"github.com/gophercloud/utils/openstack/clientconfig"
 
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/metrics"
-	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
 )
 
 type ImageClient interface {
@@ -34,9 +34,9 @@ type ImageClient interface {
 type imageClient struct{ client *gophercloud.ServiceClient }
 
 // NewImageClient returns a new glance client.
-func NewImageClient(scope *scope.Scope) (ImageClient, error) {
-	images, err := openstack.NewImageServiceV2(scope.ProviderClient, gophercloud.EndpointOpts{
-		Region: scope.ProviderClientOpts.RegionName,
+func NewImageClient(providerClient *gophercloud.ProviderClient, providerClientOpts *clientconfig.ClientOpts) (ImageClient, error) {
+	images, err := openstack.NewImageServiceV2(providerClient, gophercloud.EndpointOpts{
+		Region: providerClientOpts.RegionName,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create image service client: %v", err)

--- a/pkg/clients/loadbalancer.go
+++ b/pkg/clients/loadbalancer.go
@@ -27,9 +27,9 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/providers"
+	"github.com/gophercloud/utils/openstack/clientconfig"
 
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/metrics"
-	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
 	capoerrors "sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/errors"
 )
 
@@ -62,9 +62,9 @@ type lbClient struct {
 }
 
 // NewLbClient returns a new loadbalancer client.
-func NewLbClient(scope *scope.Scope) (LbClient, error) {
-	loadbalancerClient, err := openstack.NewLoadBalancerV2(scope.ProviderClient, gophercloud.EndpointOpts{
-		Region: scope.ProviderClientOpts.RegionName,
+func NewLbClient(providerClient *gophercloud.ProviderClient, providerClientOpts *clientconfig.ClientOpts) (LbClient, error) {
+	loadbalancerClient, err := openstack.NewLoadBalancerV2(providerClient, gophercloud.EndpointOpts{
+		Region: providerClientOpts.RegionName,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create load balancer service client: %v", err)

--- a/pkg/clients/networking.go
+++ b/pkg/clients/networking.go
@@ -31,9 +31,9 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
+	"github.com/gophercloud/utils/openstack/clientconfig"
 
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/metrics"
-	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
 )
 
 type NetworkClient interface {
@@ -94,9 +94,9 @@ type networkClient struct {
 }
 
 // NewNetworkClient returns an instance of the networking service.
-func NewNetworkClient(scope *scope.Scope) (NetworkClient, error) {
-	serviceClient, err := openstack.NewNetworkV2(scope.ProviderClient, gophercloud.EndpointOpts{
-		Region: scope.ProviderClientOpts.RegionName,
+func NewNetworkClient(providerClient *gophercloud.ProviderClient, providerClientOpts *clientconfig.ClientOpts) (NetworkClient, error) {
+	serviceClient, err := openstack.NewNetworkV2(providerClient, gophercloud.EndpointOpts{
+		Region: providerClientOpts.RegionName,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create networking service providerClient: %v", err)

--- a/pkg/clients/volume.go
+++ b/pkg/clients/volume.go
@@ -22,9 +22,9 @@ import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
+	"github.com/gophercloud/utils/openstack/clientconfig"
 
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/metrics"
-	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
 )
 
 type VolumeClient interface {
@@ -37,9 +37,9 @@ type VolumeClient interface {
 type volumeClient struct{ client *gophercloud.ServiceClient }
 
 // NewVolumeClient returns a new cinder client.
-func NewVolumeClient(scope *scope.Scope) (VolumeClient, error) {
-	volume, err := openstack.NewBlockStorageV3(scope.ProviderClient, gophercloud.EndpointOpts{
-		Region: scope.ProviderClientOpts.RegionName,
+func NewVolumeClient(providerClient *gophercloud.ProviderClient, providerClientOpts *clientconfig.ClientOpts) (VolumeClient, error) {
+	volume, err := openstack.NewBlockStorageV3(providerClient, gophercloud.EndpointOpts{
+		Region: providerClientOpts.RegionName,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create volume service client: %v", err)

--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -164,7 +164,7 @@ func (s *Service) createInstanceImpl(eventObject runtime.Object, openStackCluste
 		}
 
 		if err := s.deletePorts(eventObject, portList); err != nil {
-			s.scope.Logger.V(4).Error(err, "Failed to clean up ports after failure")
+			s.scope.Logger().V(4).Error(err, "Failed to clean up ports after failure")
 		}
 	}()
 
@@ -320,7 +320,7 @@ func (s *Service) getVolumeByName(name string) (*volumes.Volume, error) {
 	listOpts := volumes.ListOpts{
 		AllTenants: false,
 		Name:       name,
-		TenantID:   s.scope.ProjectID,
+		TenantID:   s.scope.ProjectID(),
 	}
 	volumeList, err := s.getVolumeClient().ListVolumes(listOpts)
 	if err != nil {
@@ -353,7 +353,7 @@ func (s *Service) getOrCreateRootVolume(eventObject runtime.Object, instanceSpec
 			return nil, fmt.Errorf("exected to find volume %s with size %d; found size %d", name, size, volume.Size)
 		}
 
-		s.scope.Logger.Info("using existing root volume %s", name)
+		s.scope.Logger().Info("using existing root volume %s", name)
 		return volume, nil
 	}
 
@@ -585,7 +585,7 @@ func (s *Service) DeleteInstance(eventObject runtime.Object, instanceStatus *Ins
 				return nil
 			}
 
-			s.scope.Logger.Info("deleting dangling root volume %s(%s)", volume.Name, volume.ID)
+			s.scope.Logger().Info("deleting dangling root volume %s(%s)", volume.Name, volume.ID)
 			return s.getVolumeClient().DeleteVolume(volume.ID, volumes.DeleteOpts{})
 		}
 
@@ -720,7 +720,7 @@ func (s *Service) GetInstanceStatus(resourceID string) (instance *InstanceStatus
 		return nil, fmt.Errorf("get server %q detail failed: %v", resourceID, err)
 	}
 
-	return &InstanceStatus{server, s.scope.Logger}, nil
+	return &InstanceStatus{server, s.scope.Logger()}, nil
 }
 
 func (s *Service) GetInstanceStatusByName(eventObject runtime.Object, name string) (instance *InstanceStatus, err error) {
@@ -747,7 +747,7 @@ func (s *Service) GetInstanceStatusByName(eventObject runtime.Object, name strin
 
 	// Return the first returned server, if any
 	for i := range serverList {
-		return &InstanceStatus{&serverList[i], s.scope.Logger}, nil
+		return &InstanceStatus{&serverList[i], s.scope.Logger()}, nil
 	}
 	return nil, nil
 }

--- a/pkg/cloud/services/compute/instance_test.go
+++ b/pkg/cloud/services/compute/instance_test.go
@@ -496,10 +496,7 @@ func TestService_getImageID(t *testing.T) {
 			tt.expect(mockImageClient.EXPECT())
 
 			s := Service{
-				scope: &scope.Scope{
-					ProjectID: "",
-					Logger:    logr.Discard(),
-				},
+				scope:              scope.NewTestScope("", logr.Discard()),
 				_imageClient:       mockImageClient,
 				_networkingService: &networking.Service{},
 			}
@@ -1009,10 +1006,7 @@ func TestService_ReconcileInstance(t *testing.T) {
 			tt.expect(&recorders{computeRecorder, imageRecorder, networkRecorder, volumeRecorder})
 
 			s := Service{
-				scope: &scope.Scope{
-					Logger:    logr.Discard(),
-					ProjectID: "",
-				},
+				scope:          scope.NewTestScope("", logr.Discard()),
 				_computeClient: mockComputeClient,
 				_imageClient:   mockImageClient,
 				_networkingService: networking.NewTestService(
@@ -1125,10 +1119,7 @@ func TestService_DeleteInstance(t *testing.T) {
 			tt.expect(&recorders{computeRecorder, networkRecorder, volumeRecorder})
 
 			s := Service{
-				scope: &scope.Scope{
-					ProjectID: "",
-					Logger:    logr.Discard(),
-				},
+				scope:          scope.NewTestScope("", logr.Discard()),
 				_computeClient: mockComputeClient,
 				_networkingService: networking.NewTestService(
 					"", mockNetworkClient, logr.Discard(),

--- a/pkg/cloud/services/compute/service.go
+++ b/pkg/cloud/services/compute/service.go
@@ -25,7 +25,7 @@ import (
 )
 
 type Service struct {
-	scope              *scope.Scope
+	scope              scope.Scope
 	_computeClient     clients.ComputeClient
 	_volumeClient      clients.VolumeClient
 	_imageClient       clients.ImageClient
@@ -33,11 +33,7 @@ type Service struct {
 }
 
 // NewService returns an instance of the compute service.
-func NewService(scope *scope.Scope) (*Service, error) {
-	if scope.ProviderClientOpts.AuthInfo == nil {
-		return nil, fmt.Errorf("authInfo must be set")
-	}
-
+func NewService(scope scope.Scope) (*Service, error) {
 	return &Service{
 		scope: scope,
 	}, nil
@@ -45,7 +41,7 @@ func NewService(scope *scope.Scope) (*Service, error) {
 
 func (s Service) getComputeClient() clients.ComputeClient {
 	if s._computeClient == nil {
-		computeClient, err := clients.NewComputeClient(s.scope.ProviderClient, s.scope.ProviderClientOpts)
+		computeClient, err := s.scope.NewComputeClient()
 		if err != nil {
 			return clients.NewComputeErrorClient(err)
 		}
@@ -58,7 +54,7 @@ func (s Service) getComputeClient() clients.ComputeClient {
 
 func (s Service) getVolumeClient() clients.VolumeClient {
 	if s._volumeClient == nil {
-		volumeClient, err := clients.NewVolumeClient(s.scope.ProviderClient, s.scope.ProviderClientOpts)
+		volumeClient, err := s.scope.NewVolumeClient()
 		if err != nil {
 			return clients.NewVolumeErrorClient(err)
 		}
@@ -71,7 +67,7 @@ func (s Service) getVolumeClient() clients.VolumeClient {
 
 func (s Service) getImageClient() clients.ImageClient {
 	if s._imageClient == nil {
-		imageClient, err := clients.NewImageClient(s.scope.ProviderClient, s.scope.ProviderClientOpts)
+		imageClient, err := s.scope.NewImageClient()
 		if err != nil {
 			return clients.NewImageErrorClient(err)
 		}

--- a/pkg/cloud/services/compute/service.go
+++ b/pkg/cloud/services/compute/service.go
@@ -45,7 +45,7 @@ func NewService(scope *scope.Scope) (*Service, error) {
 
 func (s Service) getComputeClient() clients.ComputeClient {
 	if s._computeClient == nil {
-		computeClient, err := clients.NewComputeClient(s.scope)
+		computeClient, err := clients.NewComputeClient(s.scope.ProviderClient, s.scope.ProviderClientOpts)
 		if err != nil {
 			return clients.NewComputeErrorClient(err)
 		}
@@ -58,7 +58,7 @@ func (s Service) getComputeClient() clients.ComputeClient {
 
 func (s Service) getVolumeClient() clients.VolumeClient {
 	if s._volumeClient == nil {
-		volumeClient, err := clients.NewVolumeClient(s.scope)
+		volumeClient, err := clients.NewVolumeClient(s.scope.ProviderClient, s.scope.ProviderClientOpts)
 		if err != nil {
 			return clients.NewVolumeErrorClient(err)
 		}
@@ -71,7 +71,7 @@ func (s Service) getVolumeClient() clients.VolumeClient {
 
 func (s Service) getImageClient() clients.ImageClient {
 	if s._imageClient == nil {
-		imageClient, err := clients.NewImageClient(s.scope)
+		imageClient, err := clients.NewImageClient(s.scope.ProviderClient, s.scope.ProviderClientOpts)
 		if err != nil {
 			return clients.NewImageErrorClient(err)
 		}

--- a/pkg/cloud/services/loadbalancer/service.go
+++ b/pkg/cloud/services/loadbalancer/service.go
@@ -28,15 +28,14 @@ import (
 
 // Service interfaces with the OpenStack Neutron LBaaS v2 API.
 type Service struct {
-	projectID          string
-	scope              *scope.Scope
+	scope              scope.Scope
 	loadbalancerClient clients.LbClient
 	networkingService  *networking.Service
 }
 
 // NewService returns an instance of the loadbalancer service.
-func NewService(scope *scope.Scope) (*Service, error) {
-	loadbalancerClient, err := clients.NewLbClient(scope.ProviderClient, scope.ProviderClientOpts)
+func NewService(scope scope.Scope) (*Service, error) {
+	loadbalancerClient, err := scope.NewLbClient()
 	if err != nil {
 		return nil, err
 	}
@@ -57,10 +56,7 @@ func NewService(scope *scope.Scope) (*Service, error) {
 // It helps to mock the load balancer service in other packages.
 func NewLoadBalancerTestService(projectID string, lbClient clients.LbClient, client *networking.Service, logger logr.Logger) *Service {
 	return &Service{
-		projectID: projectID,
-		scope: &scope.Scope{
-			Logger: logger,
-		},
+		scope:              scope.NewTestScope(projectID, logger),
 		loadbalancerClient: lbClient,
 		networkingService:  client,
 	}

--- a/pkg/cloud/services/loadbalancer/service.go
+++ b/pkg/cloud/services/loadbalancer/service.go
@@ -19,8 +19,6 @@ package loadbalancer
 import (
 	"fmt"
 
-	"github.com/go-logr/logr"
-
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/networking"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
@@ -50,14 +48,4 @@ func NewService(scope scope.Scope) (*Service, error) {
 		loadbalancerClient: loadbalancerClient,
 		networkingService:  networkingService,
 	}, nil
-}
-
-// NewLoadBalancerTestService returns a Service with no initialization. It should only be used by tests.
-// It helps to mock the load balancer service in other packages.
-func NewLoadBalancerTestService(projectID string, lbClient clients.LbClient, client *networking.Service, logger logr.Logger) *Service {
-	return &Service{
-		scope:              scope.NewTestScope(projectID, logger),
-		loadbalancerClient: lbClient,
-		networkingService:  client,
-	}
 }

--- a/pkg/cloud/services/loadbalancer/service.go
+++ b/pkg/cloud/services/loadbalancer/service.go
@@ -36,7 +36,7 @@ type Service struct {
 
 // NewService returns an instance of the loadbalancer service.
 func NewService(scope *scope.Scope) (*Service, error) {
-	loadbalancerClient, err := clients.NewLbClient(scope)
+	loadbalancerClient, err := clients.NewLbClient(scope.ProviderClient, scope.ProviderClientOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloud/services/networking/floatingip.go
+++ b/pkg/cloud/services/networking/floatingip.go
@@ -121,10 +121,10 @@ var backoff = wait.Backoff{
 }
 
 func (s *Service) AssociateFloatingIP(eventObject runtime.Object, fp *floatingips.FloatingIP, portID string) error {
-	s.scope.Logger.Info("Associating floating IP", "id", fp.ID, "ip", fp.FloatingIP)
+	s.scope.Logger().Info("Associating floating IP", "id", fp.ID, "ip", fp.FloatingIP)
 
 	if fp.PortID == portID {
-		s.scope.Logger.Info("Floating IP already associated:", "id", fp.ID, "ip", fp.FloatingIP)
+		s.scope.Logger().Info("Floating IP already associated:", "id", fp.ID, "ip", fp.FloatingIP)
 		return nil
 	}
 
@@ -153,11 +153,11 @@ func (s *Service) DisassociateFloatingIP(eventObject runtime.Object, ip string) 
 		return err
 	}
 	if fip == nil || fip.FloatingIP == "" {
-		s.scope.Logger.Info("Floating IP not associated", "ip", ip)
+		s.scope.Logger().Info("Floating IP not associated", "ip", ip)
 		return nil
 	}
 
-	s.scope.Logger.Info("Disassociating floating IP", "id", fip.ID, "ip", fip.FloatingIP)
+	s.scope.Logger().Info("Disassociating floating IP", "id", fip.ID, "ip", fip.FloatingIP)
 
 	fpUpdateOpts := &floatingips.UpdateOpts{
 		PortID: nil,
@@ -179,7 +179,7 @@ func (s *Service) DisassociateFloatingIP(eventObject runtime.Object, ip string) 
 }
 
 func (s *Service) waitForFloatingIP(id, target string) error {
-	s.scope.Logger.Info("Waiting for floating IP", "id", id, "targetStatus", target)
+	s.scope.Logger().Info("Waiting for floating IP", "id", id, "targetStatus", target)
 	return wait.ExponentialBackoff(backoff, func() (bool, error) {
 		fip, err := s.client.GetFloatingIP(id)
 		if err != nil {

--- a/pkg/cloud/services/networking/network.go
+++ b/pkg/cloud/services/networking/network.go
@@ -74,7 +74,7 @@ func (s *Service) ReconcileExternalNetwork(openStackCluster *infrav1.OpenStackCl
 	case 0:
 		// Not finding an external network is fine
 		openStackCluster.Status.ExternalNetwork = &infrav1.Network{}
-		s.scope.Logger.Info("No external network found - proceeding with internal network only")
+		s.scope.Logger().Info("No external network found - proceeding with internal network only")
 		return nil
 	case 1:
 		openStackCluster.Status.ExternalNetwork = &infrav1.Network{
@@ -82,7 +82,7 @@ func (s *Service) ReconcileExternalNetwork(openStackCluster *infrav1.OpenStackCl
 			Name: networkList[0].Name,
 			Tags: networkList[0].Tags,
 		}
-		s.scope.Logger.Info("External network found", "network id", networkList[0].ID)
+		s.scope.Logger().Info("External network found", "network id", networkList[0].ID)
 		return nil
 	}
 	return fmt.Errorf("found %d external networks, which should not happen", len(networkList))
@@ -90,7 +90,7 @@ func (s *Service) ReconcileExternalNetwork(openStackCluster *infrav1.OpenStackCl
 
 func (s *Service) ReconcileNetwork(openStackCluster *infrav1.OpenStackCluster, clusterName string) error {
 	networkName := getNetworkName(clusterName)
-	s.scope.Logger.Info("Reconciling network", "name", networkName)
+	s.scope.Logger().Info("Reconciling network", "name", networkName)
 
 	res, err := s.getNetworkByName(networkName)
 	if err != nil {
@@ -105,7 +105,7 @@ func (s *Service) ReconcileNetwork(openStackCluster *infrav1.OpenStackCluster, c
 			Tags: res.Tags,
 		}
 		sInfo := fmt.Sprintf("Reuse Existing Network %s with id %s", res.Name, res.ID)
-		s.scope.Logger.V(6).Info(sInfo)
+		s.scope.Logger().V(6).Info(sInfo)
 		return nil
 	}
 
@@ -169,12 +169,12 @@ func (s *Service) DeleteNetwork(openStackCluster *infrav1.OpenStackCluster, clus
 
 func (s *Service) ReconcileSubnet(openStackCluster *infrav1.OpenStackCluster, clusterName string) error {
 	if openStackCluster.Status.Network == nil || openStackCluster.Status.Network.ID == "" {
-		s.scope.Logger.V(4).Info("No need to reconcile network components since no network exists.")
+		s.scope.Logger().V(4).Info("No need to reconcile network components since no network exists.")
 		return nil
 	}
 
 	subnetName := getSubnetName(clusterName)
-	s.scope.Logger.Info("Reconciling subnet", "name", subnetName)
+	s.scope.Logger().Info("Reconciling subnet", "name", subnetName)
 
 	subnetList, err := s.client.ListSubnet(subnets.ListOpts{
 		NetworkID: openStackCluster.Status.Network.ID,
@@ -197,7 +197,7 @@ func (s *Service) ReconcileSubnet(openStackCluster *infrav1.OpenStackCluster, cl
 		}
 	} else if len(subnetList) == 1 {
 		subnet = &subnetList[0]
-		s.scope.Logger.V(6).Info(fmt.Sprintf("Reuse existing subnet %s with id %s", subnetName, subnet.ID))
+		s.scope.Logger().V(6).Info(fmt.Sprintf("Reuse existing subnet %s with id %s", subnetName, subnet.ID))
 	}
 
 	openStackCluster.Status.Network.Subnet = &infrav1.Subnet{

--- a/pkg/cloud/services/networking/router.go
+++ b/pkg/cloud/services/networking/router.go
@@ -32,20 +32,20 @@ import (
 
 func (s *Service) ReconcileRouter(openStackCluster *infrav1.OpenStackCluster, clusterName string) error {
 	if openStackCluster.Status.Network == nil || openStackCluster.Status.Network.ID == "" {
-		s.scope.Logger.V(3).Info("No need to reconcile router since no network exists.")
+		s.scope.Logger().V(3).Info("No need to reconcile router since no network exists.")
 		return nil
 	}
 	if openStackCluster.Status.Network.Subnet == nil || openStackCluster.Status.Network.Subnet.ID == "" {
-		s.scope.Logger.V(4).Info("No need to reconcile router since no subnet exists.")
+		s.scope.Logger().V(4).Info("No need to reconcile router since no subnet exists.")
 		return nil
 	}
 	if openStackCluster.Status.ExternalNetwork == nil || openStackCluster.Status.ExternalNetwork.ID == "" {
-		s.scope.Logger.V(3).Info("No need to create router, due to missing ExternalNetworkID.")
+		s.scope.Logger().V(3).Info("No need to create router, due to missing ExternalNetworkID.")
 		return nil
 	}
 
 	routerName := getRouterName(clusterName)
-	s.scope.Logger.Info("Reconciling router", "name", routerName)
+	s.scope.Logger().Info("Reconciling router", "name", routerName)
 
 	routerList, err := s.client.ListRouter(routers.ListOpts{
 		Name: routerName,
@@ -67,7 +67,7 @@ func (s *Service) ReconcileRouter(openStackCluster *infrav1.OpenStackCluster, cl
 		}
 	} else {
 		router = &routerList[0]
-		s.scope.Logger.V(6).Info(fmt.Sprintf("Reuse existing Router %s with id %s", routerName, router.ID))
+		s.scope.Logger().V(6).Info(fmt.Sprintf("Reuse existing Router %s with id %s", routerName, router.ID))
 	}
 
 	routerIPs := []string{}
@@ -107,14 +107,14 @@ INTERFACE_LOOP:
 
 	// ... and create a router interface for our subnet.
 	if createInterface {
-		s.scope.Logger.V(4).Info("Creating RouterInterface", "routerID", router.ID, "subnetID", openStackCluster.Status.Network.Subnet.ID)
+		s.scope.Logger().V(4).Info("Creating RouterInterface", "routerID", router.ID, "subnetID", openStackCluster.Status.Network.Subnet.ID)
 		routerInterface, err := s.client.AddRouterInterface(router.ID, routers.AddInterfaceOpts{
 			SubnetID: openStackCluster.Status.Network.Subnet.ID,
 		})
 		if err != nil {
 			return fmt.Errorf("unable to create router interface: %v", err)
 		}
-		s.scope.Logger.V(4).Info("Created RouterInterface", "id", routerInterface.ID)
+		s.scope.Logger().V(4).Info("Created RouterInterface", "id", routerInterface.ID)
 	}
 	return nil
 }
@@ -207,9 +207,9 @@ func (s *Service) DeleteRouter(openStackCluster *infrav1.OpenStackCluster, clust
 			if !capoerrors.IsNotFound(err) {
 				return fmt.Errorf("unable to remove router interface: %v", err)
 			}
-			s.scope.Logger.V(4).Info("Router Interface already removed, nothing to do", "id", router.ID)
+			s.scope.Logger().V(4).Info("Router Interface already removed, nothing to do", "id", router.ID)
 		} else {
-			s.scope.Logger.V(4).Info("Removed RouterInterface of Router", "id", router.ID)
+			s.scope.Logger().V(4).Info("Removed RouterInterface of Router", "id", router.ID)
 		}
 	}
 

--- a/pkg/cloud/services/networking/securitygroups.go
+++ b/pkg/cloud/services/networking/securitygroups.go
@@ -37,9 +37,9 @@ const (
 
 // ReconcileSecurityGroups reconcile the security groups.
 func (s *Service) ReconcileSecurityGroups(openStackCluster *infrav1.OpenStackCluster, clusterName string) error {
-	s.scope.Logger.Info("Reconciling security groups", "cluster", clusterName)
+	s.scope.Logger().Info("Reconciling security groups", "cluster", clusterName)
 	if !openStackCluster.Spec.ManagedSecurityGroups {
-		s.scope.Logger.V(4).Info("No need to reconcile security groups", "cluster", clusterName)
+		s.scope.Logger().V(4).Info("No need to reconcile security groups", "cluster", clusterName)
 		return nil
 	}
 
@@ -179,7 +179,7 @@ func (s *Service) GetSecurityGroups(securityGroupParams []infrav1.SecurityGroupP
 
 		listOpts := groups.ListOpts(sg.Filter)
 		if listOpts.ProjectID == "" {
-			listOpts.ProjectID = s.scope.ProjectID
+			listOpts.ProjectID = s.scope.ProjectID()
 		}
 		listOpts.Name = sg.Name
 		listOpts.ID = sg.UUID
@@ -285,16 +285,16 @@ func (s *Service) reconcileGroupRules(desired, observed infrav1.SecurityGroup) (
 		}
 	}
 
-	s.scope.Logger.V(4).Info("Deleting rules not needed anymore for group", "name", observed.Name, "amount", len(rulesToDelete))
+	s.scope.Logger().V(4).Info("Deleting rules not needed anymore for group", "name", observed.Name, "amount", len(rulesToDelete))
 	for _, rule := range rulesToDelete {
-		s.scope.Logger.V(6).Info("Deleting rule", "ruleID", rule.ID, "groupName", observed.Name)
+		s.scope.Logger().V(6).Info("Deleting rule", "ruleID", rule.ID, "groupName", observed.Name)
 		err := s.client.DeleteSecGroupRule(rule.ID)
 		if err != nil {
 			return infrav1.SecurityGroup{}, err
 		}
 	}
 
-	s.scope.Logger.V(4).Info("Creating new rules needed for group", "name", observed.Name, "amount", len(rulesToCreate))
+	s.scope.Logger().V(4).Info("Creating new rules needed for group", "name", observed.Name, "amount", len(rulesToCreate))
 	for _, rule := range rulesToCreate {
 		r := rule
 		r.SecurityGroupID = observed.ID
@@ -318,13 +318,13 @@ func (s *Service) createSecurityGroupIfNotExists(openStackCluster *infrav1.OpenS
 		return err
 	}
 	if secGroup == nil || secGroup.ID == "" {
-		s.scope.Logger.V(6).Info("Group doesn't exist, creating it.", "name", groupName)
+		s.scope.Logger().V(6).Info("Group doesn't exist, creating it.", "name", groupName)
 
 		createOpts := groups.CreateOpts{
 			Name:        groupName,
 			Description: "Cluster API managed group",
 		}
-		s.scope.Logger.V(6).Info("Creating group", "name", groupName)
+		s.scope.Logger().V(6).Info("Creating group", "name", groupName)
 
 		group, err := s.client.CreateSecGroup(createOpts)
 		if err != nil {
@@ -346,7 +346,7 @@ func (s *Service) createSecurityGroupIfNotExists(openStackCluster *infrav1.OpenS
 	}
 
 	sInfo := fmt.Sprintf("Reuse Existing SecurityGroup %s with %s", groupName, secGroup.ID)
-	s.scope.Logger.V(6).Info(sInfo)
+	s.scope.Logger().V(6).Info(sInfo)
 
 	return nil
 }
@@ -356,7 +356,7 @@ func (s *Service) getSecurityGroupByName(name string) (*infrav1.SecurityGroup, e
 		Name: name,
 	}
 
-	s.scope.Logger.V(6).Info("Attempting to fetch security group with", "name", name)
+	s.scope.Logger().V(6).Info("Attempting to fetch security group with", "name", name)
 	allGroups, err := s.client.ListSecGroup(opts)
 	if err != nil {
 		return &infrav1.SecurityGroup{}, err
@@ -388,7 +388,7 @@ func (s *Service) createRule(r infrav1.SecurityGroupRule) (infrav1.SecurityGroup
 		RemoteIPPrefix: r.RemoteIPPrefix,
 		SecGroupID:     r.SecurityGroupID,
 	}
-	s.scope.Logger.V(6).Info("Creating rule", "Description", r.Description, "Direction", dir, "PortRangeMin", r.PortRangeMin, "PortRangeMax", r.PortRangeMax, "Proto", proto, "etherType", etherType, "RemoteGroupID", r.RemoteGroupID, "RemoteIPPrefix", r.RemoteIPPrefix, "SecurityGroupID", r.SecurityGroupID)
+	s.scope.Logger().V(6).Info("Creating rule", "Description", r.Description, "Direction", dir, "PortRangeMin", r.PortRangeMin, "PortRangeMax", r.PortRangeMax, "Proto", proto, "etherType", etherType, "RemoteGroupID", r.RemoteGroupID, "RemoteIPPrefix", r.RemoteIPPrefix, "SecurityGroupID", r.SecurityGroupID)
 	rule, err := s.client.CreateSecGroupRule(createOpts)
 	if err != nil {
 		return infrav1.SecurityGroupRule{}, err

--- a/pkg/cloud/services/networking/service.go
+++ b/pkg/cloud/services/networking/service.go
@@ -44,7 +44,7 @@ type Service struct {
 
 // NewService returns an instance of the networking service.
 func NewService(scope *scope.Scope) (*Service, error) {
-	networkClient, err := clients.NewNetworkClient(scope)
+	networkClient, err := clients.NewNetworkClient(scope.ProviderClient, scope.ProviderClientOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloud/services/networking/service.go
+++ b/pkg/cloud/services/networking/service.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/go-logr/logr"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -53,14 +52,6 @@ func NewService(scope scope.Scope) (*Service, error) {
 		scope:  scope,
 		client: networkClient,
 	}, nil
-}
-
-// NewTestService returns a Service with no initialisation. It should only be used by tests.
-func NewTestService(projectID string, client clients.NetworkClient, logger logr.Logger) *Service {
-	return &Service{
-		scope:  scope.NewTestScope(projectID, logger),
-		client: client,
-	}
 }
 
 // replaceAllAttributesTags replaces all tags on a neworking resource.

--- a/pkg/scope/mock.go
+++ b/pkg/scope/mock.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scope
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"github.com/golang/mock/gomock"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha6"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients/mock"
+)
+
+// MockScopeFactory implements both the ScopeFactory and ClientScope interfaces. It can be used in place of the default ProviderScopeFactory
+// when we want to use mocked service clients which do not attempt to connect to a running OpenStack cloud.
+type MockScopeFactory struct {
+	ComputeClient *mock.MockComputeClient
+	NetworkClient *mock.MockNetworkClient
+	VolumeClient  *mock.MockVolumeClient
+	ImageClient   *mock.MockImageClient
+	LbClient      *mock.MockLbClient
+
+	clientScopeCreateError error
+
+	scope
+}
+
+func NewMockScopeFactory(mockCtrl *gomock.Controller) *MockScopeFactory {
+	computeClient := mock.NewMockComputeClient(mockCtrl)
+	volumeClient := mock.NewMockVolumeClient(mockCtrl)
+	imageClient := mock.NewMockImageClient(mockCtrl)
+	networkClient := mock.NewMockNetworkClient(mockCtrl)
+	lbClient := mock.NewMockLbClient(mockCtrl)
+
+	return &MockScopeFactory{
+		ComputeClient: computeClient,
+		VolumeClient:  volumeClient,
+		ImageClient:   imageClient,
+		NetworkClient: networkClient,
+		LbClient:      lbClient,
+		scope: scope{
+			projectID: "",
+			logger:    logr.Discard(),
+		},
+	}
+}
+
+func (f *MockScopeFactory) SetClientScopeCreateError(err error) {
+	f.clientScopeCreateError = err
+}
+
+func (f *MockScopeFactory) NewClientScopeFromMachine(ctx context.Context, ctrlClient client.Client, openStackMachine *infrav1.OpenStackMachine, defaultCA []byte, logger logr.Logger) (Scope, error) {
+	if f.clientScopeCreateError != nil {
+		return nil, f.clientScopeCreateError
+	}
+	return f, nil
+}
+
+func (f *MockScopeFactory) NewClientScopeFromCluster(ctx context.Context, ctrlClient client.Client, openStackCluster *infrav1.OpenStackCluster, defaultCA []byte, logger logr.Logger) (Scope, error) {
+	if f.clientScopeCreateError != nil {
+		return nil, f.clientScopeCreateError
+	}
+	return f, nil
+}
+
+func (f *MockScopeFactory) NewComputeClient() (clients.ComputeClient, error) {
+	return f.ComputeClient, nil
+}
+
+func (f *MockScopeFactory) NewVolumeClient() (clients.VolumeClient, error) {
+	return f.VolumeClient, nil
+}
+
+func (f *MockScopeFactory) NewImageClient() (clients.ImageClient, error) {
+	return f.ImageClient, nil
+}
+
+func (f *MockScopeFactory) NewNetworkClient() (clients.NetworkClient, error) {
+	return f.NetworkClient, nil
+}
+
+func (f *MockScopeFactory) NewLbClient() (clients.LbClient, error) {
+	return f.LbClient, nil
+}

--- a/pkg/scope/mock.go
+++ b/pkg/scope/mock.go
@@ -37,12 +37,12 @@ type MockScopeFactory struct {
 	ImageClient   *mock.MockImageClient
 	LbClient      *mock.MockLbClient
 
+	logger                 logr.Logger
+	projectID              string
 	clientScopeCreateError error
-
-	scope
 }
 
-func NewMockScopeFactory(mockCtrl *gomock.Controller) *MockScopeFactory {
+func NewMockScopeFactory(mockCtrl *gomock.Controller, projectID string, logger logr.Logger) *MockScopeFactory {
 	computeClient := mock.NewMockComputeClient(mockCtrl)
 	volumeClient := mock.NewMockVolumeClient(mockCtrl)
 	imageClient := mock.NewMockImageClient(mockCtrl)
@@ -55,10 +55,8 @@ func NewMockScopeFactory(mockCtrl *gomock.Controller) *MockScopeFactory {
 		ImageClient:   imageClient,
 		NetworkClient: networkClient,
 		LbClient:      lbClient,
-		scope: scope{
-			projectID: "",
-			logger:    logr.Discard(),
-		},
+		projectID:     projectID,
+		logger:        logger,
 	}
 }
 
@@ -98,4 +96,12 @@ func (f *MockScopeFactory) NewNetworkClient() (clients.NetworkClient, error) {
 
 func (f *MockScopeFactory) NewLbClient() (clients.LbClient, error) {
 	return f.LbClient, nil
+}
+
+func (f *MockScopeFactory) Logger() logr.Logger {
+	return f.logger
+}
+
+func (f *MockScopeFactory) ProjectID() string {
+	return f.projectID
 }

--- a/pkg/scope/provider.go
+++ b/pkg/scope/provider.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package provider
+package scope
 
 import (
 	"context"
@@ -58,7 +58,7 @@ func NewClientFromMachine(ctx context.Context, ctrlClient client.Client, openSta
 		caCert = defaultCACert
 	}
 
-	return NewClient(cloud, caCert)
+	return NewProviderClient(cloud, caCert)
 }
 
 func NewClientFromCluster(ctx context.Context, ctrlClient client.Client, openStackCluster *infrav1.OpenStackCluster, defaultCACert []byte) (*gophercloud.ProviderClient, *clientconfig.ClientOpts, string, error) {
@@ -77,10 +77,10 @@ func NewClientFromCluster(ctx context.Context, ctrlClient client.Client, openSta
 		caCert = defaultCACert
 	}
 
-	return NewClient(cloud, caCert)
+	return NewProviderClient(cloud, caCert)
 }
 
-func NewClient(cloud clientconfig.Cloud, caCert []byte) (*gophercloud.ProviderClient, *clientconfig.ClientOpts, string, error) {
+func NewProviderClient(cloud clientconfig.Cloud, caCert []byte) (*gophercloud.ProviderClient, *clientconfig.ClientOpts, string, error) {
 	clientOpts := new(clientconfig.ClientOpts)
 	if cloud.AuthInfo != nil {
 		clientOpts.AuthInfo = cloud.AuthInfo

--- a/pkg/scope/provider.go
+++ b/pkg/scope/provider.go
@@ -91,19 +91,6 @@ type providerScope struct {
 	logger             logr.Logger
 }
 
-// NewTestScope returns a Scope with no initialization. It should only be used by tests.
-func NewTestScope(projectID string, logger logr.Logger) Scope {
-	providerClient := new(gophercloud.ProviderClient)
-	clientOpts := new(clientconfig.ClientOpts)
-
-	return &providerScope{
-		providerClient:     providerClient,
-		providerClientOpts: clientOpts,
-		projectID:          projectID,
-		logger:             logger,
-	}
-}
-
 func NewProviderScope(cloud clientconfig.Cloud, caCert []byte, logger logr.Logger) (Scope, error) {
 	providerClient, clientOpts, projectID, err := NewProviderClient(cloud, caCert, logger)
 	if err != nil {

--- a/pkg/scope/scope.go
+++ b/pkg/scope/scope.go
@@ -17,22 +17,92 @@ limitations under the License.
 package scope
 
 import (
+	"context"
+
 	"github.com/go-logr/logr"
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/utils/openstack/clientconfig"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha6"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients"
 )
 
-// Scope is used to initialize Services from Controllers and includes the
-// common objects required for this.
-//
-// The Gophercloud ProviderClient and ClientOpts are required to create new
-// Gophercloud API Clients (e.g. for Networking/Neutron).
-//
-// The Logger includes context values such as the cluster name.
-type Scope struct {
-	ProviderClient     *gophercloud.ProviderClient
-	ProviderClientOpts *clientconfig.ClientOpts
-	ProjectID          string
+// Factory instantiates a new ClientScope using credentials from either a cluster or a machine.
+type Factory interface {
+	NewClientScopeFromMachine(ctx context.Context, ctrlClient client.Client, openStackMachine *infrav1.OpenStackMachine, defaultCACert []byte, logger logr.Logger) (Scope, error)
+	NewClientScopeFromCluster(ctx context.Context, ctrlClient client.Client, openStackCluster *infrav1.OpenStackCluster, defaultCACert []byte, logger logr.Logger) (Scope, error)
+}
 
-	Logger logr.Logger
+// Scope contains arguments common to most operations.
+type Scope interface {
+	NewComputeClient() (clients.ComputeClient, error)
+	NewVolumeClient() (clients.VolumeClient, error)
+	NewImageClient() (clients.ImageClient, error)
+	NewNetworkClient() (clients.NetworkClient, error)
+	NewLbClient() (clients.LbClient, error)
+	Logger() logr.Logger
+	ProjectID() string
+}
+
+type scope struct {
+	providerClient     *gophercloud.ProviderClient
+	providerClientOpts *clientconfig.ClientOpts
+	projectID          string
+	logger             logr.Logger
+}
+
+// NewTestScope returns a Scope with no initialization. It should only be used by tests.
+func NewTestScope(projectID string, logger logr.Logger) Scope {
+	providerClient := new(gophercloud.ProviderClient)
+	clientOpts := new(clientconfig.ClientOpts)
+
+	return &scope{
+		providerClient:     providerClient,
+		providerClientOpts: clientOpts,
+		projectID:          projectID,
+		logger:             logger,
+	}
+}
+
+func NewScope(cloud clientconfig.Cloud, caCert []byte, logger logr.Logger) (Scope, error) {
+	providerClient, clientOpts, projectID, err := NewProviderClient(cloud, caCert)
+	if err != nil {
+		return nil, err
+	}
+
+	return &scope{
+		providerClient:     providerClient,
+		providerClientOpts: clientOpts,
+		projectID:          projectID,
+		logger:             logger,
+	}, nil
+}
+
+func (s *scope) Logger() logr.Logger {
+	return s.logger
+}
+
+func (s *scope) ProjectID() string {
+	return s.projectID
+}
+
+func (s *scope) NewComputeClient() (clients.ComputeClient, error) {
+	return clients.NewComputeClient(s.providerClient, s.providerClientOpts)
+}
+
+func (s *scope) NewNetworkClient() (clients.NetworkClient, error) {
+	return clients.NewNetworkClient(s.providerClient, s.providerClientOpts)
+}
+
+func (s *scope) NewVolumeClient() (clients.VolumeClient, error) {
+	return clients.NewVolumeClient(s.providerClient, s.providerClientOpts)
+}
+
+func (s *scope) NewImageClient() (clients.ImageClient, error) {
+	return clients.NewImageClient(s.providerClient, s.providerClientOpts)
+}
+
+func (s *scope) NewLbClient() (clients.LbClient, error) {
+	return clients.NewLbClient(s.providerClient, s.providerClientOpts)
 }

--- a/pkg/scope/scope.go
+++ b/pkg/scope/scope.go
@@ -20,15 +20,16 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
-	"github.com/gophercloud/gophercloud"
-	"github.com/gophercloud/utils/openstack/clientconfig"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha6"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients"
 )
 
-// Factory instantiates a new ClientScope using credentials from either a cluster or a machine.
+// ScopeFactory is the default scope factory. It generates service clients which make OpenStack API calls against a running cloud.
+var ScopeFactory Factory = providerScopeFactory{}
+
+// Factory instantiates a new Scope using credentials from either a cluster or a machine.
 type Factory interface {
 	NewClientScopeFromMachine(ctx context.Context, ctrlClient client.Client, openStackMachine *infrav1.OpenStackMachine, defaultCACert []byte, logger logr.Logger) (Scope, error)
 	NewClientScopeFromCluster(ctx context.Context, ctrlClient client.Client, openStackCluster *infrav1.OpenStackCluster, defaultCACert []byte, logger logr.Logger) (Scope, error)
@@ -43,66 +44,4 @@ type Scope interface {
 	NewLbClient() (clients.LbClient, error)
 	Logger() logr.Logger
 	ProjectID() string
-}
-
-type scope struct {
-	providerClient     *gophercloud.ProviderClient
-	providerClientOpts *clientconfig.ClientOpts
-	projectID          string
-	logger             logr.Logger
-}
-
-// NewTestScope returns a Scope with no initialization. It should only be used by tests.
-func NewTestScope(projectID string, logger logr.Logger) Scope {
-	providerClient := new(gophercloud.ProviderClient)
-	clientOpts := new(clientconfig.ClientOpts)
-
-	return &scope{
-		providerClient:     providerClient,
-		providerClientOpts: clientOpts,
-		projectID:          projectID,
-		logger:             logger,
-	}
-}
-
-func NewScope(cloud clientconfig.Cloud, caCert []byte, logger logr.Logger) (Scope, error) {
-	providerClient, clientOpts, projectID, err := NewProviderClient(cloud, caCert, logger)
-	if err != nil {
-		return nil, err
-	}
-
-	return &scope{
-		providerClient:     providerClient,
-		providerClientOpts: clientOpts,
-		projectID:          projectID,
-		logger:             logger,
-	}, nil
-}
-
-func (s *scope) Logger() logr.Logger {
-	return s.logger
-}
-
-func (s *scope) ProjectID() string {
-	return s.projectID
-}
-
-func (s *scope) NewComputeClient() (clients.ComputeClient, error) {
-	return clients.NewComputeClient(s.providerClient, s.providerClientOpts)
-}
-
-func (s *scope) NewNetworkClient() (clients.NetworkClient, error) {
-	return clients.NewNetworkClient(s.providerClient, s.providerClientOpts)
-}
-
-func (s *scope) NewVolumeClient() (clients.VolumeClient, error) {
-	return clients.NewVolumeClient(s.providerClient, s.providerClientOpts)
-}
-
-func (s *scope) NewImageClient() (clients.ImageClient, error) {
-	return clients.NewImageClient(s.providerClient, s.providerClientOpts)
-}
-
-func (s *scope) NewLbClient() (clients.LbClient, error) {
-	return clients.NewLbClient(s.providerClient, s.providerClientOpts)
 }

--- a/pkg/scope/scope.go
+++ b/pkg/scope/scope.go
@@ -66,7 +66,7 @@ func NewTestScope(projectID string, logger logr.Logger) Scope {
 }
 
 func NewScope(cloud clientconfig.Cloud, caCert []byte, logger logr.Logger) (Scope, error) {
-	providerClient, clientOpts, projectID, err := NewProviderClient(cloud, caCert)
+	providerClient, clientOpts, projectID, err := NewProviderClient(cloud, caCert, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/shared/openstack.go
+++ b/test/e2e/shared/openstack.go
@@ -53,7 +53,7 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha6"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/compute"
-	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/provider"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
 )
 
 type ServerExtWithIP struct {
@@ -494,7 +494,7 @@ func getProviderClient(e2eCtx *E2EContext, openstackCloud string) (*gophercloud.
 	clouds := getParsedOpenStackCloudYAML(openStackCloudYAMLFile)
 	cloud := clouds.Clouds[openstackCloud]
 
-	providerClient, clientOpts, projectID, err := provider.NewClient(cloud, nil)
+	providerClient, clientOpts, projectID, err := scope.NewProviderClient(cloud, nil)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/test/e2e/shared/openstack.go
+++ b/test/e2e/shared/openstack.go
@@ -494,7 +494,7 @@ func getProviderClient(e2eCtx *E2EContext, openstackCloud string) (*gophercloud.
 	clouds := getParsedOpenStackCloudYAML(openStackCloudYAMLFile)
 	cloud := clouds.Clouds[openstackCloud]
 
-	providerClient, clientOpts, projectID, err := scope.NewProviderClient(cloud, nil)
+	providerClient, clientOpts, projectID, err := scope.NewProviderClient(cloud, nil, logr.Discard())
 	if err != nil {
 		return nil, nil, nil, err
 	}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

The purpose of this PR is to be able to run envtests using mock clients instead of real ones. This PR achieves that by enhancing Scope to return service clients. We add a new scope Factory interface to generate Scopes. We provide 2 implementations of Factory:

ProviderScopeFactory generates 'real' Scopes which expect to be able to make API calls to a running OpenStack cloud.
MockScopeFactory uses mock clients.

Because Scopes now return clients, the scope package must import those clients. However, clients are currently in their service packages. Services use scopes and must therefore import the scope package. This is a circular dependency. To avoid this we move clients into a separate package.

With the exception of the new factory interface, all other changes are mechanical. This PR does not intentionally introduce any functional changes.

Because of the large amount of code churn I have split the change into multiple commits. These commits each make a single refactor. I suggest that this PR will be simpler to review by commit, as the mechanical code churn in each individual commit is very similar.

/hold
