### PR TITLE
 🐛 Fix Octavia versions endpoint

### DIFF
--- a/pkg/clients/loadbalancer.go
+++ b/pkg/clients/loadbalancer.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
-	"github.com/gophercloud/gophercloud/openstack/compute/apiversions"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/apiversions"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors"

--- a/pkg/clients/mock/loadbalancer.go
+++ b/pkg/clients/mock/loadbalancer.go
@@ -24,7 +24,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	apiversions "github.com/gophercloud/gophercloud/openstack/compute/apiversions"
+	apiversions "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/apiversions"
 	listeners "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners"
 	loadbalancers "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers"
 	monitors "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors"

--- a/pkg/cloud/services/loadbalancer/loadbalancer_test.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
-	"github.com/gophercloud/gophercloud/openstack/compute/apiversions"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/apiversions"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors"


### PR DESCRIPTION
We were hitting the compute endpoint instead of the octavia endpoint when fetching octavia versions.

This is used to detect if Octavia supports allowed CIDRs, so presumably that feature is broken.

**Which issue(s) this PR fixes**:
Fixes #1384

/hold
