### PR TITLE
🌱 Add e2e clusterctl upgrade tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,6 @@ sshuttle.pid
 
 # Book
 docs/book/book/
+
+# venv
+.venv

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ LDFLAGS := $(shell source ./hack/version.sh; version::ldflags)
 ## --------------------------------------
 
 # The number of ginkgo tests to run concurrently
-E2E_GINKGO_PARALLEL=2
+E2E_GINKGO_PARALLEL ?= 2
 
 E2E_ARGS ?=
 
@@ -143,6 +143,7 @@ E2E_KUSTOMIZE_DIR=test/e2e/data/kustomize
 .PHONY: e2e-templates
 e2e-templates: ## Generate cluster templates for e2e tests
 e2e-templates: $(addprefix $(E2E_TEMPLATES_DIR)/, \
+		 cluster-template-v1alpha5.yaml \
 		 cluster-template-external-cloud-provider.yaml \
 		 cluster-template-multi-az.yaml \
 		 cluster-template-multi-network.yaml \

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -100,10 +100,8 @@ providers:
     - sourcePath: "./infrastructure-openstack/cluster-template-external-cloud-provider.yaml"
     - sourcePath: "./infrastructure-openstack/cluster-template-without-lb.yaml"
     replacements:
-    # TODO: We should use e2e here instead of main, but we need a way to get it into the workload cluster
-    # for upgrade tests for that to work.
     - old: gcr.io/k8s-staging-capi-openstack/capi-openstack-controller:dev
-      new: gcr.io/k8s-staging-capi-openstack/capi-openstack-controller:main
+      new: gcr.io/k8s-staging-capi-openstack/capi-openstack-controller:e2e
     - old: "imagePullPolicy: Always"
       new: "imagePullPolicy: IfNotPresent"
     - old: "--v=2"

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -35,6 +35,7 @@ providers:
   - name: v1.2.4
     value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.4/core-components.yaml"
     type: url
+    contract: v1beta1
     files:
     - sourcePath: "../data/shared/v1beta1/metadata.yaml"
     replacements:
@@ -48,6 +49,7 @@ providers:
   - name: v1.2.4
     value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.4/bootstrap-components.yaml"
     type: url
+    contract: v1beta1
     files:
     - sourcePath: "../data/shared/v1beta1/metadata.yaml"
     replacements:
@@ -61,6 +63,7 @@ providers:
   - name: v1.2.4
     value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.4/control-plane-components.yaml"
     type: url
+    contract: v1beta1
     files:
     - sourcePath: "../data/shared/v1beta1/metadata.yaml"
     replacements:
@@ -71,17 +74,36 @@ providers:
 - name: openstack
   type: InfrastructureProvider
   versions:
+  # This is only for clusterctl upgrade tests
+  - name: v0.6.3
+    value: "https://github.com/kubernetes-sigs/cluster-api-provider-openstack/releases/download/v0.6.3/infrastructure-components.yaml"
+    type: url
+    contract: v1beta1
+    files:
+    - sourcePath: "../data/shared/v1beta1_provider/metadata.yaml"
+    - sourcePath: "./infrastructure-openstack/cluster-template.yaml"
+    replacements:
+    - old: "imagePullPolicy: Always"
+      new: "imagePullPolicy: IfNotPresent"
+    - old: "--v=2"
+      new: "--v=4"
+    - old: "--leader-elect"
+      new: "--leader-elect=false\n        - --sync-period=1m"
   - name: v0.6.99
     value: ../../../config/default
-    contract: v1beta1
+    # This is the upcoming version.
+    # Specify no contract so that upgrade tests that start from a specific contract won't pick it up.
+    # contract: v1beta1
     files:
     - sourcePath: "../data/shared/v1beta1_provider/metadata.yaml"
     - sourcePath: "./infrastructure-openstack/cluster-template.yaml"
     - sourcePath: "./infrastructure-openstack/cluster-template-external-cloud-provider.yaml"
     - sourcePath: "./infrastructure-openstack/cluster-template-without-lb.yaml"
     replacements:
+    # TODO: We should use e2e here instead of main, but we need a way to get it into the workload cluster
+    # for upgrade tests for that to work.
     - old: gcr.io/k8s-staging-capi-openstack/capi-openstack-controller:dev
-      new: gcr.io/k8s-staging-capi-openstack/capi-openstack-controller:e2e
+      new: gcr.io/k8s-staging-capi-openstack/capi-openstack-controller:main
     - old: "imagePullPolicy: Always"
       new: "imagePullPolicy: IfNotPresent"
     - old: "--v=2"
@@ -116,6 +138,7 @@ variables:
   OPENSTACK_VOLUME_TYPE_ALT: "test-volume-type"
   CONFORMANCE_WORKER_MACHINE_COUNT: "5"
   CONFORMANCE_CONTROL_PLANE_MACHINE_COUNT: "1"
+  INIT_WITH_KUBERNETES_VERSION: "v1.25.0"
 
 intervals:
   conformance/wait-control-plane: ["30m", "10s"]

--- a/test/e2e/data/kustomize/default/kustomization.yaml
+++ b/test/e2e/data/kustomize/default/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
 
 components:
 - ../common-patches
+- ../upgrade-patches

--- a/test/e2e/data/kustomize/upgrade-patches/ci-hack-kcp.yaml
+++ b/test/e2e/data/kustomize/upgrade-patches/ci-hack-kcp.yaml
@@ -1,0 +1,31 @@
+---
+# Workaround for https://github.com/kubernetes-sigs/cluster-api/issues/7457
+# There is a small but important difference between these two:
+# path: /a/b/c
+# *creates* the c array, overwriting anything that was there before
+# path: /a/b/c/-
+# *adds* to the c array and does not work if the array is missing
+#
+# We add to the postKubeadmCommands (instead of pre*) since we need the CI artifacts
+# script to run first. Without this, the container images are not imported properly.
+- op: add
+  path: /spec/kubeadmConfigSpec/postKubeadmCommands
+  value:
+  - /usr/local/bin/ci-artifacts-openstack.sh
+- op: add
+  path: /spec/kubeadmConfigSpec/files/-
+  value:
+    content: |
+      #!/bin/bash
+      DOWNLOAD_E2E_IMAGE=${DOWNLOAD_E2E_IMAGE:=false}
+      if [ ! "${DOWNLOAD_E2E_IMAGE}" = true ]; then
+        echo "Not downloading E2E image, exiting"
+        exit 0
+      fi
+      # Download the locally built CAPO controller image
+      echo "Downloading ${E2E_IMAGE_URL}"
+      wget "${E2E_IMAGE_URL}" -O "/tmp/capo-controller-manager.tar"
+      sudo ctr -n k8s.io images import "/tmp/capo-controller-manager.tar" || echo "* ignoring expected 'ctr images import' result"
+    owner: root:root
+    path: /usr/local/bin/ci-artifacts-openstack.sh
+    permissions: "0750"

--- a/test/e2e/data/kustomize/upgrade-patches/ci-hack-kct.yaml
+++ b/test/e2e/data/kustomize/upgrade-patches/ci-hack-kct.yaml
@@ -1,0 +1,31 @@
+---
+# Workaround for https://github.com/kubernetes-sigs/cluster-api/issues/7457
+# There is a small but important difference between these two:
+# path: /a/b/c
+# *creates* the c array, overwriting anything that was there before
+# path: /a/b/c/-
+# *adds* to the c array and does not work if the array is missing
+#
+# We add to the postKubeadmCommands (instead of pre*) since we need the CI artifacts
+# script to run first. Without this, the container images are not imported properly.
+- op: add
+  path: /spec/template/spec/postKubeadmCommands
+  value:
+  - /usr/local/bin/ci-artifacts-openstack.sh
+- op: add
+  path: /spec/template/spec/files/-
+  value:
+    content: |
+      #!/bin/bash
+      DOWNLOAD_E2E_IMAGE=${DOWNLOAD_E2E_IMAGE:=false}
+      if [ ! "${DOWNLOAD_E2E_IMAGE}" = true ]; then
+        echo "Not downloading E2E image, exiting"
+        exit 0
+      fi
+      # Download the locally built CAPO controller image
+      echo "Downloading ${E2E_IMAGE_URL}"
+      wget "${E2E_IMAGE_URL}" -O "/tmp/capo-controller-manager.tar"
+      sudo ctr -n k8s.io images import "/tmp/capo-controller-manager.tar" || echo "* ignoring expected 'ctr images import' result"
+    owner: root:root
+    path: /usr/local/bin/ci-artifacts-openstack.sh
+    permissions: "0750"

--- a/test/e2e/data/kustomize/upgrade-patches/kustomization.yaml
+++ b/test/e2e/data/kustomize/upgrade-patches/kustomization.yaml
@@ -1,0 +1,14 @@
+# Modifications to release templates for clusterctl upgrade scenarios
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+- target:
+    kind: KubeadmControlPlane
+    name: \${CLUSTER_NAME}-control-plane
+  path: ci-hack-kcp.yaml
+- target:
+    kind: KubeadmConfigTemplate
+    name: \${CLUSTER_NAME}-md-0
+  path: ci-hack-kct.yaml

--- a/test/e2e/data/kustomize/v1alpha5/kustomization.yaml
+++ b/test/e2e/data/kustomize/v1alpha5/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+resources:
+- ../../../../../kustomize/v1alpha5/default
+
+components:
+- ../common-patches

--- a/test/e2e/shared/defaults.go
+++ b/test/e2e/shared/defaults.go
@@ -48,6 +48,7 @@ const (
 	FlavorExternalCloudProvider = "external-cloud-provider-ci-artifacts"
 	FlavorMultiNetwork          = "multi-network-ci-artifacts"
 	FlavorMultiAZ               = "multi-az-ci-artifacts"
+	FlavorV1alpha5              = "v1alpha5-ci-artifacts"
 )
 
 // DefaultScheme returns the default scheme to use for testing.

--- a/test/e2e/suites/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/suites/e2e/clusterctl_upgrade_test.go
@@ -1,0 +1,53 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
+
+	"sigs.k8s.io/cluster-api-provider-openstack/test/e2e/shared"
+)
+
+// Note: There isn't really anything fixing this to the v0.6 release. The test will
+// simply pick the latest release with the correct contract from the E2EConfig, as seen here
+// https://github.com/kubernetes-sigs/cluster-api/blob/3abb9089485f51d46054096c17ccb8b59f0f7331/test/e2e/clusterctl_upgrade.go#L265
+// When new minor releases are added (with the same contract) we will need to work on this
+// if we want to continue testing v0.6.
+var _ = Describe("When testing clusterctl upgrades (v0.6=>current) [clusterctl-upgrade]", func() {
+	ctx := context.TODO()
+	shared.SetEnvVar("USE_CI_ARTIFACTS", "true", false)
+
+	capi_e2e.ClusterctlUpgradeSpec(ctx, func() capi_e2e.ClusterctlUpgradeSpecInput {
+		return capi_e2e.ClusterctlUpgradeSpecInput{
+			E2EConfig:                 e2eCtx.E2EConfig,
+			ClusterctlConfigPath:      e2eCtx.Environment.ClusterctlConfigPath,
+			BootstrapClusterProxy:     e2eCtx.Environment.BootstrapClusterProxy,
+			ArtifactFolder:            e2eCtx.Settings.ArtifactFolder,
+			SkipCleanup:               false,
+			InitWithBinary:            "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.4/clusterctl-{OS}-{ARCH}",
+			InitWithProvidersContract: "v1beta1",
+			MgmtFlavor:                shared.FlavorDefault,
+			WorkloadFlavor:            shared.FlavorV1alpha5,
+		}
+	})
+})

