### PR TITLE
🐛 fix nilpointer during clusterctl move

### DIFF
--- a/pkg/cloud/services/loadbalancer/loadbalancer.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer.go
@@ -134,10 +134,13 @@ func (s *Service) ReconcileLoadBalancer(openStackCluster *infrav1.OpenStackClust
 		}
 
 		if allowedCIDRsSupported {
-			if err := s.getOrUpdateAllowedCIDRS(openStackCluster, listener); err != nil {
-				return err
+			// Skip reconciliation if network status is nil (e.g. during clusterctl move)
+			if openStackCluster.Status.Network != nil {
+				if err := s.getOrUpdateAllowedCIDRS(openStackCluster, listener); err != nil {
+					return err
+				}
+				allowedCIDRs = listener.AllowedCIDRs
 			}
-			allowedCIDRs = listener.AllowedCIDRs
 		}
 	}
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

If .status.network is empty (e.g. during clusterctl move) the reconciliation will fail due a nil pointer.

This commit skips the first reconciliation of
openStackCluster.Spec.APIServerLoadBalancer.AllowedCIDRs after a clusterctl move.

Signed-off-by: Mario Constanti <mario@constanti.de>


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1339

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
