### PR TITLE
🌱 Group Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ROOT_DIR_RELATIVE := .
 include $(ROOT_DIR_RELATIVE)/common.mk
 
 # If you update this file, please follow
-# https://suva.sh/posts/well-documented-makefiles
+# https://www.thapaliya.com/en/writings/well-documented-makefiles/
 
 # Active module mode, as we use go modules to manage dependencies
 export GO111MODULE=on
@@ -116,7 +116,7 @@ LDFLAGS := $(shell source ./hack/version.sh; version::ldflags)
 
 
 ## --------------------------------------
-## Testing
+##@ Testing
 ## --------------------------------------
 
 # The number of ginkgo tests to run concurrently
@@ -190,7 +190,7 @@ test-conformance-fast: ## Run clusterctl based conformance test on workload clus
 
 
 ## --------------------------------------
-## Binaries
+##@ Binaries
 ## --------------------------------------
 
 .PHONY: binaries
@@ -211,7 +211,7 @@ $(SETUP_ENVTEST): # Build setup-envtest from tools folder.
 	$(SETUP_ENVTEST_BIN): $(SETUP_ENVTEST) ## Build a local copy of setup-envtest.
 
 ## --------------------------------------
-## Linting
+##@ Linting
 ## --------------------------------------
 
 .PHONY: lint
@@ -226,7 +226,7 @@ lint-fast: $(GOLANGCI_LINT) ## Run only faster linters to detect possible issues
 	$(GOLANGCI_LINT) run -v --fast=true
 
 ## --------------------------------------
-## Generate
+##@ Generate
 ## --------------------------------------
 
 .PHONY: modules
@@ -268,7 +268,7 @@ generate-manifests: $(CONTROLLER_GEN) ## Generate manifests e.g. CRD, RBAC etc.
 		rbac:roleName=manager-role
 
 ## --------------------------------------
-## Docker
+##@ Docker
 ## --------------------------------------
 
 .PHONY: docker-build
@@ -286,7 +286,7 @@ docker-pull-prerequisites:
 	docker pull gcr.io/distroless/static:latest
 
 ## --------------------------------------
-## Docker — All ARCH
+##@ Docker — All ARCH
 ## --------------------------------------
 
 .PHONY: docker-build-all ## Build all the architecture docker images
@@ -314,7 +314,7 @@ staging-manifests:
 	$(MAKE) $(RELEASE_DIR)/$(MANIFEST_FILE).yaml PULL_POLICY=IfNotPresent TAG=$(RELEASE_ALIAS_TAG)
 
 ## --------------------------------------
-## Release
+##@ Release
 ## --------------------------------------
 
 $(RELEASE_DIR):
@@ -454,7 +454,7 @@ image-patch-pull-policy: $(IMAGE_PATCH_DIR) $(GOJQ)
 
 
 ## --------------------------------------
-## Cleanup / Verification
+##@ Cleanup / Verification
 ## --------------------------------------
 
 .PHONY: clean

--- a/common.mk
+++ b/common.mk
@@ -49,7 +49,7 @@ $(TOOLS_BIN_DIR)/%: $(TOOLS_DIR_DEPS)
 	make -C $(TOOLS_DIR) $(subst $(TOOLS_DIR)/,,$@)
 
 ## --------------------------------------
-## Help
+##@ Help
 ## --------------------------------------
 
 help:  ## Display this help


### PR DESCRIPTION
**What this PR does / why we need it**:

* Fixes link to Makefile best practice page
* Groups the Makefile targets based on existing comments

With this pr the `make` output is: 
```
Usage:
  make <target>

Testing
  test             Run tests
  e2e-templates    Generate cluster templates for e2e tests
  e2e-prerequisites  Build all artifacts required by e2e tests
  test-e2e         Run e2e tests
  test-conformance  Run clusterctl based conformance test on workload cluster (requires Docker).
  test-conformance-fast  Run clusterctl based conformance test on workload cluster (requires Docker) using a subset of the conformance suite in parallel.

Binaries
  binaries         Builds and installs all binaries
  manager-openstack-infrastructure  Build manager binary.

Linting
  lint             Lint codebase
  lint-update      Lint codebase
  lint-fast        Run only faster linters to detect possible issues

Generate
  modules          Runs go mod to ensure proper vendoring.
  generate         Generate code
  generate-manifests  Generate manifests e.g. CRD, RBAC etc.

Docker
  docker-build     Build the docker image for controller-manager
  docker-push      Push the docker image

Docker — All ARCH
  docker-push-manifest  Push the fat manifest docker image.

Release
  list-staging-releases  List staging images for image promotion
  release          Builds and push container images using the latest git tag for the commit.
  release-staging  Builds and push container images and manifests to the staging bucket.
  release-staging-nightly  Tags and push container images to the staging bucket. Example image tag: capi-openstack-controller:nightly_master_20210121
  upload-staging-artifacts  Upload release artifacts to the staging bucket
  create-gh-release  Create release on Github
  upload-gh-artifacts  Upload artifacts to Github release
  release-notes    Generate release notes
  templates        Generate cluster templates
  release-templates  Generate release templates

Cleanup / Verification
  clean            Remove all generated files
  clean-bin        Remove all generated binaries
  clean-temporary  Remove all temporary files and folders
  clean-release    Remove the release folder
  compile-e2e      Test e2e compilation

Help
  help             Display this help
```

Current output 
```
Usage:
  make <target>
  test             Run tests
  e2e-templates    Generate cluster templates for e2e tests
  e2e-prerequisites  Build all artifacts required by e2e tests
  test-e2e         Run e2e tests
  test-conformance  Run clusterctl based conformance test on workload cluster (requires Docker).
  test-conformance-fast  Run clusterctl based conformance test on workload cluster (requires Docker) using a subset of the conformance suite in parallel.
  binaries         Builds and installs all binaries
  manager-openstack-infrastructure  Build manager binary.
  lint             Lint codebase
  lint-update      Lint codebase
  lint-fast        Run only faster linters to detect possible issues
  modules          Runs go mod to ensure proper vendoring.
  generate         Generate code
  generate-manifests  Generate manifests e.g. CRD, RBAC etc.
  docker-build     Build the docker image for controller-manager
  docker-push      Push the docker image
  docker-push-manifest  Push the fat manifest docker image.
  list-staging-releases  List staging images for image promotion
  release          Builds and push container images using the latest git tag for the commit.
  release-staging  Builds and push container images and manifests to the staging bucket.
  release-staging-nightly  Tags and push container images to the staging bucket. Example image tag: capi-openstack-controller:nightly_master_20210121
  upload-staging-artifacts  Upload release artifacts to the staging bucket
  create-gh-release  Create release on Github
  upload-gh-artifacts  Upload artifacts to Github release
  release-notes    Generate release notes
  templates        Generate cluster templates
  release-templates  Generate release templates
  clean            Remove all generated files
  clean-bin        Remove all generated binaries
  clean-temporary  Remove all temporary files and folders
  clean-release    Remove the release folder
  compile-e2e      Test e2e compilation
  help             Display this help
```

/hold
