### PR TITLE
🐛 Make failure domain optional for OpenStackMachine

### DIFF
--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -421,10 +421,6 @@ func machineToInstanceSpec(openStackCluster *infrav1.OpenStackCluster, machine *
 		return nil, fmt.Errorf("create Options need be specified to create instace")
 	}
 
-	if machine.Spec.FailureDomain == nil {
-		return nil, fmt.Errorf("failure domain not set")
-	}
-
 	instanceSpec := compute.InstanceSpec{
 		Name:          openStackMachine.Name,
 		Image:         openStackMachine.Spec.Image,
@@ -434,11 +430,15 @@ func machineToInstanceSpec(openStackCluster *infrav1.OpenStackCluster, machine *
 		UserData:      userData,
 		Metadata:      openStackMachine.Spec.ServerMetadata,
 		ConfigDrive:   openStackMachine.Spec.ConfigDrive != nil && *openStackMachine.Spec.ConfigDrive,
-		FailureDomain: *machine.Spec.FailureDomain,
 		RootVolume:    openStackMachine.Spec.RootVolume,
 		Subnet:        openStackMachine.Spec.Subnet,
 		ServerGroupID: openStackMachine.Spec.ServerGroupID,
 		Trunk:         openStackMachine.Spec.Trunk,
+	}
+
+	// Add the failure domain only if specified
+	if machine.Spec.FailureDomain != nil {
+		instanceSpec.FailureDomain = *machine.Spec.FailureDomain
 	}
 
 	machineTags := []string{}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

The failure domain is an optional field for CAPI `Machine` objects. This patch makes sure that we can respect the case where a failure domain is not specified - currently this results in a failed machine.

This is implemented by omitting the availability zone from the server create if no failure domain is present on the CAPI machine. In this case, Nova will pick a suitable availability zone for the machine based on all other scheduling constraints.

This change was previously part of PR #1252.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
