### PR TITLE
✨ Enable additional linters and metalinter checks. Fix findings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,11 +1,14 @@
 linters:
   disable-all: true
   enable:
+  - asasalint
   - asciicheck
+  - bidichk
   - bodyclose
   - cyclop
   - depguard
   - dogsled
+  - dupword
   - durationcheck
   - errcheck
   - exportloopref
@@ -54,6 +57,27 @@ linters-settings:
     max-complexity: 30
   gci:
     local-prefixes: sigs.k8s.io/cluster-api-provider-openstack
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - performance
+    disabled-checks:
+      - appendAssign
+      - dupImport # https://github.com/go-critic/go-critic/issues/845
+      - evalOrder
+      - ifElseChain
+      - octalLiteral
+      - regexpSimplify
+      - sloppyReassign
+      - truncateCmp
+      - typeDefFirst
+      - unnamedResult
+      - unnecessaryDefer
+      - whyNoLint
+      - wrapperFunc
+      - rangeValCopy
+      - hugeParam
   importas:
     no-unaliased: true
     alias:

--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -421,7 +421,7 @@ func (r *OpenStackMachineReconciler) reconcileNormal(ctx context.Context, scope 
 			return ctrl.Result{}, nil
 		}
 
-		if len(fp.PortID) != 0 {
+		if fp.PortID != "" {
 			scope.Logger.Info("Floating IP already associated to a port:", "id", fp.ID, "fixed ip", fp.FixedIP, "portID", port.ID)
 		} else {
 			err = networkingService.AssociateFloatingIP(openStackMachine, fp, port.ID)
@@ -538,7 +538,7 @@ func handleUpdateMachineError(logger logr.Logger, openstackMachine *infrav1.Open
 	openstackMachine.Status.FailureReason = &err
 	openstackMachine.Status.FailureMessage = pointer.StringPtr(message.Error())
 	// TODO remove if this error is logged redundantly
-	logger.Error(fmt.Errorf(string(err)), message.Error())
+	logger.Error(fmt.Errorf("%s", string(err)), message.Error())
 }
 
 func (r *OpenStackMachineReconciler) reconcileLoadBalancerMember(scope *scope.Scope, openStackCluster *infrav1.OpenStackCluster, machine *clusterv1.Machine, openStackMachine *infrav1.OpenStackMachine, instanceNS *compute.InstanceNetworkStatus, clusterName string) error {

--- a/test/e2e/shared/context.go
+++ b/test/e2e/shared/context.go
@@ -37,7 +37,6 @@ func NewE2EContext(options ...Option) *E2EContext {
 	ctx := &E2EContext{}
 	ctx.Environment.Scheme = DefaultScheme()
 	ctx.Environment.Namespaces = map[*corev1.Namespace]context.CancelFunc{}
-	// ctx.Lifecycle = DefaultGinkgoLifecycle()
 
 	for _, opt := range options {
 		opt(ctx)
@@ -82,7 +81,7 @@ type Settings struct {
 
 // RuntimeEnvironment represents the runtime environment of the test.
 type RuntimeEnvironment struct {
-	// BootstrapClusterProvider manages provisioning of the the bootstrap cluster to be used for the e2e tests.
+	// BootstrapClusterProvider manages provisioning of the bootstrap cluster to be used for the e2e tests.
 	// Please note that provisioning will be skipped if use-existing-cluster is provided.
 	BootstrapClusterProvider bootstrap.ClusterProvider
 	// BootstrapClusterProxy allows to interact with the bootstrap cluster to be used for the e2e tests.


### PR DESCRIPTION
**What this PR does / why we need it**:

As discussed in #1342, this pr enables some additional linters that are also active in capi. 

Enable new linters: 
* asasalint
* bidichk
* dupword

Enable gocritic checks: 
* diagnostic
* experimental
* performance

Fixes the findings
```git
test/e2e/shared/context.go:85:2: Duplicate words (the) found (dupword)
	// BootstrapClusterProvider manages provisioning of the the bootstrap cluster to be used for the e2e tests.
	^
controllers/openstackmachine_controller.go:541:15: dynamicFmtString: use errors.New(string(err)) or fmt.Errorf("%s", string(err)) instead (gocritic)
	logger.Error(fmt.Errorf(string(err)), message.Error())
	             ^
controllers/openstackmachine_controller.go:424:6: emptyStringTest: replace `len(fp.PortID) != 0` with `fp.PortID != ""` (gocritic)
		if len(fp.PortID) != 0 {
		   ^
test/e2e/shared/context.go:40:2: commentedOutCode: may want to remove commented-out code (gocritic)
	// ctx.Lifecycle = DefaultGinkgoLifecycle()
	^
```

/hold
