### PR TITLE
Add e2e remediation tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,8 @@ E2E_KUSTOMIZE_DIR=test/e2e/data/kustomize
 e2e-templates: ## Generate cluster templates for e2e tests
 e2e-templates: $(addprefix $(E2E_TEMPLATES_DIR)/, \
 		 cluster-template-v1alpha5.yaml \
+		 cluster-template-md-remediation.yaml \
+		 cluster-template-kcp-remediation.yaml \
 		 cluster-template-external-cloud-provider.yaml \
 		 cluster-template-multi-az.yaml \
 		 cluster-template-multi-network.yaml \

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -154,3 +154,4 @@ intervals:
   default/wait-alt-az: ["20m", "30s"]
   default/wait-machine-upgrade: ["30m", "10s"]
   default/wait-nodes-ready: ["15m", "10s"]
+  default/wait-machine-remediation: ["10m", "10s"]

--- a/test/e2e/data/kustomize/kcp-remediation/kustomization.yaml
+++ b/test/e2e/data/kustomize/kcp-remediation/kustomization.yaml
@@ -1,0 +1,4 @@
+---
+resources:
+- ../default
+- mhc.yaml

--- a/test/e2e/data/kustomize/kcp-remediation/mhc.yaml
+++ b/test/e2e/data/kustomize/kcp-remediation/mhc.yaml
@@ -1,0 +1,18 @@
+---
+# MachineHealthCheck object with
+# - a selector that targets all the machines with label cluster.x-k8s.io/control-plane=""
+# - unhealthyConditions triggering remediation after 10s the condition is set
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: "${CLUSTER_NAME}-mhc-0"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  unhealthyConditions:
+    - type: e2e.remediation.condition
+      status: "False"
+      timeout: 10s

--- a/test/e2e/data/kustomize/md-remediation/kustomization.yaml
+++ b/test/e2e/data/kustomize/md-remediation/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+resources:
+- ../default
+- mhc.yaml
+
+patchesStrategicMerge:
+- md.yaml

--- a/test/e2e/data/kustomize/md-remediation/md.yaml
+++ b/test/e2e/data/kustomize/md-remediation/md.yaml
@@ -1,0 +1,9 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  template:
+    metadata:
+      labels:
+        "e2e.remediation.label": ""

--- a/test/e2e/data/kustomize/md-remediation/mhc.yaml
+++ b/test/e2e/data/kustomize/md-remediation/mhc.yaml
@@ -1,0 +1,18 @@
+---
+# MachineHealthCheck object with
+# - a selector that targets all the machines with label e2e.remediation.label=""
+# - unhealthyConditions triggering remediation after 10s the condition is set
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: "${CLUSTER_NAME}-mhc-0"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      e2e.remediation.label: ""
+  unhealthyConditions:
+    - type: e2e.remediation.condition
+      status: "False"
+      timeout: 10s

--- a/test/e2e/shared/defaults.go
+++ b/test/e2e/shared/defaults.go
@@ -49,6 +49,8 @@ const (
 	FlavorMultiNetwork          = "multi-network-ci-artifacts"
 	FlavorMultiAZ               = "multi-az-ci-artifacts"
 	FlavorV1alpha5              = "v1alpha5-ci-artifacts"
+	FlavorMDRemediation         = "md-remediation-ci-artifacts"
+	FlavorKCPRemediation        = "kcp-remediation-ci-artifacts"
 )
 
 // DefaultScheme returns the default scheme to use for testing.

--- a/test/e2e/suites/e2e/mhc_remediations_test.go
+++ b/test/e2e/suites/e2e/mhc_remediations_test.go
@@ -1,0 +1,46 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	"k8s.io/utils/pointer"
+	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
+
+	"sigs.k8s.io/cluster-api-provider-openstack/test/e2e/shared"
+)
+
+var _ = Describe("When testing unhealthy machines remediation [mhc-remediations]", func() {
+	ctx := context.TODO()
+	shared.SetEnvVar("USE_CI_ARTIFACTS", "true", false)
+	capi_e2e.MachineRemediationSpec(ctx, func() capi_e2e.MachineRemediationSpecInput {
+		return capi_e2e.MachineRemediationSpecInput{
+			E2EConfig:             e2eCtx.E2EConfig,
+			ClusterctlConfigPath:  e2eCtx.Environment.ClusterctlConfigPath,
+			BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
+			ArtifactFolder:        e2eCtx.Settings.ArtifactFolder,
+			SkipCleanup:           false,
+			KCPFlavor:             pointer.String(shared.FlavorKCPRemediation),
+			MDFlavor:              pointer.String(shared.FlavorMDRemediation),
+		}
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds the CAPI e2e framework remediation tests. There are two tests, one for MachineDeployment and one for KubeadmControlPlane. They simply check that the MachineHealthcheck works as expected, i.e. when a Machine becomes unhealthy, it (and its underlying OpenstackMachine) is properly deleted and a new is created to take its place.

While this is mostly a CAPI feature, it can be good to check also in CAPO that it works as expected.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #1363 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.
2. I think we could run these tests periodically, not on every PR. Does that make sense? And how should we configure it?

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
