### PR TITLE
🌱 only reconcile loadbalancer member if machine is control-plane

### DIFF
--- a/pkg/cloud/services/loadbalancer/loadbalancer.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer.go
@@ -352,10 +352,6 @@ func (s *Service) getOrCreateMonitor(openStackCluster *infrav1.OpenStackCluster,
 }
 
 func (s *Service) ReconcileLoadBalancerMember(openStackCluster *infrav1.OpenStackCluster, machine *clusterv1.Machine, openStackMachine *infrav1.OpenStackMachine, clusterName, ip string) error {
-	if !util.IsControlPlaneMachine(machine) {
-		return nil
-	}
-
 	if openStackCluster.Status.Network == nil {
 		return errors.New("network is not yet available in openStackCluster.Status")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

IMO we should check whether it is required (machine == control-plane) before
calling `loadbalancer.Service#ReconcileLoadBalancerMember`. The service
should not be concerned with the type of machine it is called on.

This also fixes one of the open bugs in PR #1288.

**Which issue(s) this PR fixes**:
-

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.
