### PR TITLE
Deprecating and/or replacing securityGroups field from OpenStackMachineTemplate

### DIFF
--- a/api/v1alpha4/conversion.go
+++ b/api/v1alpha4/conversion.go
@@ -254,6 +254,24 @@ func Convert_v1alpha5_PortOpts_To_v1alpha4_PortOpts(in *infrav1.PortOpts, out *P
 	return nil
 }
 
+func Convert_Slice_string_To_Slice_v1alpha5_SecurityGroupParam(in *[]string, out *[]infrav1.SecurityGroupParam, s conversion.Scope) error {
+	if in != nil {
+		for _, v1alpha4SecurityGroupUID := range *in {
+			*out = append(*out, infrav1.SecurityGroupParam{UUID: v1alpha4SecurityGroupUID})
+		}
+	}
+	return nil
+}
+
+func Convert_Slice_v1alpha5_SecurityGroupParam_To_Slice_string(in *[]infrav1.SecurityGroupParam, out *[]string, s conversion.Scope) error {
+	if in != nil {
+		for _, v1alpha5SecurityGroups := range *in {
+			*out = append(*out, v1alpha5SecurityGroups.UUID)
+		}
+	}
+	return nil
+}
+
 func Convert_Slice_v1alpha4_Network_To_Slice_v1alpha5_Network(in *[]Network, out *[]infrav1.Network, s conversion.Scope) error {
 	*out = make([]infrav1.Network, len(*in))
 	for i := range *in {

--- a/api/v1alpha4/conversion_test.go
+++ b/api/v1alpha4/conversion_test.go
@@ -302,7 +302,7 @@ func TestFuzzyConversion(t *testing.T) {
 						v1alpha5PortOpts.Network = nil
 					}
 				}
-				v1alpha5PortOpts.SecurityGroupFilters = nil
+				v1alpha5PortOpts.SecurityGroups = nil
 			},
 			func(v1alpha5FixedIP *infrav1.FixedIP, c fuzz.Continue) {
 				c.FuzzNoCustom(v1alpha5FixedIP)

--- a/api/v1alpha4/zz_generated.conversion.go
+++ b/api/v1alpha4/zz_generated.conversion.go
@@ -310,6 +310,11 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
+	if err := s.AddConversionFunc((*[]string)(nil), (*[]v1alpha5.SecurityGroupParam)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_Slice_string_To_Slice_v1alpha5_SecurityGroupParam(a.(*[]string), b.(*[]v1alpha5.SecurityGroupParam), scope)
+	}); err != nil {
+		return err
+	}
 	if err := s.AddConversionFunc((*[]Network)(nil), (*[]v1alpha5.Network)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_Slice_v1alpha4_Network_To_Slice_v1alpha5_Network(a.(*[]Network), b.(*[]v1alpha5.Network), scope)
 	}); err != nil {
@@ -317,6 +322,11 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}
 	if err := s.AddConversionFunc((*[]v1alpha5.Network)(nil), (*[]Network)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_Slice_v1alpha5_Network_To_Slice_v1alpha4_Network(a.(*[]v1alpha5.Network), b.(*[]Network), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*[]v1alpha5.SecurityGroupParam)(nil), (*[]string)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_Slice_v1alpha5_SecurityGroupParam_To_Slice_string(a.(*[]v1alpha5.SecurityGroupParam), b.(*[]string), scope)
 	}); err != nil {
 		return err
 	}
@@ -1471,7 +1481,15 @@ func autoConvert_v1alpha4_PortOpts_To_v1alpha5_PortOpts(in *PortOpts, out *v1alp
 	}
 	out.TenantID = in.TenantID
 	out.ProjectID = in.ProjectID
