### PR TITLE
🐛 Fix conformance tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module sigs.k8s.io/cluster-api-provider-openstack
 go 1.17
 
 require (
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/go-logr/logr v1.2.0
 	github.com/golang/mock v1.6.0
 	github.com/google/gofuzz v1.2.0
@@ -43,7 +44,6 @@ require (
 	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210826220005-b48c857c3a0e // indirect
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/coredns/caddy v1.1.0 // indirect
 	github.com/coredns/corefile-migration v1.0.17 // indirect

--- a/kustomize/v1alpha5/default/cluster-template.yaml
+++ b/kustomize/v1alpha5/default/cluster-template.yaml
@@ -53,7 +53,6 @@ spec:
           cloud-provider: openstack
           cloud-config: /etc/kubernetes/cloud.conf
     clusterConfiguration:
-      imageRepository: k8s.gcr.io
       apiServer:
         extraArgs:
           cloud-provider: openstack

--- a/kustomize/v1alpha6/default/cluster-template.yaml
+++ b/kustomize/v1alpha6/default/cluster-template.yaml
@@ -53,7 +53,6 @@ spec:
           cloud-provider: openstack
           cloud-config: /etc/kubernetes/cloud.conf
     clusterConfiguration:
-      imageRepository: k8s.gcr.io
       apiServer:
         extraArgs:
           cloud-provider: openstack

--- a/test/e2e/data/kubetest/conformance-fast-ginkgo-v2.yaml
+++ b/test/e2e/data/kubetest/conformance-fast-ginkgo-v2.yaml
@@ -5,4 +5,5 @@ ginkgo.progress: true
 ginkgo.slowSpecThreshold: 120.0
 ginkgo.flakeAttempts: 3
 ginkgo.trace: true
+ginkgo.timeout: 3h
 ginkgo.v: true

--- a/test/e2e/data/kubetest/conformance-ginkgo-v2.yaml
+++ b/test/e2e/data/kubetest/conformance-ginkgo-v2.yaml
@@ -1,8 +1,8 @@
 ginkgo.focus: \[Conformance\]
-ginkgo.skip: .*\[Serial\].*
 disable-log-dump: true
 ginkgo.progress: true
 ginkgo.slowSpecThreshold: 120.0
 ginkgo.flakeAttempts: 3
 ginkgo.trace: true
+ginkgo.timeout: 3h
 ginkgo.v: true

--- a/test/e2e/data/kubetest/conformance.yaml
+++ b/test/e2e/data/kubetest/conformance.yaml
@@ -4,5 +4,4 @@ ginkgo.progress: true
 ginkgo.slowSpecThreshold: 120.0
 ginkgo.flakeAttempts: 3
 ginkgo.trace: true
-ginkgo.timeout: 3h
 ginkgo.v: true

--- a/test/e2e/suites/conformance/conformance_test.go
+++ b/test/e2e/suites/conformance/conformance_test.go
@@ -24,7 +24,9 @@ import (
 	"fmt"
 	"path/filepath"
 	"strconv"
+	"strings"
 
+	"github.com/blang/semver"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -62,6 +64,15 @@ var _ = Describe("conformance tests", func() {
 			var err error
 			kubernetesVersion, err = kubernetesversions.LatestCIRelease()
 			Expect(err).NotTo(HaveOccurred())
+		}
+
+		// Starting with Kubernetes v1.25, the kubetest config file needs to be compatible with Ginkgo V2.
+		v125 := semver.MustParse("1.25.0-alpha.0.0")
+		v, err := semver.ParseTolerant(kubernetesVersion)
+		Expect(err).NotTo(HaveOccurred())
+		if v.GTE(v125) {
+			// Use the Ginkgo V2 config file.
+			e2eCtx.Settings.KubetestConfigFilePath = getGinkgoV2ConfigFilePath(e2eCtx.Settings.KubetestConfigFilePath)
 		}
 
 		workerMachineCount, err := strconv.ParseInt(e2eCtx.E2EConfig.GetVariable("CONFORMANCE_WORKER_MACHINE_COUNT"), 10, 64)
@@ -111,3 +122,7 @@ var _ = Describe("conformance tests", func() {
 		shared.DumpSpecResourcesAndCleanup(ctx, specName, namespace, e2eCtx)
 	})
 })
+
+func getGinkgoV2ConfigFilePath(kubetestConfigFilePath string) string {
+	return strings.Replace(kubetestConfigFilePath, ".yaml", "-ginkgo-v2.yaml", 1)
+}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR fixes the conformance tests.

`Jul 19 15:46:21 cluster-conformance-t93zy8-control-plane-6wnvx cloud-init[612]: [2022-07-19 15:45:45]         [ERROR ImagePull]: failed to pull image k8s.gcr.io/kube-apiserver:v1.25.0-alpha.2.398_3992eda8e61725: output: time="2022-07-19T15:45:35Z" level=fatal msg="pulling image: rpc error: code = NotFound desc = failed to pull and unpack image \"k8s.gcr.io/kube-apiserver:v1.25.0-alpha.2.398_3992eda8e61725\": failed to resolve reference \"k8s.gcr.io/kube-apiserver:v1.25.0-alpha.2.398_3992eda8e61725\": k8s.gcr.io/kube-apiserver:v1.25.0-alpha.2.398_3992eda8e61725: not found"
[...]`

xref: [cloud-final.log](https://storage.googleapis.com/kubernetes-jenkins/logs/periodic-cluster-api-provider-openstack-conformance-test-main-with-k8s-ci-artifacts/1549406378202763264/artifacts/clusters/bootstrap/instances/conformance-t93zy8/cluster-conformance-t93zy8-control-plane-6wnvx/cloud-final.log)
xref2: [Slack conversation](https://kubernetes.slack.com/archives/CFKJB65G9/p1658298925234219?thread_ts=1656576200.179469&cid=CFKJB65G9)

Further I fixed the previous PR #1297 by adapting https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2478

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold

<sub>Tobias Giese <tobias.giese@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [legal info/Impressum](https://github.com/mercedes-benz/foss/blob/master/LEGAL_IMPRINT.md)</sub>