### PR TITLE
🌱 add merge strategy markers

### DIFF
--- a/api/v1alpha6/openstackcluster_types.go
+++ b/api/v1alpha6/openstackcluster_types.go
@@ -48,6 +48,7 @@ type OpenStackClusterSpec struct {
 	// DNSNameservers is the list of nameservers for OpenStack Subnet being created.
 	// Set this value when you need create a new network/subnet while the access
 	// through DNS is required.
+	// +listType=set
 	DNSNameservers []string `json:"dnsNameservers,omitempty"`
 	// ExternalRouterIPs is an array of externalIPs on the respective subnets.
 	// This is necessary if the router needs a fixed ip in a specific subnet.
@@ -117,6 +118,7 @@ type OpenStackClusterSpec struct {
 	DisablePortSecurity bool `json:"disablePortSecurity,omitempty"`
 
 	// Tags for all resources in cluster
+	// +listType=set
 	Tags []string `json:"tags,omitempty"`
 
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
@@ -124,6 +126,7 @@ type OpenStackClusterSpec struct {
 	ControlPlaneEndpoint clusterv1.APIEndpoint `json:"controlPlaneEndpoint"`
 
 	// ControlPlaneAvailabilityZones is the az to deploy control plane to
+	// +listType=set
 	ControlPlaneAvailabilityZones []string `json:"controlPlaneAvailabilityZones,omitempty"`
 
 	// Bastion is the OpenStack instance to login the nodes

--- a/api/v1alpha6/openstackmachine_types.go
+++ b/api/v1alpha6/openstackmachine_types.go
@@ -78,6 +78,7 @@ type OpenStackMachineSpec struct {
 
 	// Machine tags
 	// Requires Nova api 2.52 minimum!
+	// +listType=set
 	Tags []string `json:"tags,omitempty"`
 
 	// Metadata mapping. Allows you to create a map of key value pairs to add to the server instance.

--- a/api/v1alpha6/types.go
+++ b/api/v1alpha6/types.go
@@ -118,6 +118,7 @@ type PortOpts struct {
 	TenantID  string    `json:"tenantId,omitempty"`
 	ProjectID string    `json:"projectId,omitempty"`
 	// The uuids of the security groups to assign to the instance
+	// +listType=set
 	SecurityGroups *[]string `json:"securityGroups,omitempty"`
 	// The names, uuids, filters or any combination these of the security groups to assign to the instance
 	SecurityGroupFilters []SecurityGroupParam `json:"securityGroupFilters,omitempty"`
@@ -142,6 +143,7 @@ type PortOpts struct {
 
 	// Tags applied to the port (and corresponding trunk, if a trunk is configured.)
 	// These tags are applied in addition to the instance's tags, which will also be applied to the port.
+	// +listType=set
 	Tags []string `json:"tags,omitempty"`
 }
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -4593,6 +4593,7 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: set
                             tags:
                               description: Tags applied to the port (and corresponding
                                 trunk, if a trunk is configured.) These tags are applied
@@ -4601,6 +4602,7 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: set
                             tenantId:
                               type: string
                             trunk:
@@ -4692,6 +4694,7 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: set
                       trunk:
                         description: Whether the server instance is created on a trunk
                           port or not.
@@ -4709,6 +4712,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: set
               controlPlaneEndpoint:
                 description: ControlPlaneEndpoint represents the endpoint used to
                   communicate with the control plane.
@@ -4751,6 +4755,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: set
               externalNetworkId:
                 description: ExternalNetworkID is the ID of an external OpenStack
                   Network. This is necessary to get public internet to the VMs.
@@ -4898,6 +4903,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: set
             type: object
           status:
             description: OpenStackClusterStatus defines the observed state of OpenStackCluster.
@@ -5116,6 +5122,7 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: set
                             tags:
                               description: Tags applied to the port (and corresponding
                                 trunk, if a trunk is configured.) These tags are applied
@@ -5124,6 +5131,7 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: set
                             tenantId:
                               type: string
                             trunk:
@@ -5504,6 +5512,7 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: set
                       tags:
                         description: Tags applied to the port (and corresponding trunk,
                           if a trunk is configured.) These tags are applied in addition
@@ -5512,6 +5521,7 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: set
                       tenantId:
                         type: string
                       trunk:
@@ -5806,6 +5816,7 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: set
                       tags:
                         description: Tags applied to the port (and corresponding trunk,
                           if a trunk is configured.) These tags are applied in addition
@@ -5814,6 +5825,7 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: set
                       tenantId:
                         type: string
                       trunk:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
@@ -1827,6 +1827,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: set
                                     tags:
                                       description: Tags applied to the port (and corresponding
                                         trunk, if a trunk is configured.) These tags
@@ -1835,6 +1836,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: set
                                     tenantId:
                                       type: string
                                     trunk:
@@ -1929,6 +1931,7 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: set
                               trunk:
                                 description: Whether the server instance is created
                                   on a trunk port or not.
@@ -1947,6 +1950,7 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: set
                       controlPlaneEndpoint:
                         description: ControlPlaneEndpoint represents the endpoint
                           used to communicate with the control plane.
@@ -1992,6 +1996,7 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: set
                       externalNetworkId:
                         description: ExternalNetworkID is the ID of an external OpenStack
                           Network. This is necessary to get public internet to the
@@ -2143,6 +2148,7 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: set
                     type: object
                 required:
                 - spec

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
@@ -1729,6 +1729,7 @@ spec:
                       items:
                         type: string
                       type: array
+                      x-kubernetes-list-type: set
                     tags:
                       description: Tags applied to the port (and corresponding trunk,
                         if a trunk is configured.) These tags are applied in addition
@@ -1737,6 +1738,7 @@ spec:
                       items:
                         type: string
                       type: array
+                      x-kubernetes-list-type: set
                     tenantId:
                       type: string
                     trunk:
@@ -1826,6 +1828,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: set
               trunk:
                 description: Whether the server instance is created on a trunk port
                   or not.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
@@ -1439,6 +1439,7 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: set
                             tags:
                               description: Tags applied to the port (and corresponding
                                 trunk, if a trunk is configured.) These tags are applied
@@ -1447,6 +1448,7 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: set
                             tenantId:
                               type: string
                             trunk:
@@ -1538,6 +1540,7 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: set
                       trunk:
                         description: Whether the server instance is created on a trunk
                           port or not.


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit adds merge strategy markers to our v1alpha6 API. This is required for Server-Side Apply (SSA) to work correctly. SSA is used in Cluster API v1.2, and not having these markers might cause issues when using ClusterClass patches.

This only adds a subset of markers, where it was possible. I skipped adding markers for two cases:

- We have many slices that do not have any proper map keys, as all fields are optional. This includes mostly "filter" structs, for example `NetworkParam` and `SecurityGroupParam`.
- The selected map key may not be optional (`omitempty`). If it is, it can not be used as the map key. This applied to structs `AddressPair` and `ExternalRouterIPParam`.

Further documentation:

- CAPI v1.2 provider migration: https://cluster-api.sigs.k8s.io/developer/providers/v1.1-to-v1.2.html#required-api-changes-for-providers
- SSA Markers: https://kubernetes.io/docs/reference/using-api/server-side-apply/#merge-strategy


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #1282

**Special notes for your reviewer**:

/hold