-	out.SecurityGroups = (*[]string)(unsafe.Pointer(in.SecurityGroups))
+	if in.SecurityGroups != nil {
+		in, out := &in.SecurityGroups, &out.SecurityGroups
+		*out = new([]v1alpha5.SecurityGroupParam)
+		if err := Convert_Slice_string_To_Slice_v1alpha5_SecurityGroupParam(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.SecurityGroups = nil
+	}
 	out.AllowedAddressPairs = *(*[]v1alpha5.AddressPair)(unsafe.Pointer(&in.AllowedAddressPairs))
 	out.Trunk = (*bool)(unsafe.Pointer(in.Trunk))
 	out.HostID = in.HostID
@@ -1501,8 +1519,15 @@ func autoConvert_v1alpha5_PortOpts_To_v1alpha4_PortOpts(in *v1alpha5.PortOpts, o
 	}
 	out.TenantID = in.TenantID
 	out.ProjectID = in.ProjectID
-	out.SecurityGroups = (*[]string)(unsafe.Pointer(in.SecurityGroups))
-	// WARNING: in.SecurityGroupFilters requires manual conversion: does not exist in peer-type
+	if in.SecurityGroups != nil {
+		in, out := &in.SecurityGroups, &out.SecurityGroups
+		*out = new([]string)
+		if err := Convert_Slice_v1alpha5_SecurityGroupParam_To_Slice_string(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.SecurityGroups = nil
+	}
 	out.AllowedAddressPairs = *(*[]AddressPair)(unsafe.Pointer(&in.AllowedAddressPairs))
 	out.Trunk = (*bool)(unsafe.Pointer(in.Trunk))
 	out.HostID = in.HostID

--- a/api/v1alpha5/types.go
+++ b/api/v1alpha5/types.go
@@ -117,11 +117,9 @@ type PortOpts struct {
 	FixedIPs  []FixedIP `json:"fixedIPs,omitempty"`
 	TenantID  string    `json:"tenantId,omitempty"`
 	ProjectID string    `json:"projectId,omitempty"`
-	// The uuids of the security groups to assign to the instance
-	SecurityGroups *[]string `json:"securityGroups,omitempty"`
-	// The names, uuids, filters or any combination these of the security groups to assign to the instance
-	SecurityGroupFilters []SecurityGroupParam `json:"securityGroupFilters,omitempty"`
-	AllowedAddressPairs  []AddressPair        `json:"allowedAddressPairs,omitempty"`
+	// The names of the security groups to assign to the port
+	SecurityGroups      *[]SecurityGroupParam `json:"securityGroups,omitempty"`
+	AllowedAddressPairs []AddressPair         `json:"allowedAddressPairs,omitempty"`
 	// Enables and disables trunk at port level. If not provided, openStackMachine.Spec.Trunk is inherited.
 	Trunk *bool `json:"trunk,omitempty"`
 

--- a/api/v1alpha5/zz_generated.deepcopy.go
+++ b/api/v1alpha5/zz_generated.deepcopy.go
@@ -825,17 +825,12 @@ func (in *PortOpts) DeepCopyInto(out *PortOpts) {
 	}
 	if in.SecurityGroups != nil {
 		in, out := &in.SecurityGroups, &out.SecurityGroups
-		*out = new([]string)
+		*out = new([]SecurityGroupParam)
 		if **in != nil {
 			in, out := *in, *out
-			*out = make([]string, len(*in))
+			*out = make([]SecurityGroupParam, len(*in))
 			copy(*out, *in)
 		}
-	}
-	if in.SecurityGroupFilters != nil {
-		in, out := &in.SecurityGroupFilters, &out.SecurityGroupFilters
-		*out = make([]SecurityGroupParam, len(*in))
-		copy(*out, *in)
 	}
 	if in.AllowedAddressPairs != nil {
 		in, out := &in.AllowedAddressPairs, &out.AllowedAddressPairs

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -2785,9 +2785,9 @@ spec:
                               type: object
                             projectId:
                               type: string
-                            securityGroupFilters:
-                              description: The names, uuids, filters or any combination
-                                these of the security groups to assign to the instance
+                            securityGroups:
+                              description: The names of the security groups to assign
+                                to the port
                               items:
                                 properties:
                                   filter:
@@ -2828,12 +2828,6 @@ spec:
                                     description: Security Group UID
                                     type: string
                                 type: object
-                              type: array
-                            securityGroups:
-                              description: The uuids of the security groups to assign
-                                to the instance
-                              items:
-                                type: string
                               type: array
                             tags:
                               description: Tags applied to the port (and corresponding
@@ -3308,9 +3302,9 @@ spec:
                               type: object
                             projectId:
                               type: string
-                            securityGroupFilters:
-                              description: The names, uuids, filters or any combination
-                                these of the security groups to assign to the instance
+                            securityGroups:
+                              description: The names of the security groups to assign
+                                to the port
                               items:
                                 properties:
                                   filter:
@@ -3351,12 +3345,6 @@ spec:
                                     description: Security Group UID
                                     type: string
                                 type: object
-                              type: array
-                            securityGroups:
-                              description: The uuids of the security groups to assign
-                                to the instance
-                              items:
-                                type: string
                               type: array
                             tags:
                               description: Tags applied to the port (and corresponding
@@ -3696,9 +3684,9 @@ spec:
                         type: object
                       projectId:
                         type: string
-                      securityGroupFilters:
-                        description: The names, uuids, filters or any combination
-                          these of the security groups to assign to the instance
+                      securityGroups:
+                        description: The names of the security groups to assign to
+                          the port
                         items:
                           properties:
                             filter:
@@ -3739,12 +3727,6 @@ spec:
                               description: Security Group UID
                               type: string
                           type: object
-                        type: array
-                      securityGroups:
-                        description: The uuids of the security groups to assign to
-                          the instance
-                        items:
-                          type: string
                         type: array
                       tags:
                         description: Tags applied to the port (and corresponding trunk,
@@ -3998,9 +3980,9 @@ spec:
                         type: object
                       projectId:
                         type: string
-                      securityGroupFilters:
-                        description: The names, uuids, filters or any combination
-                          these of the security groups to assign to the instance
+                      securityGroups:
+                        description: The names of the security groups to assign to
+                          the port
                         items:
                           properties:
                             filter:
@@ -4041,12 +4023,6 @@ spec:
                               description: Security Group UID
                               type: string
                           type: object
-                        type: array
-                      securityGroups:
-                        description: The uuids of the security groups to assign to
-                          the instance
-                        items:
-                          type: string
                         type: array
                       tags:
                         description: Tags applied to the port (and corresponding trunk,

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
@@ -1055,10 +1055,9 @@ spec:
                                       type: object
                                     projectId:
                                       type: string
-                                    securityGroupFilters:
-                                      description: The names, uuids, filters or any
-                                        combination these of the security groups to
-                                        assign to the instance
+                                    securityGroups:
+                                      description: The names of the security groups
+                                        to assign to the port
                                       items:
                                         properties:
                                           filter:
@@ -1099,12 +1098,6 @@ spec:
                                             description: Security Group UID
                                             type: string
                                         type: object
-                                      type: array
-                                    securityGroups:
-                                      description: The uuids of the security groups
-                                        to assign to the instance
-                                      items:
-                                        type: string
                                       type: array
                                     tags:
                                       description: Tags applied to the port (and corresponding

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
@@ -1044,9 +1044,9 @@ spec:
                       type: object
                     projectId:
                       type: string
-                    securityGroupFilters:
-                      description: The names, uuids, filters or any combination these
-                        of the security groups to assign to the instance
+                    securityGroups:
+                      description: The names of the security groups to assign to the
+                        port
                       items:
                         properties:
                           filter:
@@ -1087,12 +1087,6 @@ spec:
                             description: Security Group UID
                             type: string
                         type: object
-                      type: array
-                    securityGroups:
-                      description: The uuids of the security groups to assign to the
-                        instance
-                      items:
-                        type: string
                       type: array
                     tags:
                       description: Tags applied to the port (and corresponding trunk,

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
@@ -951,9 +951,9 @@ spec:
                               type: object
                             projectId:
                               type: string
-                            securityGroupFilters:
-                              description: The names, uuids, filters or any combination
-                                these of the security groups to assign to the instance
+                            securityGroups:
+                              description: The names of the security groups to assign
+                                to the port
                               items:
                                 properties:
                                   filter:
@@ -994,12 +994,6 @@ spec:
                                     description: Security Group UID
                                     type: string
                                 type: object
-                              type: array
-                            securityGroups:
-                              description: The uuids of the security groups to assign
-                                to the instance
-                              items:
-                                type: string
                               type: array
                             tags:
                               description: Tags applied to the port (and corresponding

--- a/pkg/cloud/services/networking/port.go
+++ b/pkg/cloud/services/networking/port.go
@@ -89,9 +89,15 @@ func (s *Service) GetOrCreatePort(eventObject runtime.Object, clusterName string
 				MACAddress: ap.MACAddress,
 			})
 		}
-		securityGroups, err = s.CollectPortSecurityGroups(eventObject, portOpts.SecurityGroups, portOpts.SecurityGroupFilters)
-		if err != nil {
-			return nil, err
+		portSecurityGroups := portOpts.SecurityGroups
+		if portSecurityGroups != nil {
+			portSecurityGroups, err := s.GetSecurityGroups(*portSecurityGroups)
+			if err != nil {
+				return nil, fmt.Errorf("error getting security groups: %v", err)
+			}
+			if len(portSecurityGroups) > 0 {
+				securityGroups = &portSecurityGroups
+			}
 		}
 		// inherit port security groups from the instance if not explicitly specified
 		if securityGroups == nil || len(*securityGroups) == 0 {
@@ -257,42 +263,4 @@ func (s *Service) GarbageCollectErrorInstancesPort(eventObject runtime.Object, i
 	}
 
 	return nil
-}
-
-// CollectPortSecurityGroups collects distinct securityGroups from port.SecurityGroups and port.SecurityGroupFilter fields.
-func (s *Service) CollectPortSecurityGroups(eventObject runtime.Object, portSecurityGroups *[]string, portSecurityGroupFilters []infrav1.SecurityGroupParam) (*[]string, error) {
-	var allSecurityGroupIDs []string
-	// security groups provided with the portSecurityGroupFilters fields
-	securityGroupFiltersByID, err := s.GetSecurityGroups(portSecurityGroupFilters)
-	if err != nil {
-		return portSecurityGroups, fmt.Errorf("error getting security groups: %v", err)
-	}
-	allSecurityGroupIDs = append(allSecurityGroupIDs, securityGroupFiltersByID...)
-	securityGroupCount := 0
-	// security groups provided with the portSecurityGroups fields
-	if portSecurityGroups != nil {
-		allSecurityGroupIDs = append(allSecurityGroupIDs, *portSecurityGroups...)
-	}
-	// generate unique values
-	uids := make(map[string]int)
-	for _, sg := range allSecurityGroupIDs {
-		if sg == "" {
-			continue
-		}
-		// count distinct values
-		_, ok := uids[sg]
-		if !ok {
-			securityGroupCount++
-		}
-		uids[sg] = 1
-	}
-	distinctSecurityGroupIDs := make([]string, 0, securityGroupCount)
-	// collect distict values
-	for key := range uids {
-		if key == "" {
-			continue
-		}
-		distinctSecurityGroupIDs = append(distinctSecurityGroupIDs, key)
-	}
-	return &distinctSecurityGroupIDs, nil
 }

--- a/pkg/cloud/services/networking/port_test.go
+++ b/pkg/cloud/services/networking/port_test.go
@@ -49,8 +49,7 @@ func Test_GetOrCreatePort(t *testing.T) {
 
 	// Other arbitrary variables passed in to the tests
 	instanceSecurityGroups := []string{"instance-secgroup"}
-	portSecurityGroups := []string{"port-secgroup"}
-
+	portSecurityGroups := []infrav1.SecurityGroupParam{{Name: "port-secgroup"}}
 	pointerToTrue := pointerTo(true)
 	pointerToFalse := pointerTo(false)
 
@@ -166,9 +165,8 @@ func Test_GetOrCreatePort(t *testing.T) {
 						},
 						IPAddress: "192.168.0.50",
 					}, {IPAddress: "192.168.1.50"}},
-					TenantID:       tenantID,
-					ProjectID:      projectID,
-					SecurityGroups: &portSecurityGroups,
+					TenantID:  tenantID,
+					ProjectID: projectID,
 					AllowedAddressPairs: []infrav1.AddressPair{{
 						IPAddress:  "10.10.10.10",
 						MACAddress: "f1:f1:f1:f1:f1:f1",
@@ -197,9 +195,8 @@ func Test_GetOrCreatePort(t *testing.T) {
 							IPAddress: "192.168.1.50",
 						},
 					},
-					TenantID:       tenantID,
-					ProjectID:      projectID,
-					SecurityGroups: &portSecurityGroups,
+					TenantID:  tenantID,
+					ProjectID: projectID,
 					AllowedAddressPairs: []ports.AddressPair{{
 						IPAddress:  "10.10.10.10",
 						MACAddress: "f1:f1:f1:f1:f1:f1",
@@ -313,7 +310,7 @@ func Test_GetOrCreatePort(t *testing.T) {
 						CreateOptsBuilder: ports.CreateOpts{
 							Name:                "foo-port-1",
 							Description:         "Created by cluster-api-provider-openstack cluster test-cluster",
-							SecurityGroups:      &portSecurityGroups,
+							SecurityGroups:      &instanceSecurityGroups,
 							NetworkID:           netID,
 							AllowedAddressPairs: []ports.AddressPair{},
 						},

--- a/pkg/cloud/services/networking/securitygroups.go
+++ b/pkg/cloud/services/networking/securitygroups.go
@@ -393,6 +393,9 @@ func (s *Service) generateDesiredSecGroups(openStackCluster *infrav1.OpenStackCl
 func (s *Service) GetSecurityGroups(securityGroupParams []infrav1.SecurityGroupParam) ([]string, error) {
 	var sgIDs []string
 	for _, sg := range securityGroupParams {
+		if sg.UUID == "" {
+			continue
+		}
 		// Don't validate an explicit UUID if we were given one
 		if sg.UUID != "" {
 			if isDuplicate(sgIDs, sg.UUID) {


### PR DESCRIPTION
Deprecating and replacing `PortOpts.SecurityGroups` of `[]string` format field from `OpenStackMachineTemplate` ports and replace is by `[]SecurityGroupParam` format.

fixes: https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/1251