### PR TITLE
bugfix: delete port left over

### DIFF
--- a/api/v1alpha4/openstackmachine_types.go
+++ b/api/v1alpha4/openstackmachine_types.go
@@ -90,6 +90,8 @@ type OpenStackMachineSpec struct {
 	// IdentityRef is a reference to a identity to be used when reconciling this cluster
 	// +optional
 	IdentityRef *OpenStackIdentityReference `json:"identityRef,omitempty"`
+
+	AdminPass string `json:"adminPass,omitempty"`
 }
 
 // OpenStackMachineStatus defines the observed state of OpenStackMachine.

--- a/api/v1beta1/openstackmachine_types.go
+++ b/api/v1beta1/openstackmachine_types.go
@@ -90,6 +90,8 @@ type OpenStackMachineSpec struct {
 	// IdentityRef is a reference to a identity to be used when reconciling this cluster
 	// +optional
 	IdentityRef *OpenStackIdentityReference `json:"identityRef,omitempty"`
+
+	AdminPass string `json:"adminPass,omitempty"`
 }
 
 // OpenStackMachineStatus defines the observed state of OpenStackMachine.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
@@ -273,6 +273,9 @@ spec:
               sshKeyName:
                 description: The ssh key to inject in the instance
                 type: string
+              adminPass:
+                description: The admin password to inject in the instance
+                type: string
               subnet:
                 description: UUID, IP address of a port from this subnet will be marked
                   as AccessIPv4 on the created compute instance
@@ -702,6 +705,9 @@ spec:
               sshKeyName:
                 description: The ssh key to inject in the instance
                 type: string
+              adminPass:
+                description: the adminpass to inject in the instance
+                type: string
               subnet:
                 description: UUID, IP address of a port from this subnet will be marked
                   as AccessIPv4 on the created compute instance
@@ -1117,6 +1123,9 @@ spec:
                 type: object
               sshKeyName:
                 description: The ssh key to inject in the instance
+                type: string
+              adminPass:
+                description: The admin pass to inject in the instance
                 type: string
               subnet:
                 description: UUID, IP address of a port from this subnet will be marked

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
@@ -268,6 +268,9 @@ spec:
                       sshKeyName:
                         description: The ssh key to inject in the instance
                         type: string
+                      adminPass:
+                        description: The admin pass to inject in the instance
+                        type: string
                       subnet:
                         description: UUID, IP address of a port from this subnet will
                           be marked as AccessIPv4 on the created compute instance
@@ -654,6 +657,9 @@ spec:
                       sshKeyName:
                         description: The ssh key to inject in the instance
                         type: string
+                      adminPass:
+                        description: The admin pass to inject in the instance
+                        type: string
                       subnet:
                         description: UUID, IP address of a port from this subnet will
                           be marked as AccessIPv4 on the created compute instance
@@ -1026,6 +1032,9 @@ spec:
                         type: object
                       sshKeyName:
                         description: The ssh key to inject in the instance
+                        type: string
+                      adminPass:
+                        description: The admin pass to inject in the instance
                         type: string
                       subnet:
                         description: UUID, IP address of a port from this subnet will

