### PR TITLE
🐛 openstackmachine: do not set transient error message and reason

### DIFF
--- a/api/v1alpha6/openstackmachine_types.go
+++ b/api/v1alpha6/openstackmachine_types.go
@@ -19,6 +19,7 @@ package v1alpha6
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/errors"
 )
@@ -172,6 +173,12 @@ func (r *OpenStackMachine) GetConditions() clusterv1.Conditions {
 // SetConditions sets the underlying service state of the OpenStackMachine to the predescribed clusterv1.Conditions.
 func (r *OpenStackMachine) SetConditions(conditions clusterv1.Conditions) {
 	r.Status.Conditions = conditions
+}
+
+// SetFailure sets the OpenStackMachine status failure reason and failure message.
+func (r *OpenStackMachine) SetFailure(failureReason errors.MachineStatusError, failureMessage error) {
+	r.Status.FailureReason = &failureReason
+	r.Status.FailureMessage = pointer.StringPtr(failureMessage.Error())
 }
 
 func init() {

--- a/controllers/openstackmachine_controller_test.go
+++ b/controllers/openstackmachine_controller_test.go
@@ -119,7 +119,6 @@ func Test_machineToInstanceSpec(t *testing.T) {
 		machine          func() *clusterv1.Machine
 		openStackMachine func() *infrav1.OpenStackMachine
 		wantInstanceSpec func() *compute.InstanceSpec
-		wantErr          bool
 	}{
 		{
 			name:             "Defaults",
@@ -127,7 +126,6 @@ func Test_machineToInstanceSpec(t *testing.T) {
 			machine:          getDefaultMachine,
 			openStackMachine: getDefaultOpenStackMachine,
 			wantInstanceSpec: getDefaultInstanceSpec,
-			wantErr:          false,
 		},
 		{
 			name: "Control plane security group",
@@ -149,7 +147,6 @@ func Test_machineToInstanceSpec(t *testing.T) {
 				i.SecurityGroups = []infrav1.SecurityGroupParam{{UUID: controlPlaneSecurityGroupUUID}}
 				return i
 			},
-			wantErr: false,
 		},
 		{
 			name: "Worker security group",
@@ -165,7 +162,6 @@ func Test_machineToInstanceSpec(t *testing.T) {
 				i.SecurityGroups = []infrav1.SecurityGroupParam{{UUID: workerSecurityGroupUUID}}
 				return i
 			},
-			wantErr: false,
 		},
 		{
 			name: "Extra security group",
@@ -188,7 +184,6 @@ func Test_machineToInstanceSpec(t *testing.T) {
 				}
 				return i
 			},
-			wantErr: false,
 		},
 		{
 			name: "Tags",
@@ -208,18 +203,11 @@ func Test_machineToInstanceSpec(t *testing.T) {
 				i.Tags = []string{"machine-tag", "duplicate-tag", "cluster-tag"}
 				return i
 			},
-			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := machineToInstanceSpec(tt.openStackCluster(), tt.machine(), tt.openStackMachine(), "user-data")
-			if tt.wantErr {
-				Expect(err).To(HaveOccurred())
-			} else {
-				Expect(err).NotTo(HaveOccurred())
-			}
-
+			got := machineToInstanceSpec(tt.openStackCluster(), tt.machine(), tt.openStackMachine(), "user-data")
 			Expect(got).To(Equal(tt.wantInstanceSpec()))
 		})
 	}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

With this PR we set `failureReason` & `failureMessage` of the OpenStackMachine for the following three cases:
* Instance not found
* Instance in ERROR state
  * as pointed out in https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/1116#issuecomment-1029792653, unsure if we should really stop reconciliation. However, keeping this to remain with the same behavior.
* json marshalling or unmarshalling error in the network status

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1116 

**Special notes for your reviewer**:

* Introduced separate functions for setting the `failureReason`& `failureMessage` to have a choice when setting the `failureReason` compared to just setting UpdateMachineError for everything.
* openstackcluster will pe part of a separate PR

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
<sub>Sean Schneeweiss <sean.schneeweiss@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)</sub>