### PR TITLE
 🌱 List resources in GCP project before creating devstack

### DIFF
--- a/hack/ci/create_devstack.sh
+++ b/hack/ci/create_devstack.sh
@@ -228,6 +228,9 @@ function main() {
         cleanup
     fi
 
+    # List all resources in this project
+    list_all_resources
+
     # Initialize the necessary infrastructure requirements
     cloud_init
     if [[ -n "${SKIP_INIT_INFRA:-}" ]]; then

--- a/hack/ci/gce-project.sh
+++ b/hack/ci/gce-project.sh
@@ -130,6 +130,14 @@ function create_vm {
   fi
 }
 
+function list_all_resources {
+  echo "Listing all resources - should be empty."
+  for resource in networks firewall-rules routers "routers nats" disks images instances; do
+    echo "  ${resource}:"
+    echo "gcloud compute $resource list --project=\"$GCP_PROJECT\""
+  done
+}
+
 function get_public_ip {
   local ip
   while ! ip=$(gcloud compute instances describe "${CLUSTER_NAME}-controller" \


### PR DESCRIPTION
Signed-off-by: Tobias Giese <tobias.giese@mercedes-benz.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR lists all GCP resource before creating the devstack.
Maybe we can identity the following issue with this change

```
The zone 'projects/k8s-jenkins-charts/zones/us-east4-a' does not have enough resources available to fulfill the request.  '(resource type:compute)'.
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold

<sub>Tobias Giese <tobias.giese@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [legal info/Impressum](https://github.com/mercedes-benz/foss/blob/master/LEGAL_IMPRINT.md)</sub>