--- a/test/e2e/suites/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/suites/e2e/clusterctl_upgrade_test.go
@@ -36,6 +36,8 @@ import (
 var _ = Describe("When testing clusterctl upgrades (v0.6=>current) [clusterctl-upgrade]", func() {
 	ctx := context.TODO()
 	shared.SetEnvVar("USE_CI_ARTIFACTS", "true", false)
+	shared.SetEnvVar("DOWNLOAD_E2E_IMAGE", "true", false)
+	shared.SetEnvVar("E2E_IMAGE_URL", "http://10.0.3.15/capo-e2e-image.tar", false)
 
 	capi_e2e.ClusterctlUpgradeSpec(ctx, func() capi_e2e.ClusterctlUpgradeSpecInput {
 		return capi_e2e.ClusterctlUpgradeSpecInput{


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This adds e2e clusterctl upgrade tests from the CAPI e2e framework. Having a clusterctl upgrade test is very important for verifying upgrades between API versions.
The CAPI [clusterctl upgrade test spec](https://github.com/kubernetes-sigs/cluster-api/blob/release-1.2/test/e2e/clusterctl_upgrade.go) is a bit special since it creates not just a workload cluster, but a secondary management cluster also. The flow goes like this:
1. From the bootstrap cluster, create secondary management cluster with older CAPI/CAPO
2. From the secondary management cluster, create a workload cluster to check that the older versions are working correctly
3. Run clusterctl upgrade for the secondary management cluster (this requires a way to get the e2e image to the node where there upgraded controller will run)
4. Scale the workload cluster to verify that the upgraded versions are working.

The reason for the secondary management cluster is to avoid any issues with parallel jobs requiring different versions, so the bootstrap cluster can be shared as normal.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #1363 but I would want to add some more tests before closing it.

**Special notes for your reviewer**:

1. There are 2 commits in this PR for making it easier to discuss and review until we agree on the implementation:
    1. Adding the tests
    2. WIP upload the e2e image to the devstack controller and pre-pull it on the nodes.
        Note that this is only needed if we want to test the image built by CI (for example on PRs). If it is ok to just take the `main` tagged image, then we can drop this.
2. I added tests only for v0.6 -> current as agreed in the office hours. The work required to add older versions would make things more complicated in a few different ways:
   1. They don't all support the latest kubernetes version, so we need to set the version separately for them
   2. We get new combinations of CAPI/CAPO API versions, which means that the current way to just divide by the CAPO API version [here](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/tree/main/kustomize) would not be enough. (We would have CAPI v1alpha4 + CAPO v1alpha4 and CAPI v1beta1 + CAPO v1alpha4.)
   3. Already for v0.5 we would have the issue that it does not support Openstack yoga, so we would need to run the devstack with some older version.
3. Because of the secondary management cluster, we get quite a lot of VMs, which means we cannot run 2 of these tests in parallel as we currently do. We get a total of 1 bastion + 1 KCP + 1 worker for the management cluster + 1 bastion + 1 KCP + 2 workers (when scaling to test) in the workload cluster. If we run in parallel we are already above the devstack default quota of 10 instances.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
