### PR TITLE
update devstack release

### DIFF
--- a/hack/ci/cloud-init/controller.yaml.tpl
+++ b/hack/ci/cloud-init/controller.yaml.tpl
@@ -79,6 +79,10 @@
     [[post-config|/$NEUTRON_CORE_PLUGIN_CONF]]
     [ml2]
     path_mtu = ${MTU}
+
+    [[post-config|$NEUTRON_CONF]]
+    [DEFAULT]
+    service_plugins = ovn-router,trunk, router
 - path: /tmp/register-worker.sh
   permissions: 0755
   content: |

--- a/hack/ci/create_devstack.sh
+++ b/hack/ci/create_devstack.sh
@@ -30,7 +30,7 @@ source "${scriptdir}/${RESOURCE_TYPE}.sh"
 
 CLUSTER_NAME=${CLUSTER_NAME:-"capo-e2e"}
 
-OPENSTACK_RELEASE=${OPENSTACK_RELEASE:-"xena"}
+OPENSTACK_RELEASE=${OPENSTACK_RELEASE:-"yoga"}
 OPENSTACK_ENABLE_HORIZON=${OPENSTACK_ENABLE_HORIZON:-"false"}
 
 # Devstack will create a provider network using this range


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

upgrade devstack to Yoga

NOTE:
I suspect this commit change the neutron plugin behavior of devstack so the service plugin trunk is not enabled by default (which leaves e2e fail) ,so I updated the conf file directly to include trunk plugin
```
commit f758b60a4b70261393242b932063d2b6d705594c
Author: Slawek Kaplonski <skaplons@redhat.com>
Date:   Wed Oct 6 12:02:22 2021 +0200

    Rehome functions to enable Neutron's Trunk service plugin

    Those functions were part of the neutron devstack plugin but we
    discussed on the neutron team meeting [1] to move it to the Devstack
    repo as it's mature enough now.

    [1] https://meetings.opendev.org/meetings/networking/2021/networking.2021-10-05-14.00.log.html#l-156

    Change-Id: I35446adad1d8a7fed142d834de20c48b611015a5

```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
