### PR TITLE
🌱 Remove macaptain from cluster-api-openstack-reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -30,5 +30,4 @@ aliases:
     - seanschneeweiss
     - tobiasgiese
   cluster-api-openstack-reviewers:
-    - macaptain
     - apricote


### PR DESCRIPTION
Unfortunately, I haven't much time nowadays to contribute and participate in reviews. Hope to be back contributing again soon! But will remove myself as a default reviewer for now.
