### PR TITLE
🌱 Remove unnecessary mock import aliases

### DIFF
--- a/pkg/cloud/services/compute/instance_test.go
+++ b/pkg/cloud/services/compute/instance_test.go
@@ -45,7 +45,7 @@ import (
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha6"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients"
-	mock_clients "sigs.k8s.io/cluster-api-provider-openstack/pkg/clients/mock"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients/mock"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/networking"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
 )
@@ -183,7 +183,7 @@ func TestService_getServerNetworks(t *testing.T) {
 		name          string
 		networkParams []infrav1.NetworkParam
 		want          []infrav1.Network
-		expect        func(m *mock_clients.MockNetworkClientMockRecorder)
+		expect        func(m *mock.MockNetworkClientMockRecorder)
 		wantErr       bool
 	}{
 		{
@@ -194,7 +194,7 @@ func TestService_getServerNetworks(t *testing.T) {
 			want: []infrav1.Network{
 				{ID: networkAUUID, Subnet: &infrav1.Subnet{}},
 			},
-			expect: func(m *mock_clients.MockNetworkClientMockRecorder) {
+			expect: func(m *mock.MockNetworkClientMockRecorder) {
 			},
 			wantErr: false,
 		},
@@ -207,7 +207,7 @@ func TestService_getServerNetworks(t *testing.T) {
 				{ID: networkAUUID, Subnet: &infrav1.Subnet{}},
 				{ID: networkBUUID, Subnet: &infrav1.Subnet{}},
 			},
-			expect: func(m *mock_clients.MockNetworkClientMockRecorder) {
+			expect: func(m *mock.MockNetworkClientMockRecorder) {
 				// List tagged networks (A & B)
 				m.ListNetwork(&testNetworkListOpts).
 					Return([]networks.Network{testNetworkA, testNetworkB}, nil)
@@ -226,7 +226,7 @@ func TestService_getServerNetworks(t *testing.T) {
 				{ID: networkAUUID, Subnet: &infrav1.Subnet{ID: subnetA2UUID}},
 				{ID: networkBUUID, Subnet: &infrav1.Subnet{ID: subnetB1UUID}},
 			},
-			expect: func(m *mock_clients.MockNetworkClientMockRecorder) {
+			expect: func(m *mock.MockNetworkClientMockRecorder) {
 				// List all tagged subnets in any network (A1, A2, and B1)
 				m.ListSubnet(&testSubnetListOpts).
 					Return([]subnets.Subnet{testSubnetA1, testSubnetA2, testSubnetB1}, nil)
@@ -247,7 +247,7 @@ func TestService_getServerNetworks(t *testing.T) {
 				{ID: networkAUUID, Subnet: &infrav1.Subnet{ID: subnetA1UUID}},
 				{ID: networkAUUID, Subnet: &infrav1.Subnet{ID: subnetA2UUID}},
 			},
-			expect: func(m *mock_clients.MockNetworkClientMockRecorder) {
+			expect: func(m *mock.MockNetworkClientMockRecorder) {
 				// List tagged subnets in network A (A1 & A2)
 				networkAFilter := testSubnetListOpts
 				networkAFilter.NetworkID = networkAUUID
@@ -269,7 +269,7 @@ func TestService_getServerNetworks(t *testing.T) {
 			want: []infrav1.Network{
 				{ID: networkAUUID, Subnet: &infrav1.Subnet{ID: subnetA1UUID}},
 			},
-			expect: func(m *mock_clients.MockNetworkClientMockRecorder) {
+			expect: func(m *mock.MockNetworkClientMockRecorder) {
 			},
 			wantErr: false,
 		},
@@ -289,7 +289,7 @@ func TestService_getServerNetworks(t *testing.T) {
 				{ID: networkAUUID, Subnet: &infrav1.Subnet{ID: subnetA1UUID}},
 				{ID: networkAUUID, Subnet: &infrav1.Subnet{ID: subnetA2UUID}},
 			},
-			expect: func(m *mock_clients.MockNetworkClientMockRecorder) {
+			expect: func(m *mock.MockNetworkClientMockRecorder) {
 				// List tagged subnets in network A
 				networkAFilter := testSubnetListOpts
 				networkAFilter.NetworkID = networkAUUID
@@ -320,7 +320,7 @@ func TestService_getServerNetworks(t *testing.T) {
 				{ID: networkAUUID, Subnet: &infrav1.Subnet{ID: subnetA2UUID}},
 				{ID: networkBUUID, Subnet: &infrav1.Subnet{ID: subnetB1UUID}},
 			},
-			expect: func(m *mock_clients.MockNetworkClientMockRecorder) {
+			expect: func(m *mock.MockNetworkClientMockRecorder) {
 				// List tagged networks (A & B)
 				m.ListNetwork(&testNetworkListOpts).
 					Return([]networks.Network{testNetworkA, testNetworkB}, nil)
@@ -346,7 +346,7 @@ func TestService_getServerNetworks(t *testing.T) {
 				{Filter: testNetworkFilter},
 			},
 			want: nil,
-			expect: func(m *mock_clients.MockNetworkClientMockRecorder) {
+			expect: func(m *mock.MockNetworkClientMockRecorder) {
 				// List tagged networks (none for this test)
 				m.ListNetwork(&testNetworkListOpts).Return([]networks.Network{}, nil)
 			},
@@ -364,7 +364,7 @@ func TestService_getServerNetworks(t *testing.T) {
 				},
 			},
 			want: nil,
-			expect: func(m *mock_clients.MockNetworkClientMockRecorder) {
+			expect: func(m *mock.MockNetworkClientMockRecorder) {
 				// List tagged subnets in network A
 				networkAFilter := testSubnetListOpts
 				networkAFilter.NetworkID = networkAUUID
@@ -380,7 +380,7 @@ func TestService_getServerNetworks(t *testing.T) {
 				}},
 			},
 			want: nil,
-			expect: func(m *mock_clients.MockNetworkClientMockRecorder) {
+			expect: func(m *mock.MockNetworkClientMockRecorder) {
 			},
 			wantErr: true,
 		},
@@ -389,7 +389,7 @@ func TestService_getServerNetworks(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			mockNetworkClient := mock_clients.NewMockNetworkClient(mockCtrl)
+			mockNetworkClient := mock.NewMockNetworkClient(mockCtrl)
 			tt.expect(mockNetworkClient.EXPECT())
 
 			networkingService := networking.NewTestService(
@@ -420,7 +420,7 @@ func TestService_getImageID(t *testing.T) {
 		testName  string
 		imageUUID string
 		imageName string
-		expect    func(m *mock_clients.MockImageClientMockRecorder)
+		expect    func(m *mock.MockImageClientMockRecorder)
 		want      string
 		wantErr   bool
 	}{
@@ -428,7 +428,7 @@ func TestService_getImageID(t *testing.T) {
 			testName:  "Return image uuid if uuid given",
 			imageUUID: imageIDC,
 			want:      imageIDC,
-			expect: func(m *mock_clients.MockImageClientMockRecorder) {
+			expect: func(m *mock.MockImageClientMockRecorder) {
 			},
 			wantErr: false,
 		},
@@ -436,7 +436,7 @@ func TestService_getImageID(t *testing.T) {
 			testName:  "Return through uuid if both uuid and name given",
 			imageName: "dummy",
 			imageUUID: imageIDC,
-			expect: func(m *mock_clients.MockImageClientMockRecorder) {
+			expect: func(m *mock.MockImageClientMockRecorder) {
 			},
 			want:    imageIDC,
 			wantErr: false,
@@ -444,7 +444,7 @@ func TestService_getImageID(t *testing.T) {
 		{
 			testName:  "Return image ID",
 			imageName: "test-image",
-			expect: func(m *mock_clients.MockImageClientMockRecorder) {
+			expect: func(m *mock.MockImageClientMockRecorder) {
 				m.ListImages(images.ListOpts{Name: "test-image"}).Return(
 					[]images.Image{{ID: imageIDA, Name: "test-image"}},
 					nil)
@@ -455,7 +455,7 @@ func TestService_getImageID(t *testing.T) {
 		{
 			testName:  "Return no results",
 			imageName: "test-image",
-			expect: func(m *mock_clients.MockImageClientMockRecorder) {
+			expect: func(m *mock.MockImageClientMockRecorder) {
 				m.ListImages(images.ListOpts{Name: "test-image"}).Return(
 					[]images.Image{},
 					nil)
@@ -466,7 +466,7 @@ func TestService_getImageID(t *testing.T) {
 		{
 			testName:  "Return multiple results",
 			imageName: "test-image",
-			expect: func(m *mock_clients.MockImageClientMockRecorder) {
+			expect: func(m *mock.MockImageClientMockRecorder) {
 				m.ListImages(images.ListOpts{Name: "test-image"}).Return(
 					[]images.Image{
 						{ID: imageIDA, Name: "test-image"},
@@ -479,7 +479,7 @@ func TestService_getImageID(t *testing.T) {
 		{
 			testName:  "OpenStack returns error",
 			imageName: "test-image",
-			expect: func(m *mock_clients.MockImageClientMockRecorder) {
+			expect: func(m *mock.MockImageClientMockRecorder) {
 				m.ListImages(images.ListOpts{Name: "test-image"}).Return(
 					nil,
 					fmt.Errorf("test error"))
@@ -491,7 +491,7 @@ func TestService_getImageID(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			mockImageClient := mock_clients.NewMockImageClient(mockCtrl)
+			mockImageClient := mock.NewMockImageClient(mockCtrl)
 			tt.expect(mockImageClient.EXPECT())
 
 			s := Service{
@@ -613,7 +613,7 @@ func TestService_ReconcileInstance(t *testing.T) {
 	}
 
 	// Expected calls to create a server with a single default port
-	expectUseExistingDefaultPort := func(networkRecorder *mock_clients.MockNetworkClientMockRecorder) {
+	expectUseExistingDefaultPort := func(networkRecorder *mock.MockNetworkClientMockRecorder) {
 		// Returning a pre-existing port requires fewer mocks
 		networkRecorder.ListPort(ports.ListOpts{
 			Name:      portName,
@@ -626,7 +626,7 @@ func TestService_ReconcileInstance(t *testing.T) {
 		}, nil)
 	}
 
-	expectCreatePort := func(networkRecorder *mock_clients.MockNetworkClientMockRecorder, name string, networkID string) {
+	expectCreatePort := func(networkRecorder *mock.MockNetworkClientMockRecorder, name string, networkID string) {
 		networkRecorder.ListPort(ports.ListOpts{
 			Name:      name,
 			NetworkID: networkID,
@@ -655,19 +655,19 @@ func TestService_ReconcileInstance(t *testing.T) {
 	}
 
 	// Expected calls if we delete the network port
-	expectCleanupDefaultPort := func(networkRecorder *mock_clients.MockNetworkClientMockRecorder) {
+	expectCleanupDefaultPort := func(networkRecorder *mock.MockNetworkClientMockRecorder) {
 		networkRecorder.ListExtensions()
 		networkRecorder.DeletePort(portUUID).Return(nil)
 	}
 
 	// Expected calls when using default image and flavor
-	expectDefaultImageAndFlavor := func(computeRecorder *mock_clients.MockComputeClientMockRecorder, imageRecorder *mock_clients.MockImageClientMockRecorder) {
+	expectDefaultImageAndFlavor := func(computeRecorder *mock.MockComputeClientMockRecorder, imageRecorder *mock.MockImageClientMockRecorder) {
 		imageRecorder.ListImages(images.ListOpts{Name: imageName}).Return([]images.Image{{ID: imageUUID}}, nil)
 		computeRecorder.GetFlavorIDFromName(flavorName).Return(flavorUUID, nil)
 	}
 
 	// Expected calls and custom match function for creating a server
-	expectCreateServer := func(computeRecorder *mock_clients.MockComputeClientMockRecorder, expectedCreateOpts map[string]interface{}, wantError bool) {
+	expectCreateServer := func(computeRecorder *mock.MockComputeClientMockRecorder, expectedCreateOpts map[string]interface{}, wantError bool) {
 		// This nonsense is because ConfigDrive is a bool pointer, so we
 		// can't assert its exact contents with gomock.
 		// Instead we call ToServerCreateMap() on it to obtain a
@@ -688,13 +688,13 @@ func TestService_ReconcileInstance(t *testing.T) {
 	}
 
 	// Expected calls when polling for server creation
-	expectServerPoll := func(computeRecorder *mock_clients.MockComputeClientMockRecorder, states []string) {
+	expectServerPoll := func(computeRecorder *mock.MockComputeClientMockRecorder, states []string) {
 		for _, state := range states {
 			computeRecorder.GetServer(instanceUUID).Return(returnedServer(state), nil)
 		}
 	}
 
-	expectServerPollSuccess := func(computeRecorder *mock_clients.MockComputeClientMockRecorder) {
+	expectServerPollSuccess := func(computeRecorder *mock.MockComputeClientMockRecorder) {
 		expectServerPoll(computeRecorder, []string{"ACTIVE"})
 	}
 
@@ -706,13 +706,13 @@ func TestService_ReconcileInstance(t *testing.T) {
 	}
 
 	// Expected calls when polling for server creation
-	expectVolumePoll := func(volumeRecorder *mock_clients.MockVolumeClientMockRecorder, states []string) {
+	expectVolumePoll := func(volumeRecorder *mock.MockVolumeClientMockRecorder, states []string) {
 		for _, state := range states {
 			volumeRecorder.GetVolume(volumeUUID).Return(returnedVolume(state), nil)
 		}
 	}
 
-	expectVolumePollSuccess := func(volumeRecorder *mock_clients.MockVolumeClientMockRecorder) {
+	expectVolumePollSuccess := func(volumeRecorder *mock.MockVolumeClientMockRecorder) {
 		expectVolumePoll(volumeRecorder, []string{"available"})
 	}
 
@@ -721,10 +721,10 @@ func TestService_ReconcileInstance(t *testing.T) {
 	// *******************
 
 	type recorders struct {
-		compute *mock_clients.MockComputeClientMockRecorder
-		image   *mock_clients.MockImageClientMockRecorder
-		network *mock_clients.MockNetworkClientMockRecorder
-		volume  *mock_clients.MockVolumeClientMockRecorder
+		compute *mock.MockComputeClientMockRecorder
+		image   *mock.MockImageClientMockRecorder
+		network *mock.MockNetworkClientMockRecorder
+		volume  *mock.MockVolumeClientMockRecorder
 	}
 
 	tests := []struct {
@@ -991,10 +991,10 @@ func TestService_ReconcileInstance(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			mockComputeClient := mock_clients.NewMockComputeClient(mockCtrl)
-			mockImageClient := mock_clients.NewMockImageClient(mockCtrl)
-			mockNetworkClient := mock_clients.NewMockNetworkClient(mockCtrl)
-			mockVolumeClient := mock_clients.NewMockVolumeClient(mockCtrl)
+			mockComputeClient := mock.NewMockComputeClient(mockCtrl)
+			mockImageClient := mock.NewMockImageClient(mockCtrl)
+			mockNetworkClient := mock.NewMockNetworkClient(mockCtrl)
+			mockVolumeClient := mock.NewMockVolumeClient(mockCtrl)
 
 			computeRecorder := mockComputeClient.EXPECT()
 			imageRecorder := mockImageClient.EXPECT()
@@ -1043,9 +1043,9 @@ func TestService_DeleteInstance(t *testing.T) {
 	// *******************
 
 	type recorders struct {
-		compute *mock_clients.MockComputeClientMockRecorder
-		network *mock_clients.MockNetworkClientMockRecorder
-		volume  *mock_clients.MockVolumeClientMockRecorder
+		compute *mock.MockComputeClientMockRecorder
+		network *mock.MockNetworkClientMockRecorder
+		volume  *mock.MockVolumeClientMockRecorder
 	}
 
 	tests := []struct {
@@ -1109,9 +1109,9 @@ func TestService_DeleteInstance(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			mockComputeClient := mock_clients.NewMockComputeClient(mockCtrl)
-			mockNetworkClient := mock_clients.NewMockNetworkClient(mockCtrl)
-			mockVolumeClient := mock_clients.NewMockVolumeClient(mockCtrl)
+			mockComputeClient := mock.NewMockComputeClient(mockCtrl)
+			mockNetworkClient := mock.NewMockNetworkClient(mockCtrl)
+			mockVolumeClient := mock.NewMockVolumeClient(mockCtrl)
 
 			computeRecorder := mockComputeClient.EXPECT()
 			networkRecorder := mockNetworkClient.EXPECT()

--- a/pkg/cloud/services/loadbalancer/loadbalancer_test.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer_test.go
@@ -30,7 +30,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha6"
-	mock_clients "sigs.k8s.io/cluster-api-provider-openstack/pkg/clients/mock"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients/mock"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/networking"
 )
 
@@ -55,27 +55,27 @@ func Test_ReconcileLoadBalancer(t *testing.T) {
 	}
 	type serviceFields struct {
 		projectID          string
-		networkingClient   *mock_clients.MockNetworkClient
-		loadbalancerClient *mock_clients.MockLbClient
+		networkingClient   *mock.MockNetworkClient
+		loadbalancerClient *mock.MockLbClient
 	}
 	lbtests := []struct {
 		name               string
 		fields             serviceFields
 		prepareServiceMock func(sf *serviceFields)
-		expectNetwork      func(m *mock_clients.MockNetworkClientMockRecorder)
-		expectLoadBalancer func(m *mock_clients.MockLbClientMockRecorder)
+		expectNetwork      func(m *mock.MockNetworkClientMockRecorder)
+		expectLoadBalancer func(m *mock.MockLbClientMockRecorder)
 		wantError          error
 	}{
 		{
 			name: "reconcile loadbalancer in non active state should wait for active state",
 			prepareServiceMock: func(sf *serviceFields) {
-				sf.networkingClient = mock_clients.NewMockNetworkClient(mockCtrl)
-				sf.loadbalancerClient = mock_clients.NewMockLbClient(mockCtrl)
+				sf.networkingClient = mock.NewMockNetworkClient(mockCtrl)
+				sf.loadbalancerClient = mock.NewMockLbClient(mockCtrl)
 			},
-			expectNetwork: func(m *mock_clients.MockNetworkClientMockRecorder) {
+			expectNetwork: func(m *mock.MockNetworkClientMockRecorder) {
 				// add network api call results here
 			},
-			expectLoadBalancer: func(m *mock_clients.MockLbClientMockRecorder) {
+			expectLoadBalancer: func(m *mock.MockLbClientMockRecorder) {
 				// return loadbalancer providers
 				providers := []providers.Provider{
 					{Name: "amphora", Description: "The Octavia Amphora driver."},

--- a/pkg/cloud/services/networking/floatingip_test.go
+++ b/pkg/cloud/services/networking/floatingip_test.go
@@ -24,7 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha6"
-	mock_clients "sigs.k8s.io/cluster-api-provider-openstack/pkg/clients/mock"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients/mock"
 )
 
 func Test_GetOrCreateFloatingIP(t *testing.T) {
@@ -34,13 +34,13 @@ func Test_GetOrCreateFloatingIP(t *testing.T) {
 	tests := []struct {
 		name   string
 		ip     string
-		expect func(m *mock_clients.MockNetworkClientMockRecorder)
+		expect func(m *mock.MockNetworkClientMockRecorder)
 		want   *floatingips.FloatingIP
 	}{
 		{
 			name: "creates floating IP when one doesn't already exist",
 			ip:   "192.168.111.0",
-			expect: func(m *mock_clients.MockNetworkClientMockRecorder) {
+			expect: func(m *mock.MockNetworkClientMockRecorder) {
 				m.
 					ListFloatingIP(floatingips.ListOpts{FloatingIP: "192.168.111.0"}).
 					Return([]floatingips.FloatingIP{}, nil)
@@ -56,7 +56,7 @@ func Test_GetOrCreateFloatingIP(t *testing.T) {
 		{
 			name: "finds existing floating IP where one exists",
 			ip:   "192.168.111.0",
-			expect: func(m *mock_clients.MockNetworkClientMockRecorder) {
+			expect: func(m *mock.MockNetworkClientMockRecorder) {
 				m.
 					ListFloatingIP(floatingips.ListOpts{FloatingIP: "192.168.111.0"}).
 					Return([]floatingips.FloatingIP{{FloatingIP: "192.168.111.0"}}, nil)
@@ -72,7 +72,7 @@ func Test_GetOrCreateFloatingIP(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			mockClient := mock_clients.NewMockNetworkClient(mockCtrl)
+			mockClient := mock.NewMockNetworkClient(mockCtrl)
 			tt.expect(mockClient.EXPECT())
 			s := Service{
 				client: mockClient,

--- a/pkg/cloud/services/networking/port_test.go
+++ b/pkg/cloud/services/networking/port_test.go
@@ -29,7 +29,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha6"
-	mock_clients "sigs.k8s.io/cluster-api-provider-openstack/pkg/clients/mock"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients/mock"
 )
 
 func Test_GetOrCreatePort(t *testing.T) {
@@ -60,7 +60,7 @@ func Test_GetOrCreatePort(t *testing.T) {
 		net                    infrav1.Network
 		instanceSecurityGroups *[]string
 		tags                   []string
-		expect                 func(m *mock_clients.MockNetworkClientMockRecorder)
+		expect                 func(m *mock.MockNetworkClientMockRecorder)
 		// Note the 'wanted' port isn't so important, since it will be whatever we tell ListPort or CreatePort to return.
 		// Mostly in this test suite, we're checking that ListPort/CreatePort is called with the expected port opts.
 		want    *ports.Port
@@ -75,7 +75,7 @@ func Test_GetOrCreatePort(t *testing.T) {
 			},
 			nil,
 			[]string{},
-			func(m *mock_clients.MockNetworkClientMockRecorder) {
+			func(m *mock.MockNetworkClientMockRecorder) {
 				m.
 					ListPort(ports.ListOpts{
 						Name:      "foo-port-1",
@@ -98,7 +98,7 @@ func Test_GetOrCreatePort(t *testing.T) {
 			},
 			nil,
 			[]string{},
-			func(m *mock_clients.MockNetworkClientMockRecorder) {
+			func(m *mock.MockNetworkClientMockRecorder) {
 				m.
 					ListPort(ports.ListOpts{
 						Name:      "foo-port-1",
@@ -128,7 +128,7 @@ func Test_GetOrCreatePort(t *testing.T) {
 			},
 			&instanceSecurityGroups,
 			[]string{},
-			func(m *mock_clients.MockNetworkClientMockRecorder) {
+			func(m *mock.MockNetworkClientMockRecorder) {
 				// No ports found
 				m.
 					ListPort(ports.ListOpts{
@@ -182,7 +182,7 @@ func Test_GetOrCreatePort(t *testing.T) {
 			},
 			nil,
 			nil,
-			func(m *mock_clients.MockNetworkClientMockRecorder) {
+			func(m *mock.MockNetworkClientMockRecorder) {
 				portCreateOpts := ports.CreateOpts{
 					NetworkID:    netID,
 					Name:         "foo-port-bar",
@@ -264,7 +264,7 @@ func Test_GetOrCreatePort(t *testing.T) {
 			},
 			nil,
 			nil,
-			func(m *mock_clients.MockNetworkClientMockRecorder) {
+			func(m *mock.MockNetworkClientMockRecorder) {
 				m.
 					ListPort(ports.ListOpts{
 						Name:      "foo-port-bar",
@@ -301,7 +301,7 @@ func Test_GetOrCreatePort(t *testing.T) {
 			},
 			&instanceSecurityGroups,
 			[]string{},
-			func(m *mock_clients.MockNetworkClientMockRecorder) {
+			func(m *mock.MockNetworkClientMockRecorder) {
 				// No ports found
 				m.
 					ListPort(ports.ListOpts{
@@ -332,7 +332,7 @@ func Test_GetOrCreatePort(t *testing.T) {
 			},
 			nil,
 			[]string{"my-instance-tag"},
-			func(m *mock_clients.MockNetworkClientMockRecorder) {
+			func(m *mock.MockNetworkClientMockRecorder) {
 				// No ports found
 				m.
 					ListPort(ports.ListOpts{
@@ -361,7 +361,7 @@ func Test_GetOrCreatePort(t *testing.T) {
 			},
 			nil,
 			[]string{"my-instance-tag"},
-			func(m *mock_clients.MockNetworkClientMockRecorder) {
+			func(m *mock.MockNetworkClientMockRecorder) {
 				// No ports found
 				m.
 					ListPort(ports.ListOpts{
@@ -394,7 +394,7 @@ func Test_GetOrCreatePort(t *testing.T) {
 			},
 			nil,
 			[]string{"my-tag"},
-			func(m *mock_clients.MockNetworkClientMockRecorder) {
+			func(m *mock.MockNetworkClientMockRecorder) {
 				// No ports found
 				m.
 					ListPort(ports.ListOpts{
@@ -434,7 +434,7 @@ func Test_GetOrCreatePort(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			mockClient := mock_clients.NewMockNetworkClient(mockCtrl)
+			mockClient := mock.NewMockNetworkClient(mockCtrl)
 			tt.expect(mockClient.EXPECT())
 			s := Service{
 				client: mockClient,

--- a/pkg/cloud/services/networking/trunk_test.go
+++ b/pkg/cloud/services/networking/trunk_test.go
@@ -24,7 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha6"
-	mock_clients "sigs.k8s.io/cluster-api-provider-openstack/pkg/clients/mock"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients/mock"
 )
 
 func Test_GetOrCreateTrunk(t *testing.T) {
@@ -35,7 +35,7 @@ func Test_GetOrCreateTrunk(t *testing.T) {
 		name      string
 		trunkName string
 		portID    string
-		expect    func(m *mock_clients.MockNetworkClientMockRecorder)
+		expect    func(m *mock.MockNetworkClientMockRecorder)
 		// Note the 'wanted' port isn't so important, since it will be whatever we tell ListPort or CreatePort to return.
 		// Mostly in this test suite, we're checking that ListPort/CreatePort is called with the expected port opts.
 		want    *trunks.Trunk
@@ -45,7 +45,7 @@ func Test_GetOrCreateTrunk(t *testing.T) {
 			"return trunk if found",
 			"trunk-1",
 			"port-1",
-			func(m *mock_clients.MockNetworkClientMockRecorder) {
+			func(m *mock.MockNetworkClientMockRecorder) {
 				m.
 					ListTrunk(trunks.ListOpts{
 						Name:   "trunk-1",
@@ -62,7 +62,7 @@ func Test_GetOrCreateTrunk(t *testing.T) {
 			"creates trunk if not found",
 			"trunk-1",
 			"port-1",
-			func(m *mock_clients.MockNetworkClientMockRecorder) {
+			func(m *mock.MockNetworkClientMockRecorder) {
 				// No ports found
 				m.
 					ListTrunk(trunks.ListOpts{
@@ -86,7 +86,7 @@ func Test_GetOrCreateTrunk(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			mockClient := mock_clients.NewMockNetworkClient(mockCtrl)
+			mockClient := mock.NewMockNetworkClient(mockCtrl)
 			tt.expect(mockClient.EXPECT())
 			s := Service{
 				client: mockClient,


### PR DESCRIPTION
**What this PR does / why we need it**:

The `mock` import doesn't appear to conflict with anything. Remove the aliasing to `mock_clients` as it's unnecessary.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

N/A

**TODOs**:

- [x] squashed commits

/hold
