### PR TITLE
Passing security groups by specifying more options in addition to UUIDs on ports

### DIFF
--- a/api/v1alpha4/conversion_test.go
+++ b/api/v1alpha4/conversion_test.go
@@ -244,6 +244,7 @@ func TestFuzzyConversion(t *testing.T) {
 						v1alpha5PortOpts.Network = nil
 					}
 				}
+				v1alpha5PortOpts.SecurityGroupFilters = nil
 			},
 			func(v1alpha5FixedIP *infrav1.FixedIP, c fuzz.Continue) {
 				c.FuzzNoCustom(v1alpha5FixedIP)

--- a/api/v1alpha4/zz_generated.conversion.go
+++ b/api/v1alpha4/zz_generated.conversion.go
@@ -1474,6 +1474,7 @@ func autoConvert_v1alpha5_PortOpts_To_v1alpha4_PortOpts(in *v1alpha5.PortOpts, o
 	out.TenantID = in.TenantID
 	out.ProjectID = in.ProjectID
 	out.SecurityGroups = (*[]string)(unsafe.Pointer(in.SecurityGroups))
+	// WARNING: in.SecurityGroupFilters requires manual conversion: does not exist in peer-type
 	out.AllowedAddressPairs = *(*[]AddressPair)(unsafe.Pointer(&in.AllowedAddressPairs))
 	out.Trunk = (*bool)(unsafe.Pointer(in.Trunk))
 	out.HostID = in.HostID

--- a/api/v1alpha5/types.go
+++ b/api/v1alpha5/types.go
@@ -114,11 +114,14 @@ type PortOpts struct {
 	AdminStateUp *bool  `json:"adminStateUp,omitempty"`
 	MACAddress   string `json:"macAddress,omitempty"`
 	// Specify pairs of subnet and/or IP address. These should be subnets of the network with the given NetworkID.
-	FixedIPs            []FixedIP     `json:"fixedIPs,omitempty"`
-	TenantID            string        `json:"tenantId,omitempty"`
-	ProjectID           string        `json:"projectId,omitempty"`
-	SecurityGroups      *[]string     `json:"securityGroups,omitempty"`
-	AllowedAddressPairs []AddressPair `json:"allowedAddressPairs,omitempty"`
+	FixedIPs  []FixedIP `json:"fixedIPs,omitempty"`
+	TenantID  string    `json:"tenantId,omitempty"`
+	ProjectID string    `json:"projectId,omitempty"`
+	// The uuids of the security groups to assign to the instance
+	SecurityGroups *[]string `json:"securityGroups,omitempty"`
+	// The names, uuids, filters or any combination these of the security groups to assign to the instance
+	SecurityGroupFilters []SecurityGroupParam `json:"securityGroupFilters,omitempty"`
+	AllowedAddressPairs  []AddressPair        `json:"allowedAddressPairs,omitempty"`
 	// Enables and disables trunk at port level. If not provided, openStackMachine.Spec.Trunk is inherited.
 	Trunk *bool `json:"trunk,omitempty"`
 

--- a/api/v1alpha5/zz_generated.deepcopy.go
+++ b/api/v1alpha5/zz_generated.deepcopy.go
@@ -822,6 +822,11 @@ func (in *PortOpts) DeepCopyInto(out *PortOpts) {
 			copy(*out, *in)
 		}
 	}
+	if in.SecurityGroupFilters != nil {
+		in, out := &in.SecurityGroupFilters, &out.SecurityGroupFilters
+		*out = make([]SecurityGroupParam, len(*in))
+		copy(*out, *in)
+	}
 	if in.AllowedAddressPairs != nil {
 		in, out := &in.AllowedAddressPairs, &out.AllowedAddressPairs
 		*out = make([]AddressPair, len(*in))

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -2779,7 +2779,53 @@ spec:
                               type: object
                             projectId:
                               type: string
+                            securityGroupFilters:
+                              description: The names, uuids, filters or any combination
+                                these of the security groups to assign to the instance
+                              items:
+                                properties:
+                                  filter:
+                                    description: Filters used to query security groups
+                                      in openstack
+                                    properties:
+                                      description:
+                                        type: string
+                                      id:
+                                        type: string
+                                      limit:
+                                        type: integer
+                                      marker:
+                                        type: string
+                                      name:
+                                        type: string
+                                      notTags:
+                                        type: string
+                                      notTagsAny:
+                                        type: string
+                                      projectId:
+                                        type: string
+                                      sortDir:
+                                        type: string
+                                      sortKey:
+                                        type: string
+                                      tags:
+                                        type: string
+                                      tagsAny:
+                                        type: string
+                                      tenantId:
+                                        type: string
+                                    type: object
+                                  name:
+                                    description: Security Group name
+                                    type: string
+                                  uuid:
+                                    description: Security Group UID
+                                    type: string
+                                type: object
+                              type: array
                             securityGroups:
+                              description: The uuids of the security groups to assign
+                                to the instance
                               items:
                                 type: string
                               type: array
@@ -3252,7 +3298,53 @@ spec:
                               type: object
                             projectId:
                               type: string
+                            securityGroupFilters:
+                              description: The names, uuids, filters or any combination
+                                these of the security groups to assign to the instance
+                              items:
+                                properties:
+                                  filter:
+                                    description: Filters used to query security groups
+                                      in openstack
+                                    properties:
+                                      description:
+                                        type: string
+                                      id:
+                                        type: string
+                                      limit:
+                                        type: integer
+                                      marker:
+                                        type: string
+                                      name:
+                                        type: string
+                                      notTags:
+                                        type: string
+                                      notTagsAny:
+                                        type: string
+                                      projectId:
+                                        type: string
+                                      sortDir:
+                                        type: string
+                                      sortKey:
+                                        type: string
+                                      tags:
+                                        type: string
+                                      tagsAny:
+                                        type: string
+                                      tenantId:
+                                        type: string
+                                    type: object
+                                  name:
+                                    description: Security Group name
+                                    type: string
+                                  uuid:
+                                    description: Security Group UID
+                                    type: string
+                                type: object
+                              type: array
                             securityGroups:
+                              description: The uuids of the security groups to assign
+                                to the instance
                               items:
                                 type: string
                               type: array
@@ -3586,7 +3678,53 @@ spec:
                         type: object
                       projectId:
                         type: string
+                      securityGroupFilters:
+                        description: The names, uuids, filters or any combination
+                          these of the security groups to assign to the instance
+                        items:
+                          properties:
+                            filter:
+                              description: Filters used to query security groups in
+                                openstack
+                              properties:
+                                description:
+                                  type: string
+                                id:
+                                  type: string
+                                limit:
+                                  type: integer
+                                marker:
+                                  type: string
+                                name:
+                                  type: string
+                                notTags:
+                                  type: string
+                                notTagsAny:
+                                  type: string
+                                projectId:
+                                  type: string
+                                sortDir:
+                                  type: string
+                                sortKey:
+                                  type: string
+                                tags:
+                                  type: string
+                                tagsAny:
+                                  type: string
+                                tenantId:
+                                  type: string
+                              type: object
+                            name:
+                              description: Security Group name
+                              type: string
+                            uuid:
+                              description: Security Group UID
+                              type: string
+                          type: object
+                        type: array
                       securityGroups:
+                        description: The uuids of the security groups to assign to
+                          the instance
                         items:
                           type: string
                         type: array
@@ -3834,7 +3972,53 @@ spec:
                         type: object
                       projectId:
                         type: string
+                      securityGroupFilters:
+                        description: The names, uuids, filters or any combination
+                          these of the security groups to assign to the instance
+                        items:
+                          properties:
+                            filter:
+                              description: Filters used to query security groups in
+                                openstack
+                              properties:
+                                description:
+                                  type: string
+                                id:
+                                  type: string
+                                limit:
+                                  type: integer
+                                marker:
+                                  type: string
+                                name:
+                                  type: string
+                                notTags:
+                                  type: string
+                                notTagsAny:
+                                  type: string
+                                projectId:
+                                  type: string
+                                sortDir:
+                                  type: string
+                                sortKey:
+                                  type: string
+                                tags:
+                                  type: string
+                                tagsAny:
+                                  type: string
+                                tenantId:
+                                  type: string
+                              type: object
+                            name:
+                              description: Security Group name
+                              type: string
+                            uuid:
+                              description: Security Group UID
+                              type: string
+                          type: object
+                        type: array
                       securityGroups:
+                        description: The uuids of the security groups to assign to
+                          the instance
                         items:
                           type: string
                         type: array

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
@@ -1049,7 +1049,54 @@ spec:
                                       type: object
                                     projectId:
                                       type: string
+                                    securityGroupFilters:
+                                      description: The names, uuids, filters or any
+                                        combination these of the security groups to
+                                        assign to the instance
+                                      items:
+                                        properties:
+                                          filter:
+                                            description: Filters used to query security
+                                              groups in openstack
+                                            properties:
+                                              description:
+                                                type: string
+                                              id:
+                                                type: string
+                                              limit:
+                                                type: integer
+                                              marker:
+                                                type: string
+                                              name:
+                                                type: string
+                                              notTags:
+                                                type: string
+                                              notTagsAny:
+                                                type: string
+                                              projectId:
+                                                type: string
+                                              sortDir:
+                                                type: string
+                                              sortKey:
+                                                type: string
+                                              tags:
+                                                type: string
+                                              tagsAny:
+                                                type: string
+                                              tenantId:
+                                                type: string
+                                            type: object
+                                          name:
+                                            description: Security Group name
+                                            type: string
+                                          uuid:
+                                            description: Security Group UID
+                                            type: string
+                                        type: object
+                                      type: array
                                     securityGroups:
+                                      description: The uuids of the security groups
+                                        to assign to the instance
                                       items:
                                         type: string
                                       type: array

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
@@ -1044,7 +1044,53 @@ spec:
                       type: object
                     projectId:
                       type: string
+                    securityGroupFilters:
+                      description: The names, uuids, filters or any combination these
+                        of the security groups to assign to the instance
+                      items:
+                        properties:
+                          filter:
+                            description: Filters used to query security groups in
+                              openstack
+                            properties:
+                              description:
+                                type: string
+                              id:
+                                type: string
+                              limit:
+                                type: integer
+                              marker:
+                                type: string
+                              name:
+                                type: string
+                              notTags:
+                                type: string
+                              notTagsAny:
+                                type: string
+                              projectId:
+                                type: string
+                              sortDir:
+                                type: string
+                              sortKey:
+                                type: string
+                              tags:
+                                type: string
+                              tagsAny:
+                                type: string
+                              tenantId:
+                                type: string
+                            type: object
+                          name:
+                            description: Security Group name
+                            type: string
+                          uuid:
+                            description: Security Group UID
+                            type: string
+                        type: object
+                      type: array
                     securityGroups:
+                      description: The uuids of the security groups to assign to the
+                        instance
                       items:
                         type: string
                       type: array

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
@@ -951,7 +951,53 @@ spec:
                               type: object
                             projectId:
                               type: string
+                            securityGroupFilters:
+                              description: The names, uuids, filters or any combination
+                                these of the security groups to assign to the instance
+                              items:
+                                properties:
+                                  filter:
+                                    description: Filters used to query security groups
+                                      in openstack
+                                    properties:
+                                      description:
+                                        type: string
+                                      id:
+                                        type: string
+                                      limit:
+                                        type: integer
+                                      marker:
+                                        type: string
+                                      name:
+                                        type: string
+                                      notTags:
+                                        type: string
+                                      notTagsAny:
+                                        type: string
+                                      projectId:
+                                        type: string
+                                      sortDir:
+                                        type: string
+                                      sortKey:
+                                        type: string
+                                      tags:
+                                        type: string
+                                      tagsAny:
+                                        type: string
+                                      tenantId:
+                                        type: string
+                                    type: object
+                                  name:
+                                    description: Security Group name
+                                    type: string
+                                  uuid:
+                                    description: Security Group UID
+                                    type: string
+                                type: object
+                              type: array
                             securityGroups:
+                              description: The uuids of the security groups to assign
+                                to the instance
                               items:
                                 type: string
                               type: array

--- a/hack/ci/cloud-init/controller.yaml.tpl
+++ b/hack/ci/cloud-init/controller.yaml.tpl
@@ -152,7 +152,10 @@
 
     # Adjust the CPU quota
     openstack quota set --cores 32 demo
-    openstack quota set --secgroups 50 demo
+    openstack quota set --secgroups 200 demo
+    openstack quota set --secgroup-rules 1000 demo
+    openstack quota set --secgroups 100 admin
+    openstack quota set --secgroup-rules 1000 admin
 - path: /root/devstack.sh
   permissions: 0755
   content: |

--- a/test/e2e/shared/openstack.go
+++ b/test/e2e/shared/openstack.go
@@ -311,6 +311,32 @@ func DumpOpenStackPorts(e2eCtx *E2EContext, filter ports.ListOpts) ([]ports.Port
 	return portsList, nil
 }
 
+// CreateOpenStackSecurityGroup creates a security group to be consumed by a worker node.
+func CreateOpenStackSecurityGroup(e2eCtx *E2EContext, securityGroupName, description string) error {
+	providerClient, clientOpts, _, err := GetTenantProviderClient(e2eCtx)
+	if err != nil {
+		return fmt.Errorf("error creating provider client: %s", err)
+	}
+
+	networkClient, err := openstack.NewNetworkV2(providerClient, gophercloud.EndpointOpts{
+		Region: clientOpts.RegionName,
+	})
+	if err != nil {
+		return fmt.Errorf("error creating network client: %s", err)
+	}
+
+	createOpts := groups.CreateOpts{
+		Name:        securityGroupName,
+		Description: description,
+	}
+
+	_, err = groups.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // DumpOpenStackTrunks trunks for a given port.
 func DumpOpenStackTrunks(e2eCtx *E2EContext, portID string) (*trunks.Trunk, error) {
 	providerClient, clientOpts, _, err := GetTenantProviderClient(e2eCtx)


### PR DESCRIPTION
With `OpenStackMachineTemplate` it is possible to specify security groups at both instance and port levels. However, both levels do not have same format, with the instance level having more options. This PR moves the port level format closer to that of the instance level, as shown below.

Specifying security groups at port level:

```
spec:
  template:
    spec:
      ports:
      - description: "Port 1 with security group in UUID format"
        securityGroups: 
        - "2f6584db-5138-453b-b47b-99696cb11f0f" 
```

Specifying security groups at port level:

```
spec:
  template:
    spec:
        securityGroups:
        - name: "capo-port-instance-level-sg"
           uuid: ....
           filter: .....
```

As can be seen above, the instance level setting has more options. This PR the `securityGroupsFilters` field. The original field `port.securityGroups` is kept for backward compatibility. However, the old field is redundant  due to the `securityGroupsFilters` already containing the `UUID` field. Therefore, removing it is more preferable. 

Fixes #1245

**Special notes for your reviewer**: