### PR TITLE
🐛 Fix logger arguments

### DIFF
--- a/pkg/cloud/services/compute/instance_types.go
+++ b/pkg/cloud/services/compute/instance_types.go
@@ -157,7 +157,7 @@ func (is *InstanceStatus) NetworkStatus() (*InstanceNetworkStatus, error) {
 
 			// Only consider IPv4
 			if address.Version != 4 {
-				is.logger.V(6).Info("Ignoring IPv%d address %s: only IPv4 is supported", address.Version, address.Address)
+				is.logger.V(6).Info("Ignoring IP address: only IPv4 is supported", "version", address.Version, "address", address.Address)
 				continue
 			}
 
@@ -168,7 +168,7 @@ func (is *InstanceStatus) NetworkStatus() (*InstanceNetworkStatus, error) {
 			case "fixed":
 				addressType = corev1.NodeInternalIP
 			default:
-				is.logger.V(6).Info("Ignoring address %s with unknown type '%s'", address.Address, address.Type)
+				is.logger.V(6).Info("Ignoring address with unknown type", "address", address.Address, "type", address.Type)
 				continue
 			}
 

--- a/pkg/cloud/services/compute/instance_types_test.go
+++ b/pkg/cloud/services/compute/instance_types_test.go
@@ -277,6 +277,37 @@ func TestInstanceNetworkStatus(t *testing.T) {
 			wantFloatingIP: "10.0.0.1",
 		},
 		{
+			name: "Ignore unknown address type",
+			addresses: map[string][]networkAddress{
+				"primary": {
+					{
+						Version: 4,
+						Addr:    "192.168.0.2",
+						Type:    "not-valid",
+						MacAddr: macAddr1,
+					}, {
+						Version: 4,
+						Addr:    "192.168.0.3",
+						Type:    "unknown",
+						MacAddr: macAddr2,
+					}, {
+						Version: 4,
+						Addr:    "10.0.0.1",
+						Type:    "floating",
+						MacAddr: macAddr3,
+					}, {
+						Version: 4,
+						Addr:    "192.168.0.1",
+						Type:    "fixed",
+						MacAddr: macAddr4,
+					},
+				},
+			},
+			networkName:    "primary",
+			wantIP:         "192.168.0.1",
+			wantFloatingIP: "10.0.0.1",
+		},
+		{
 			name: "Multiple networks",
 			addresses: map[string][]networkAddress{
 				"primary": {


### PR DESCRIPTION
**What this PR does / why we need it**:

The logger does not use string formatting. Instead it is doing structured logging and expects key-value arguments, as seen [here](https://github.com/go-logr/logr#but-i-really-want-to-use-a-format-string).
This PR fixes the arguments so that they follow the expected format.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1280

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.
2. I have a sort of reproducer for the issue. It is possible to trigger the logger when running the unit tests and then see that it is complaining about the arguments. The test doesn't fail from this though as it uses a different logger.
Here is a patch for enabling the logger in the test if you want to reproduce the issue. 
[logger-patch.txt](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/files/9000823/logger-patch.txt)


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [x] adds unit tests
