### PR TITLE
🐛 implement conversion for OpenStackClusterTemplate CRD

### DIFF
--- a/api/v1alpha4/conversion.go
+++ b/api/v1alpha4/conversion.go
@@ -51,6 +51,34 @@ func (r *OpenStackClusterList) ConvertFrom(srcRaw ctrlconversion.Hub) error {
 	return Convert_v1alpha5_OpenStackClusterList_To_v1alpha4_OpenStackClusterList(src, r, nil)
 }
 
+var _ ctrlconversion.Convertible = &OpenStackClusterTemplate{}
+
+func (r *OpenStackClusterTemplate) ConvertTo(dstRaw ctrlconversion.Hub) error {
+	dst := dstRaw.(*infrav1.OpenStackClusterTemplate)
+
+	return Convert_v1alpha4_OpenStackClusterTemplate_To_v1alpha5_OpenStackClusterTemplate(r, dst, nil)
+}
+
+func (r *OpenStackClusterTemplate) ConvertFrom(srcRaw ctrlconversion.Hub) error {
+	src := srcRaw.(*infrav1.OpenStackClusterTemplate)
+
+	return Convert_v1alpha5_OpenStackClusterTemplate_To_v1alpha4_OpenStackClusterTemplate(src, r, nil)
+}
+
+var _ ctrlconversion.Convertible = &OpenStackClusterTemplateList{}
+
+func (r *OpenStackClusterTemplateList) ConvertTo(dstRaw ctrlconversion.Hub) error {
+	dst := dstRaw.(*infrav1.OpenStackClusterTemplateList)
+
+	return Convert_v1alpha4_OpenStackClusterTemplateList_To_v1alpha5_OpenStackClusterTemplateList(r, dst, nil)
+}
+
+func (r *OpenStackClusterTemplateList) ConvertFrom(srcRaw ctrlconversion.Hub) error {
+	src := srcRaw.(*infrav1.OpenStackClusterTemplateList)
+
+	return Convert_v1alpha5_OpenStackClusterTemplateList_To_v1alpha4_OpenStackClusterTemplateList(src, r, nil)
+}
+
 var _ ctrlconversion.Convertible = &OpenStackMachine{}
 
 func (r *OpenStackMachine) ConvertTo(dstRaw ctrlconversion.Hub) error {

--- a/api/v1alpha4/conversion_test.go
+++ b/api/v1alpha4/conversion_test.go
@@ -88,6 +88,16 @@ func TestConvertTo(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "OpenStackClusterTemplate",
+			spoke: &OpenStackClusterTemplate{
+				Spec: OpenStackClusterTemplateSpec{},
+			},
+			hub: &infrav1.OpenStackClusterTemplate{},
+			want: &infrav1.OpenStackClusterTemplate{
+				Spec: infrav1.OpenStackClusterTemplateSpec{},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -155,6 +165,16 @@ func TestConvertFrom(t *testing.T) {
 					ManagedAPIServerLoadBalancer:         true,
 					APIServerLoadBalancerAdditionalPorts: []int{80, 443},
 				},
+			},
+		},
+		{
+			name:  "OpenStackClusterTemplate",
+			spoke: &OpenStackClusterTemplate{},
+			hub: &infrav1.OpenStackClusterTemplate{
+				Spec: infrav1.OpenStackClusterTemplateSpec{},
+			},
+			want: &OpenStackClusterTemplate{
+				Spec: OpenStackClusterTemplateSpec{},
 			},
 		},
 	}
@@ -304,6 +324,13 @@ func TestFuzzyConversion(t *testing.T) {
 		Scheme:      scheme,
 		Hub:         &infrav1.OpenStackCluster{},
 		Spoke:       &OpenStackCluster{},
+		FuzzerFuncs: []fuzzer.FuzzerFuncs{fuzzerFuncs},
+	}))
+
+	t.Run("for OpenStackClusterTemplate", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
+		Scheme:      scheme,
+		Hub:         &infrav1.OpenStackClusterTemplate{},
+		Spoke:       &OpenStackClusterTemplate{},
 		FuzzerFuncs: []fuzzer.FuzzerFuncs{fuzzerFuncs},
 	}))
 

--- a/api/v1alpha5/conversion.go
+++ b/api/v1alpha5/conversion.go
@@ -22,6 +22,12 @@ func (*OpenStackCluster) Hub() {}
 // Hub marks OpenStackClusterList as a conversion hub.
 func (*OpenStackClusterList) Hub() {}
 
+// Hub marks OpenStackClusterTemplate as a conversion hub.
+func (*OpenStackClusterTemplate) Hub() {}
+
+// Hub marks OpenStackClusterTemplateList as a conversion hub.
+func (*OpenStackClusterTemplateList) Hub() {}
+
 // Hub marks OpenStackMachine as a conversion hub.
 func (*OpenStackMachine) Hub() {}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `Hub()` methods to `v1alpha5` `OpenStackClusterTemplate` struct and implements `Convertible` interface in `v1alpha4`. API was only introduced in `v1alpha4`, so conversion to/from `v1alpha3` is not needed.

`conversion-gen` already generated the automatic conversion functions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1248

/hold