--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -139,6 +139,11 @@ func reconcileDelete(ctx context.Context, log logr.Logger, client client.Client,
 
 	clusterName := fmt.Sprintf("%s-%s", cluster.Namespace, cluster.Name)
 
+	if err = networkingService.DeletePorts(openStackCluster); err != nil {
+		handleUpdateOSCError(openStackCluster, errors.Errorf("failed to delete ports: %v", err))
+		return reconcile.Result{}, errors.Errorf("failed to delete ports: %v", err)
+	}
+
 	if openStackCluster.Spec.ManagedAPIServerLoadBalancer {
 		loadBalancerService, err := loadbalancer.NewService(osProviderClient, clientOpts, log)
 		if err != nil {

--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"fmt"
@@ -469,7 +470,16 @@ func (r *OpenStackMachineReconciler) getBootstrapData(ctx context.Context, machi
 		return "", errors.New("error retrieving bootstrap data: secret value key is missing")
 	}
 
-	return base64.StdEncoding.EncodeToString(value), nil
+	//return base64.StdEncoding.EncodeToString(value), nil
+	var buffer bytes.Buffer
+	buffer.Write(value)
+	if openStackMachine.Spec.AdminPass != ""{
+		adminPass := openStackMachine.Spec.AdminPass
+		resetpwd := "  - '(echo "+ adminPass +";sleep 1; echo "+ adminPass +") | passwd root' "
+		userPwd := []byte(resetpwd)
+		buffer.Write(userPwd)
+	}
+	return base64.StdEncoding.EncodeToString(buffer.Bytes()), nil
 }
 
 func (r *OpenStackMachineReconciler) requeueOpenStackMachinesForUnpausedCluster(ctx context.Context) handler.MapFunc {

--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
 	"fmt"
@@ -470,16 +469,7 @@ func (r *OpenStackMachineReconciler) getBootstrapData(ctx context.Context, machi
 		return "", errors.New("error retrieving bootstrap data: secret value key is missing")
 	}
 
-	//return base64.StdEncoding.EncodeToString(value), nil
-	var buffer bytes.Buffer
-	buffer.Write(value)
-	if openStackMachine.Spec.AdminPass != ""{
-		adminPass := openStackMachine.Spec.AdminPass
-		resetpwd := "  - '(echo "+ adminPass +";sleep 1; echo "+ adminPass +") | passwd root' "
-		userPwd := []byte(resetpwd)
-		buffer.Write(userPwd)
-	}
-	return base64.StdEncoding.EncodeToString(buffer.Bytes()), nil
+	return base64.StdEncoding.EncodeToString(value), nil
 }
 
 func (r *OpenStackMachineReconciler) requeueOpenStackMachinesForUnpausedCluster(ctx context.Context) handler.MapFunc {

--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -70,6 +70,7 @@ func (s *Service) createInstanceImpl(openStackCluster *infrav1.OpenStackCluster,
 		RootVolume:    openStackMachine.Spec.RootVolume,
 		Subnet:        openStackMachine.Spec.Subnet,
 		ServerGroupID: openStackMachine.Spec.ServerGroupID,
+		AdminPass:     openStackMachine.Spec.AdminPass,
 	}
 
 	// verify that trunk is supported if set at instance level.
@@ -245,6 +246,7 @@ func (s *Service) createInstance(eventObject runtime.Object, clusterName string,
 		Metadata:         instanceSpec.Metadata,
 		ConfigDrive:      &instanceSpec.ConfigDrive,
 		AccessIPv4:       accessIPv4,
+		AdminPass:        instanceSpec.AdminPass,
 	}
 
 	serverCreateOpts = applyRootVolume(serverCreateOpts, instanceSpec.RootVolume)

--- a/pkg/cloud/services/compute/instance_types.go
+++ b/pkg/cloud/services/compute/instance_types.go
@@ -47,6 +47,7 @@ type InstanceSpec struct {
 	Tags           []string
 	SecurityGroups []string
 	Networks       []infrav1.Network
+	AdminPass      string
 }
 
 // InstanceIdentifier describes an instance which has not necessarily been fetched.

--- a/pkg/cloud/services/networking/service.go
+++ b/pkg/cloud/services/networking/service.go
@@ -41,6 +41,7 @@ const (
 type Service struct {
 	projectID string
 	client    NetworkClient
+	nsclient  *gophercloud.ServiceClient
 	logger    logr.Logger
 }
 

--- a/templates/cluster-template-external-cloud-provider.yaml
+++ b/templates/cluster-template-external-cloud-provider.yaml
@@ -75,6 +75,7 @@ spec:
       flavor: ${OPENSTACK_CONTROL_PLANE_MACHINE_FLAVOR}
       image: ${OPENSTACK_IMAGE_NAME}
       sshKeyName: ${OPENSTACK_SSH_KEY_NAME}
+      adminPass: ${OPENSTACK_ADMINPASS}
       cloudName: ${OPENSTACK_CLOUD}
       identityRef:
         name: ${CLUSTER_NAME}-cloud-config
@@ -118,6 +119,7 @@ spec:
       flavor: ${OPENSTACK_NODE_MACHINE_FLAVOR}
       image: ${OPENSTACK_IMAGE_NAME}
       sshKeyName: ${OPENSTACK_SSH_KEY_NAME}
+      adminPass: ${OPENSTACK_ADMINPASS}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/templates/cluster-template-without-lb.yaml
+++ b/templates/cluster-template-without-lb.yaml
@@ -103,6 +103,7 @@ spec:
       flavor: ${OPENSTACK_CONTROL_PLANE_MACHINE_FLAVOR}
       image: ${OPENSTACK_IMAGE_NAME}
       sshKeyName: ${OPENSTACK_SSH_KEY_NAME}
+      adminPass: ${OPENSTACK_ADMINPASS}
       cloudName: ${OPENSTACK_CLOUD}
       identityRef:
         name: ${CLUSTER_NAME}-cloud-config
@@ -146,6 +147,7 @@ spec:
       flavor: ${OPENSTACK_NODE_MACHINE_FLAVOR}
       image: ${OPENSTACK_IMAGE_NAME}
       sshKeyName: ${OPENSTACK_SSH_KEY_NAME}
+      adminPass: ${OPENSTACK_ADMINPASS}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -104,6 +104,7 @@ spec:
       flavor: ${OPENSTACK_CONTROL_PLANE_MACHINE_FLAVOR}
       image: ${OPENSTACK_IMAGE_NAME}
       sshKeyName: ${OPENSTACK_SSH_KEY_NAME}
+      adminPass: ${OPENSTACK_ADMINPASS}
       cloudName: ${OPENSTACK_CLOUD}
       identityRef:
         name: ${CLUSTER_NAME}-cloud-config
@@ -147,6 +148,7 @@ spec:
       flavor: ${OPENSTACK_NODE_MACHINE_FLAVOR}
       image: ${OPENSTACK_IMAGE_NAME}
       sshKeyName: ${OPENSTACK_SSH_KEY_NAME}
+      adminPass: ${OPENSTACK_ADMINPASS}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This is an abnormal scenario: the virtual machine creation fails, but the port creation succeeds. In this case, the port will be left when deleting the cluster, because this port cannot be deleted according to the virtual machine. In this case, we can query the relevant port according to the subnet to delete it
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
