### PR TITLE
📖 Instance create timeout is in minutes

### DIFF
--- a/docs/book/src/clusteropenstack/configuration.md
+++ b/docs/book/src/clusteropenstack/configuration.md
@@ -451,7 +451,7 @@ If `availabilityZone` is not specified, the volume will be created in the cinder
 
 ## Timeout settings
 
-If creating servers in your OpenStack takes a long time, you can increase the timeout, by default it's 5 minutes. You can set it via the `CLUSTER_API_OPENSTACK_INSTANCE_CREATE_TIMEOUT` in your Cluster API Provider OpenStack controller deployment.
+The default timeout for instance creation is 5 minutes. If creating servers in your OpenStack takes a long time, you can increase the timeout. You can set a new value, in minutes, via the envorinment variable `CLUSTER_API_OPENSTACK_INSTANCE_CREATE_TIMEOUT` in your Cluster API Provider OpenStack controller deployment.
 
 ## Custom pod network CIDR
 


### PR DESCRIPTION
Mention that the value of
`CLUSTER_API_OPENSTACK_INSTANCE_CREATE_TIMEOUT` must be set in minutes.

**What this PR does / why we need it**:
In the user documentation, it was not clear that the value passed as `CLUSTER_API_OPENSTACK_INSTANCE_CREATE_TIMEOUT` is interpreted as minutes (as opposed to seconds, for example).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1266

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- if necessary:
  - [X] includes documentation
  - [ ] adds unit tests

/hold
