### PR TITLE
Add Age column for osc/osm

### DIFF
--- a/api/v1alpha3/openstackcluster_types.go
+++ b/api/v1alpha3/openstackcluster_types.go
@@ -152,6 +152,7 @@ type OpenStackClusterStatus struct {
 // +kubebuilder:printcolumn:name="Subnet",type="string",JSONPath=".status.network.subnet.id",description="Subnet the cluster is using"
 // +kubebuilder:printcolumn:name="Endpoint",type="string",JSONPath=".spec.controlPlaneEndpoint.host",description="API Endpoint",priority=1
 // +kubebuilder:printcolumn:name="Bastion",type="string",JSONPath=".status.bastion.floatingIP",description="Bastion floating IP"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of OpenStackCluster"
 
 // OpenStackCluster is the Schema for the openstackclusters API.
 type OpenStackCluster struct {

--- a/api/v1alpha3/openstackmachine_types.go
+++ b/api/v1alpha3/openstackmachine_types.go
@@ -135,6 +135,7 @@ type OpenStackMachineStatus struct {
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Machine ready status"
 // +kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="OpenStack instance ID"
 // +kubebuilder:printcolumn:name="Machine",type="string",JSONPath=".metadata.ownerReferences[?(@.kind==\"Machine\")].name",description="Machine object which owns with this OpenStackMachine"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of OpenStackMachine"
 
 // OpenStackMachine is the Schema for the openstackmachines API.
 type OpenStackMachine struct {

--- a/api/v1alpha4/openstackcluster_types.go
+++ b/api/v1alpha4/openstackcluster_types.go
@@ -217,6 +217,7 @@ type OpenStackClusterStatus struct {
 // +kubebuilder:printcolumn:name="Subnet",type="string",JSONPath=".status.network.subnet.id",description="Subnet the cluster is using"
 // +kubebuilder:printcolumn:name="Endpoint",type="string",JSONPath=".spec.controlPlaneEndpoint.host",description="API Endpoint",priority=1
 // +kubebuilder:printcolumn:name="Bastion IP",type="string",JSONPath=".status.bastion.floatingIP",description="Bastion address for breakglass access"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of OpenStackCluster"
 
 // OpenStackCluster is the Schema for the openstackclusters API.
 type OpenStackCluster struct {

--- a/api/v1alpha4/openstackmachine_types.go
+++ b/api/v1alpha4/openstackmachine_types.go
@@ -135,6 +135,7 @@ type OpenStackMachineStatus struct {
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Machine ready status"
 // +kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="OpenStack instance ID"
 // +kubebuilder:printcolumn:name="Machine",type="string",JSONPath=".metadata.ownerReferences[?(@.kind==\"Machine\")].name",description="Machine object which owns with this OpenStackMachine"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of OpenStackMachine"
 
 // OpenStackMachine is the Schema for the openstackmachines API.
 type OpenStackMachine struct {

--- a/api/v1alpha5/openstackcluster_types.go
+++ b/api/v1alpha5/openstackcluster_types.go
@@ -214,6 +214,7 @@ type OpenStackClusterStatus struct {
 // +kubebuilder:printcolumn:name="Subnet",type="string",JSONPath=".status.network.subnet.id",description="Subnet the cluster is using"
 // +kubebuilder:printcolumn:name="Endpoint",type="string",JSONPath=".spec.controlPlaneEndpoint.host",description="API Endpoint",priority=1
 // +kubebuilder:printcolumn:name="Bastion IP",type="string",JSONPath=".status.bastion.floatingIP",description="Bastion address for breakglass access"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of OpenStackCluster"
 
 // OpenStackCluster is the Schema for the openstackclusters API.
 type OpenStackCluster struct {

--- a/api/v1alpha5/openstackmachine_types.go
+++ b/api/v1alpha5/openstackmachine_types.go
@@ -139,6 +139,7 @@ type OpenStackMachineStatus struct {
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Machine ready status"
 // +kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="OpenStack instance ID"
 // +kubebuilder:printcolumn:name="Machine",type="string",JSONPath=".metadata.ownerReferences[?(@.kind==\"Machine\")].name",description="Machine object which owns with this OpenStackMachine"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of OpenStackMachine"
 
 // OpenStackMachine is the Schema for the openstackmachines API.
 type OpenStackMachine struct {

--- a/api/v1alpha6/openstackcluster_types.go
+++ b/api/v1alpha6/openstackcluster_types.go
@@ -215,6 +215,7 @@ type OpenStackClusterStatus struct {
 // +kubebuilder:printcolumn:name="Subnet",type="string",JSONPath=".status.network.subnet.id",description="Subnet the cluster is using"
 // +kubebuilder:printcolumn:name="Endpoint",type="string",JSONPath=".spec.controlPlaneEndpoint.host",description="API Endpoint",priority=1
 // +kubebuilder:printcolumn:name="Bastion IP",type="string",JSONPath=".status.bastion.floatingIP",description="Bastion address for breakglass access"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of OpenStackCluster"
 
 // OpenStackCluster is the Schema for the openstackclusters API.
 type OpenStackCluster struct {

--- a/api/v1alpha6/openstackmachine_types.go
+++ b/api/v1alpha6/openstackmachine_types.go
@@ -140,6 +140,7 @@ type OpenStackMachineStatus struct {
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Machine ready status"
 // +kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="OpenStack instance ID"
 // +kubebuilder:printcolumn:name="Machine",type="string",JSONPath=".metadata.ownerReferences[?(@.kind==\"Machine\")].name",description="Machine object which owns with this OpenStackMachine"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of OpenStackMachine"
 
 // OpenStackMachine is the Schema for the openstackmachines API.
 type OpenStackMachine struct {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -46,6 +46,10 @@ spec:
       jsonPath: .status.bastion.floatingIP
       name: Bastion
       type: string
+    - description: Time duration since creation of OpenStackCluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha3
     schema:
       openAPIV3Schema:
@@ -1055,6 +1059,10 @@ spec:
       jsonPath: .status.bastion.floatingIP
       name: Bastion IP
       type: string
+    - description: Time duration since creation of OpenStackCluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha4
     schema:
       openAPIV3Schema:
@@ -2462,6 +2470,10 @@ spec:
       jsonPath: .status.bastion.floatingIP
       name: Bastion IP
       type: string
+    - description: Time duration since creation of OpenStackCluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha5
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -4202,6 +4202,10 @@ spec:
       jsonPath: .status.bastion.floatingIP
       name: Bastion IP
       type: string
+    - description: Time duration since creation of OpenStackCluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha6
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
@@ -1272,6 +1272,10 @@ spec:
       jsonPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
       name: Machine
       type: string
+    - description: Time duration since creation of OpenStackMachine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha6
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
@@ -41,6 +41,10 @@ spec:
       jsonPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
       name: Machine
       type: string
+    - description: Time duration since creation of OpenStackMachine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha3
     schema:
       openAPIV3Schema:
@@ -376,6 +380,10 @@ spec:
       jsonPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
       name: Machine
       type: string
+    - description: Time duration since creation of OpenStackMachine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha4
     schema:
       openAPIV3Schema:
@@ -792,6 +800,10 @@ spec:
       jsonPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
       name: Machine
       type: string
+    - description: Time duration since creation of OpenStackMachine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha5
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
Add the age column to openstackcluster and openstackmachine.

As openstackclustertemplate and opensackmachinetemplate don't have any custom `printcolumn` defined, per default only name of the object and Age will be printed - so we're already fine.

Signed-off-by: Mario Constanti <mario@constanti.de>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
