### PR TITLE
🌱 Add renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,55 @@
+{
+  "extends":[
+    "config:base"
+  ],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/vendor/**",
+    "**/examples/**"
+  ],
+  "enabled": "true",
+  "baseBranches": ["main"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["golang"],
+      "allowedVersions": "<=1.17"
+    },
+    {
+      "matchPackageNames": ["kubernetes/kubernetes"],
+      "allowedVersions": "<=1.23"
+    },
+    {
+      "extends": ["group:kubernetes"],
+      "allowedVersions": "<=0.23"
+    },
+    {
+      "matchPackageNames": ["sigs.k8s.io/cluster-api", "sigs.k8s.io/cluster-api/test"],
+      "groupName": "Cluster API"
+    }
+  ],
+  "prHourlyLimit": 5,
+  "prConcurrentLimit": 5,
+  "rangeStrategy": "bump",
+  "renovateFork": true,
+  "stabilityDays": 5,
+  "regexManagers": [
+    {
+      "fileMatch": ["^Makefile$"],
+      "matchStrings": [
+        "KUBEBUILDER_ENVTEST_KUBERNETES_VERSION .= (?<currentValue>.*?)\\n"
+      ],
+      "depNameTemplate": "kubernetes/kubernetes",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*?)$"
+    },
+    {
+      "fileMatch": ["^test/e2e/data/e2e_conf.yaml$"],
+      "matchStrings": [
+        "KUBERNETES_VERSION: \"(?<currentValue>.*?)\"\\n"
+      ],
+      "depNameTemplate": "kubernetes/kubernetes",
+      "datasourceTemplate": "github-releases"
+    }
+   ]
+ }


### PR DESCRIPTION
**What this PR does / why we need it**:

This is to automatically bump versions through pull requests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1093 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.
2. Merging this PR is not enough to enable renovate. Someone with privileges to add GitHub apps also needs to follow the [onboarding steps](https://docs.renovatebot.com/getting-started/installing-onboarding/). The best way to do this is probably to *start* with the onboarding, then copy the configuration from this PR to the renovate onboarding PR and merge that instead
3. **I have tested the configuration in this PR in my fork. You can see the pull requests that renovate has created [here](https://github.com/lentzi90/cluster-api-provider-openstack/pulls).** Please check these to see if renovate is doing things the way we want.

**TODOs**:

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
