### PR TITLE
:bug: Add security groups to ports only

### DIFF
--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -235,7 +235,6 @@ func (s *Service) createInstanceImpl(eventObject runtime.Object, openStackCluste
 		AvailabilityZone: instanceSpec.FailureDomain,
 		Networks:         portList,
 		UserData:         []byte(instanceSpec.UserData),
-		SecurityGroups:   securityGroups,
 		Tags:             instanceSpec.Tags,
 		Metadata:         instanceSpec.Metadata,
 		ConfigDrive:      &instanceSpec.ConfigDrive,

--- a/pkg/cloud/services/compute/instance_test.go
+++ b/pkg/cloud/services/compute/instance_test.go
@@ -582,9 +582,6 @@ func TestService_ReconcileInstance(t *testing.T) {
 				"imageRef":          imageUUID,
 				"flavorRef":         flavorUUID,
 				"availability_zone": failureDomain,
-				"security_groups": []map[string]interface{}{
-					{"name": workerSecurityGroupUUID},
-				},
 				"networks": []map[string]interface{}{
 					{"port": portUUID},
 				},


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR removes the used of a [deprecated API](https://docs.openstack.org/nova/latest/contributor/project-scope.html#no-more-api-proxies) by removing the setting of security groups directly on instances.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1316 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
