### PR TITLE
🐛 Improve `env.rc` and `create_cloud_conf.sh` templates

### DIFF
--- a/templates/create_cloud_conf.sh
+++ b/templates/create_cloud_conf.sh
@@ -81,6 +81,9 @@ yqNavigating(){
 CAPO_AUTH_URL=$(echo "$CAPO_OPENSTACK_CLOUD_YAML_CONTENT" | yqNavigating - clouds.${CAPO_CLOUD}.auth.auth_url)
 CAPO_USERNAME=$(echo "$CAPO_OPENSTACK_CLOUD_YAML_CONTENT" | yqNavigating - clouds.${CAPO_CLOUD}.auth.username)
 CAPO_PASSWORD=$(echo "$CAPO_OPENSTACK_CLOUD_YAML_CONTENT" | yqNavigating - clouds.${CAPO_CLOUD}.auth.password)
+if [[ "$CAPO_PASSWORD" = "" || "$CAPO_PASSWORD" = "null" ]]; then
+  CAPO_PASSWORD="${OS_PASSWORD}"
+fi
 CAPO_REGION=$(echo "$CAPO_OPENSTACK_CLOUD_YAML_CONTENT" | yqNavigating - clouds.${CAPO_CLOUD}.region_name)
 CAPO_PROJECT_ID=$(echo "$CAPO_OPENSTACK_CLOUD_YAML_CONTENT" | yqNavigating - clouds.${CAPO_CLOUD}.auth.project_id)
 CAPO_PROJECT_NAME=$(echo "$CAPO_OPENSTACK_CLOUD_YAML_CONTENT" | yqNavigating - clouds.${CAPO_CLOUD}.auth.project_name)

--- a/templates/env.rc
+++ b/templates/env.rc
@@ -70,10 +70,22 @@ yqNavigating(){
         fi
 }
 
+b64encode(){
+  # Check if wrap is supported. Otherwise, break is supported.
+  if echo | base64 --wrap=0 &> /dev/null; then
+    base64 --wrap=0 $1
+  else
+    base64 --break=0 $1
+  fi
+}
+
 # Just blindly parse the cloud.yaml here, overwriting old vars.
 CAPO_AUTH_URL=$(echo "$CAPO_OPENSTACK_CLOUD_YAML_CONTENT" | yqNavigating - clouds.${CAPO_CLOUD}.auth.auth_url)
 CAPO_USERNAME=$(echo "$CAPO_OPENSTACK_CLOUD_YAML_CONTENT" | yqNavigating - clouds.${CAPO_CLOUD}.auth.username)
 CAPO_PASSWORD=$(echo "$CAPO_OPENSTACK_CLOUD_YAML_CONTENT" | yqNavigating - clouds.${CAPO_CLOUD}.auth.password)
+if [[ "$CAPO_PASSWORD" = "" || "$CAPO_PASSWORD" = "null" ]]; then
+  CAPO_PASSWORD="${OS_PASSWORD}"
+fi
 CAPO_REGION=$(echo "$CAPO_OPENSTACK_CLOUD_YAML_CONTENT" | yqNavigating - clouds.${CAPO_CLOUD}.region_name)
 CAPO_PROJECT_ID=$(echo "$CAPO_OPENSTACK_CLOUD_YAML_CONTENT" | yqNavigating - clouds.${CAPO_CLOUD}.auth.project_id)
 CAPO_PROJECT_NAME=$(echo "$CAPO_OPENSTACK_CLOUD_YAML_CONTENT" | yqNavigating - clouds.${CAPO_CLOUD}.auth.project_name)
@@ -94,9 +106,9 @@ export OPENSTACK_CLOUD="${CAPO_CLOUD}"
 
 # Build OPENSTACK_CLOUD_YAML_B64
 if [[ ${CAPO_YQ_VERSION} == *"version 1"* || ${CAPO_YQ_VERSION} == *"version 2"* || ${CAPO_YQ_VERSION} == *"version 3"* ]]; then
-    CAPO_OPENSTACK_CLOUD_YAML_SELECTED_CLOUD_B64=$(echo "${CAPO_OPENSTACK_CLOUD_YAML_CONTENT}" | yq r - clouds.${CAPO_CLOUD} | yq p - clouds.${CAPO_CLOUD} | base64 --wrap=0)
+    CAPO_OPENSTACK_CLOUD_YAML_SELECTED_CLOUD_B64=$(echo "${CAPO_OPENSTACK_CLOUD_YAML_CONTENT}" | yq r - clouds.${CAPO_CLOUD} | yq w - auth.password ${CAPO_PASSWORD} | yq p - clouds.${CAPO_CLOUD} | b64encode)
 else
-    CAPO_OPENSTACK_CLOUD_YAML_SELECTED_CLOUD_B64=$(echo "${CAPO_OPENSTACK_CLOUD_YAML_CONTENT}" | yq e .clouds.${CAPO_CLOUD} - | yq eval '{"clouds": {"'${CAPO_CLOUD}'": . }}' - | base64 --wrap=0)
+    CAPO_OPENSTACK_CLOUD_YAML_SELECTED_CLOUD_B64=$(echo "${CAPO_OPENSTACK_CLOUD_YAML_CONTENT}" | yq e .clouds.${CAPO_CLOUD} - | PASSWORD=${CAPO_PASSWORD} yq e '.auth.password = env(PASSWORD)' - | yq e '{"clouds": {"'${CAPO_CLOUD}'": . }}' - | b64encode)
 fi
 export OPENSTACK_CLOUD_YAML_B64="${CAPO_OPENSTACK_CLOUD_YAML_SELECTED_CLOUD_B64}"
 
@@ -146,11 +158,11 @@ fi
 if [[ "$CAPO_APPLICATION_CREDENTIAL_SECRET" != "" && "$CAPO_APPLICATION_CREDENTIAL_SECRET" != "null" ]]; then
   echo "application-credential-secret=\"${CAPO_APPLICATION_CREDENTIAL_SECRET}\"" >> ${CAPO_CLOUD_PROVIDER_CONF_TMP}
 fi
-export OPENSTACK_CLOUD_PROVIDER_CONF_B64="$(cat ${CAPO_CLOUD_PROVIDER_CONF_TMP} | base64 --wrap=0)"
+export OPENSTACK_CLOUD_PROVIDER_CONF_B64="$(cat ${CAPO_CLOUD_PROVIDER_CONF_TMP} | b64encode)"
 
 # Build OPENSTACK_CLOUD_CACERT_B64
-OPENSTACK_CLOUD_CACERT_B64=$(echo "" | base64 --wrap=0)
+OPENSTACK_CLOUD_CACERT_B64=$(echo "" | b64encode)
 if [[ "$CAPO_CACERT_ORIGINAL" != "" && "$CAPO_CACERT_ORIGINAL" != "null" ]]; then
-  OPENSTACK_CLOUD_CACERT_B64=$(cat "$CAPO_CACERT_ORIGINAL"  | base64 --wrap=0)
+  OPENSTACK_CLOUD_CACERT_B64=$(cat "$CAPO_CACERT_ORIGINAL" | b64encode)
 fi
 export OPENSTACK_CLOUD_CACERT_B64


### PR DESCRIPTION
**What this PR does / why we need it**:

It fixes the following erroneous situations:
1. Scripts are run from macOS where base64 supports `--break` instead of `--wrap`
2. For security reasons OpenStack password is present in `OS_PASSWORD` environment variable rather than clouds.yaml

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
