### PR TITLE
✨ Add OpenStack simulator for running envtests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -170,6 +170,12 @@ issues:
     - stylecheck
     text: "ST1003: should not use underscores in Go names;"
     path: .*(api|types)\/.*\/.*conversion.*\.go$
+  # Disable goconst in the simulator package due to the large number of false
+  # positives: fields with the same name in different structs should not be
+  # combined with a common const definition.
+  - linters:
+    - goconst
+    path: pkg/clients/simulator/.*\.go$
 
 run:
   timeout: 10m

--- a/Makefile
+++ b/Makefile
@@ -226,12 +226,15 @@ $(SETUP_ENVTEST): # Build setup-envtest from tools folder.
 ##@ Linting
 ## --------------------------------------
 
+# e2e-templates are a dependency of lint and lint-update to validate the
+# go:embed directive which reads them.
+
 .PHONY: lint
-lint: $(GOLANGCI_LINT) ## Lint codebase
+lint: $(GOLANGCI_LINT) e2e-templates ## Lint codebase
 	$(GOLANGCI_LINT) run -v --fast=false
 
 .PHONY: lint-update
-lint-update: $(GOLANGCI_LINT) ## Lint codebase
+lint-update: $(GOLANGCI_LINT) e2e-templates ## Lint codebase
 	$(GOLANGCI_LINT) run -v --fast=false --fix
 
 lint-fast: $(GOLANGCI_LINT) ## Run only faster linters to detect possible issues

--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -47,7 +47,6 @@ import (
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/compute"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/loadbalancer"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/networking"
-	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/provider"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
 )
 
@@ -111,7 +110,7 @@ func (r *OpenStackClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 	}()
 
-	osProviderClient, clientOpts, projectID, err := provider.NewClientFromCluster(ctx, r.Client, openStackCluster)
+	osProviderClient, clientOpts, projectID, err := scope.NewClientFromCluster(ctx, r.Client, openStackCluster)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/controllers/openstackcluster_controller_test.go
+++ b/controllers/openstackcluster_controller_test.go
@@ -186,7 +186,7 @@ var _ = Describe("OpenStackCluster controller", func() {
 		// 	},
 		// }
 		// // TODO: Can we fake the client in some way?
-		// providerClient, clientOpts, _, err := provider.NewClient(cloud, nil)
+		// providerClient, clientOpts, _, err := scope.NewProviderClient(cloud, nil)
 		// Expect(err).To(BeNil())
 		// scope := &scope.Scope{
 		// 	ProviderClient:     providerClient,

--- a/controllers/openstackcluster_controller_test.go
+++ b/controllers/openstackcluster_controller_test.go
@@ -178,7 +178,7 @@ var _ = Describe("OpenStackCluster controller", func() {
 		mockScopeFactory.SetClientScopeCreateError(clientCreateErr)
 
 		result, err := reconciler.Reconcile(ctx, req)
-		// Expect error for getting OS clinet and empty result
+		// Expect error for getting OS client and empty result
 		Expect(err).To(MatchError(clientCreateErr))
 		Expect(result).To(Equal(reconcile.Result{}))
 	})

--- a/controllers/openstackcluster_controller_test.go
+++ b/controllers/openstackcluster_controller_test.go
@@ -20,7 +20,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha6"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
 )
 
@@ -178,49 +182,30 @@ var _ = Describe("OpenStackCluster controller", func() {
 		Expect(err).To(MatchError(clientCreateErr))
 		Expect(result).To(Equal(reconcile.Result{}))
 	})
+	It("should be able to reconcile when bastion is disabled and does not exist", func() {
+		testCluster.SetName("no-bastion")
+		testCluster.Spec = infrav1.OpenStackClusterSpec{
+			Bastion: &infrav1.Bastion{
+				Enabled: false,
+			},
+		}
+		err := k8sClient.Create(ctx, testCluster)
+		Expect(err).To(BeNil())
+		err = k8sClient.Create(ctx, capiCluster)
+		Expect(err).To(BeNil())
+		scope, err := mockScopeFactory.NewClientScopeFromCluster(ctx, k8sClient, testCluster, logr.Discard())
+		Expect(err).To(BeNil())
 
-	// TODO: This test is set to pending (PIt instead of It) since it is not working.
-	PIt("should be able to reconcile when basition disabled", func() {
-		// verify := false
-		// cloud := clientconfig.Cloud{
-		// 	Cloud:      "test",
-		// 	RegionName: "test",
-		// 	Verify:     &verify,
-		// 	AuthInfo: &clientconfig.AuthInfo{
-		// 		AuthURL:        "https://example.com:5000",
-		// 		Username:       "testuser",
-		// 		Password:       "secret",
-		// 		ProjectName:    "test",
-		// 		DomainName:     "test",
-		// 		UserDomainName: "test",
-		// 	},
-		// }
-		// // TODO: Can we fake the client in some way?
-		// providerClient, clientOpts, _, err := scope.NewProviderClient(cloud, nil)
-		// Expect(err).To(BeNil())
-		// scope := &scope.Scope{
-		// 	ProviderClient:     providerClient,
-		// 	ProviderClientOpts: clientOpts,
-		// }
+		computeClientRecorder := mockScopeFactory.ComputeClient.EXPECT()
+		computeClientRecorder.ListServers(servers.ListOpts{
+			Name: "^capi-cluster-bastion$",
+		}).Return([]clients.ServerExt{}, nil)
 
-		// TODO: This won't work without filling in proper values.
-		// scope := &scope.Scope{
-		//	ProviderClient:     &gophercloud.ProviderClient{},
-		//	ProviderClientOpts: &clientconfig.ClientOpts{},
-		// }
-		// testCluster.SetName("no-bastion")
-		// testCluster.Spec = infrav1.OpenStackClusterSpec{
-		//	Bastion: &infrav1.Bastion{
-		//		Enabled: false,
-		// 	},
-		// }
-		// err := k8sClient.Create(ctx, testCluster)
-		// Expect(err).To(BeNil())
-		// err = k8sClient.Create(ctx, capiCluster)
-		// Expect(err).To(BeNil())
-		//
-		// err = deleteBastion(scope, capiCluster, testCluster)
-		// Expect(err).To(BeNil())
+		networkClientRecorder := mockScopeFactory.NetworkClient.EXPECT()
+		networkClientRecorder.ListSecGroup(gomock.Any()).Return([]groups.SecGroup{}, nil)
+
+		err = deleteBastion(scope, capiCluster, testCluster)
+		Expect(err).To(BeNil())
 	})
 })
 

--- a/controllers/openstackcluster_controller_test.go
+++ b/controllers/openstackcluster_controller_test.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
@@ -26,18 +27,25 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha6"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients/simulator"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
+	"sigs.k8s.io/cluster-api-provider-openstack/test"
 )
 
 var (
@@ -216,4 +224,225 @@ func createRequestFromOSCluster(openStackCluster *infrav1.OpenStackCluster) reco
 			Namespace: openStackCluster.GetNamespace(),
 		},
 	}
+}
+
+var _ = Describe("OpenStackCluster controller Bastion", func() {
+	const (
+		externalNetworkUUID = "6c22ea3c-5589-4651-b559-ca8124e99d5e"
+		imageUUID           = "9391d6ac-3f2c-4f0c-a840-d29fcec19bab"
+		workerFlavorUUID    = "4d8bef18-a149-4b9a-be7e-0386173b9b08"
+		projectID           = "60ff3abf-1f3d-41ba-aa3c-40a54c6790a7"
+	)
+
+	var (
+		templateVars test.TemplateVars
+		templateName string
+
+		objs []runtime.Object
+		sim  *simulator.OpenStackSimulator
+
+		cleanupMgr func()
+
+		capiCluster      *clusterv1.Cluster
+		openStackCluster *infrav1.OpenStackCluster
+
+		testNamespace string
+		testNum       int
+
+		ctx context.Context
+	)
+
+	BeforeEach(func() {
+		ctx = context.TODO()
+
+		testNum++
+		testNamespace = fmt.Sprintf("cluster-bastion-test-%d", testNum)
+		namespace := &corev1.Namespace{}
+		namespace.Name = testNamespace
+		Expect(k8sClient.Create(ctx, namespace)).To(Succeed())
+
+		templateVars = test.TemplateVars{
+			ClusterName:                        "test-cluster",
+			CNIResources:                       "{}",
+			KubernetesVersion:                  "1.25.0",
+			OpenStackBastionImageName:          "test-bastion-image",
+			OpenStackBastionMachineFlavor:      "test-bastion-flavor",
+			OpenStackCloud:                     "openstack",
+			OpenStackCloudCACert:               "-",
+			OpenStackCloudYAML:                 "---\nopenstack:",
+			OpenStackCloudProviderConf:         "-",
+			OpenStackDNSNameservers:            "8.8.8.8",
+			OpenStackExternalNetworkID:         externalNetworkUUID,
+			OpenStackFailureDomain:             "test-failuredomain",
+			OpenStackImageName:                 "test-image",
+			OpenStackSSHKeyName:                "test-keypair",
+			OpenStackControlPlaneMachineFlavor: "test-controlplaneflavor",
+			OpenStackNodeMachineFlavor:         "test-workerflavor",
+			ControlPlaneMachineCount:           "3",
+			WorkerMachineCount:                 "2",
+		}
+		templateName = "cluster-template.yaml"
+
+		sim = simulator.NewOpenStackSimulator()
+		sim.Network.SimAddNetworkWithSubnet("test-external-network", externalNetworkUUID, "192.168.0.0/24", true)
+		sim.Compute.SimAddAvailabilityZone("test-az")
+		sim.Image.SimAddImage("test-bastion-image", imageUUID)
+		sim.Compute.SimAddFlavor("test-bastion-flavor", workerFlavorUUID)
+
+		var mgr manager.Manager
+		var runMgr func()
+		mgr, runMgr, cleanupMgr = getManager(ctx, logger, scheme.Scheme)
+		scopeFactory := scope.NewSimulatorScopeFactory(sim, projectID, logger)
+		addClusterController(mgr, k8sClient, scopeFactory)
+
+		go runMgr()
+	})
+
+	JustBeforeEach(func() {
+		var err error
+		objs, err = test.ReadTemplatedObjects(templateName, templateVars, scheme.Scheme)
+		Expect(err).NotTo(HaveOccurred())
+
+		capiCluster = func() *clusterv1.Cluster {
+			for _, obj := range objs {
+				if capiCluster, ok := obj.(*clusterv1.Cluster); ok {
+					return capiCluster
+				}
+			}
+			return nil
+		}()
+		Expect(capiCluster).ToNot(BeNil())
+		capiCluster.Namespace = testNamespace
+
+		openStackCluster = func() *infrav1.OpenStackCluster {
+			for _, obj := range objs {
+				if openstackCluster, ok := obj.(*infrav1.OpenStackCluster); ok {
+					return openstackCluster
+				}
+			}
+			return nil
+		}()
+		Expect(openStackCluster).ToNot(BeNil())
+		openStackCluster.Namespace = testNamespace
+	})
+
+	AfterEach(func() {
+		// Move this to DeferCleanup() when we upgrade to ginkgo v2
+		cleanupMgr()
+	})
+
+	Context("when the OpenStackCluster has an initial bastion", func() {
+		It("should provision and deprovision successfully", func() {
+			openStackCluster.Spec.Bastion = &infrav1.Bastion{
+				Enabled: true,
+				Instance: infrav1.OpenStackMachineSpec{
+					Flavor:     "test-bastion-flavor",
+					Image:      "test-bastion-image",
+					SSHKeyName: "test-key",
+					/*
+						RootVolume: &infrav1.RootVolume{
+							Size:             100,
+							VolumeType:       "test-volumetype",
+							AvailabilityZone: "test-az2",
+						},
+					*/
+				},
+				AvailabilityZone: "test-az2",
+			}
+
+			By("creating the cluster")
+			createClusters(ctx, k8sClient, capiCluster, openStackCluster)
+
+			By("waiting for bastion to exist")
+			Eventually(func() *infrav1.Instance {
+				Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: openStackCluster.Name}, openStackCluster)).To(Succeed())
+				return openStackCluster.Status.Bastion
+			}).WithTimeout(30*time.Second).ShouldNot(BeNil(), "Bastion should exist")
+
+			By("deleting the cluster")
+			Expect(k8sClient.Delete(ctx, openStackCluster)).To(Succeed())
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{Namespace: openStackCluster.Name, Name: openStackCluster.Namespace}, openStackCluster)
+				return apierrors.IsNotFound(err)
+			}).Should(BeTrue(), "OpenStackCluster should be deleted")
+		})
+	})
+
+	Context("when the OpenStackCluster has no initial bastion", func() {
+		It("should provision and deprovision successfully", func() {
+			// The E2E templates have an initial bastion, so we need to remove it
+			openStackCluster.Spec.Bastion = nil
+
+			By("creating the cluster")
+			createClusters(ctx, k8sClient, capiCluster, openStackCluster)
+
+			By("waiting for the cluster to be ready")
+			Eventually(func() bool {
+				Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: openStackCluster.Name}, openStackCluster)).To(Succeed())
+				return openStackCluster.Status.Ready
+			}).WithTimeout(30*time.Second).Should(BeTrue(), "OpenStackCluster should be ready")
+
+			By("adding a bastion")
+			// Retry because we can race with the controller
+			Eventually(func() error {
+				Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: openStackCluster.Name}, openStackCluster)).To(Succeed())
+				openStackCluster.Spec.Bastion = &infrav1.Bastion{
+					Enabled: true,
+					Instance: infrav1.OpenStackMachineSpec{
+						Flavor:     "test-bastion-flavor",
+						Image:      "test-bastion-image",
+						SSHKeyName: "test-key",
+						/*
+							RootVolume: &infrav1.RootVolume{
+								Size:             100,
+								VolumeType:       "test-volumetype",
+								AvailabilityZone: "test-az2",
+							},
+						*/
+					},
+					AvailabilityZone: "test-az2",
+				}
+				return k8sClient.Update(ctx, openStackCluster)
+			}).Should(Succeed())
+
+			By("waiting for bastion to exist")
+			Eventually(func() *infrav1.Instance {
+				Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: openStackCluster.Name}, openStackCluster)).To(Succeed())
+				return openStackCluster.Status.Bastion
+			}).WithTimeout(30*time.Second).ShouldNot(BeNil(), "Bastion should exist")
+
+			By("the bastion should have been created correctly")
+			bastion := openStackCluster.Status.Bastion
+
+			// We don't populate very much in APIStatus, so check it directly in the simulator
+			simServer := sim.Compute.SimGetServer(bastion.ID)
+			Expect(simServer).ToNot(BeNil(), "bastion should exist in simulator")
+			Expect(simServer.Image).To(HaveKeyWithValue("name", "test-bastion-image"), "bastion image should be correct")
+			Expect(simServer.AvailabilityZone).To(Equal("test-az2"), "bastion availability zone should be correct")
+
+			Expect(bastion.SSHKeyName).To(Equal("test-key"), "bastion SSH key name should be correct")
+			Expect(bastion.FloatingIP).ToNot(BeEmpty(), "bastion should have a floating IP")
+
+			By("deleting the cluster")
+			Expect(k8sClient.Delete(ctx, openStackCluster)).To(Succeed())
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{Namespace: openStackCluster.Name, Name: openStackCluster.Namespace}, openStackCluster)
+				return apierrors.IsNotFound(err)
+			}).Should(BeTrue(), "OpenStackCluster should be deleted")
+		})
+	})
+})
+
+func createClusters(ctx context.Context, k8sClient client.Client, capiCluster *clusterv1.Cluster, openStackCluster *infrav1.OpenStackCluster) {
+	Expect(k8sClient.Create(ctx, capiCluster)).To(Succeed())
+
+	openStackCluster.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion: clusterv1.GroupVersion.String(),
+			Kind:       "Cluster",
+			Name:       capiCluster.Name,
+			UID:        capiCluster.UID,
+		},
+	}
+	Expect(k8sClient.Create(ctx, openStackCluster)).To(Succeed())
 }

--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -61,6 +61,7 @@ type OpenStackMachineReconciler struct {
 	Client           client.Client
 	Recorder         record.EventRecorder
 	WatchFilterValue string
+	ScopeFactory     scope.Factory
 }
 
 const (
@@ -139,16 +140,9 @@ func (r *OpenStackMachineReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 	}()
 
-	osProviderClient, clientOpts, projectID, err := scope.NewClientFromMachine(ctx, r.Client, openStackMachine)
+	scope, err := r.ScopeFactory.NewClientScopeFromMachine(ctx, r.Client, openStackMachine, log)
 	if err != nil {
 		return reconcile.Result{}, err
-	}
-
-	scope := &scope.Scope{
-		ProviderClient:     osProviderClient,
-		ProviderClientOpts: clientOpts,
-		ProjectID:          projectID,
-		Logger:             log,
 	}
 
 	// Handle deleted machines
@@ -224,8 +218,8 @@ func (r *OpenStackMachineReconciler) SetupWithManager(ctx context.Context, mgr c
 		Complete(r)
 }
 
-func (r *OpenStackMachineReconciler) reconcileDelete(ctx context.Context, scope *scope.Scope, patchHelper *patch.Helper, cluster *clusterv1.Cluster, openStackCluster *infrav1.OpenStackCluster, machine *clusterv1.Machine, openStackMachine *infrav1.OpenStackMachine) (ctrl.Result, error) {
-	scope.Logger.Info("Reconciling Machine delete")
+func (r *OpenStackMachineReconciler) reconcileDelete(ctx context.Context, scope scope.Scope, patchHelper *patch.Helper, cluster *clusterv1.Cluster, openStackCluster *infrav1.OpenStackCluster, machine *clusterv1.Machine, openStackMachine *infrav1.OpenStackMachine) (ctrl.Result, error) {
+	scope.Logger().Info("Reconciling Machine delete")
 
 	clusterName := fmt.Sprintf("%s-%s", cluster.ObjectMeta.Namespace, cluster.Name)
 
@@ -285,17 +279,17 @@ func (r *OpenStackMachineReconciler) reconcileDelete(ctx context.Context, scope 
 	}
 
 	controllerutil.RemoveFinalizer(openStackMachine, infrav1.MachineFinalizer)
-	scope.Logger.Info("Reconciled Machine delete successfully")
+	scope.Logger().Info("Reconciled Machine delete successfully")
 	if err := patchHelper.Patch(ctx, openStackMachine); err != nil {
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{}, nil
 }
 
-func (r *OpenStackMachineReconciler) reconcileNormal(ctx context.Context, scope *scope.Scope, patchHelper *patch.Helper, cluster *clusterv1.Cluster, openStackCluster *infrav1.OpenStackCluster, machine *clusterv1.Machine, openStackMachine *infrav1.OpenStackMachine) (_ ctrl.Result, reterr error) {
+func (r *OpenStackMachineReconciler) reconcileNormal(ctx context.Context, scope scope.Scope, patchHelper *patch.Helper, cluster *clusterv1.Cluster, openStackCluster *infrav1.OpenStackCluster, machine *clusterv1.Machine, openStackMachine *infrav1.OpenStackMachine) (_ ctrl.Result, reterr error) {
 	// If the OpenStackMachine is in an error state, return early.
 	if openStackMachine.Status.FailureReason != nil || openStackMachine.Status.FailureMessage != nil {
-		scope.Logger.Info("Not reconciling machine in failed state. See openStackMachine.status.failureReason, openStackMachine.status.failureMessage, or previously logged error for details")
+		scope.Logger().Info("Not reconciling machine in failed state. See openStackMachine.status.failureReason, openStackMachine.status.failureMessage, or previously logged error for details")
 		return ctrl.Result{}, nil
 	}
 
@@ -307,14 +301,14 @@ func (r *OpenStackMachineReconciler) reconcileNormal(ctx context.Context, scope 
 	}
 
 	if !cluster.Status.InfrastructureReady {
-		scope.Logger.Info("Cluster infrastructure is not ready yet, requeuing machine")
+		scope.Logger().Info("Cluster infrastructure is not ready yet, requeuing machine")
 		conditions.MarkFalse(openStackMachine, infrav1.InstanceReadyCondition, infrav1.WaitingForClusterInfrastructureReason, clusterv1.ConditionSeverityInfo, "")
 		return ctrl.Result{RequeueAfter: waitForClusterInfrastructureReadyDuration}, nil
 	}
 
 	// Make sure bootstrap data is available and populated.
 	if machine.Spec.Bootstrap.DataSecretName == nil {
-		scope.Logger.Info("Bootstrap data secret reference is not yet available")
+		scope.Logger().Info("Bootstrap data secret reference is not yet available")
 		conditions.MarkFalse(openStackMachine, infrav1.InstanceReadyCondition, infrav1.WaitingForBootstrapDataReason, clusterv1.ConditionSeverityInfo, "")
 		return ctrl.Result{}, nil
 	}
@@ -322,7 +316,7 @@ func (r *OpenStackMachineReconciler) reconcileNormal(ctx context.Context, scope 
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	scope.Logger.Info("Reconciling Machine")
+	scope.Logger().Info("Reconciling Machine")
 
 	clusterName := fmt.Sprintf("%s-%s", cluster.ObjectMeta.Namespace, cluster.Name)
 
@@ -336,7 +330,7 @@ func (r *OpenStackMachineReconciler) reconcileNormal(ctx context.Context, scope 
 		return ctrl.Result{}, err
 	}
 
-	instanceStatus, err := r.getOrCreate(scope.Logger, cluster, openStackCluster, machine, openStackMachine, computeService, userData)
+	instanceStatus, err := r.getOrCreate(scope.Logger(), cluster, openStackCluster, machine, openStackMachine, computeService, userData)
 	if err != nil {
 		// Conditions set in getOrCreate
 		return ctrl.Result{}, err
@@ -368,31 +362,31 @@ func (r *OpenStackMachineReconciler) reconcileNormal(ctx context.Context, scope 
 
 	switch instanceStatus.State() {
 	case infrav1.InstanceStateActive:
-		scope.Logger.Info("Machine instance state is ACTIVE", "instance-id", instanceStatus.ID())
+		scope.Logger().Info("Machine instance state is ACTIVE", "instance-id", instanceStatus.ID())
 		conditions.MarkTrue(openStackMachine, infrav1.InstanceReadyCondition)
 		openStackMachine.Status.Ready = true
 	case infrav1.InstanceStateError:
 		// Error is unexpected, thus we report error and never retry
-		scope.Logger.Info("Machine instance state is ERROR", "instance-id", instanceStatus.ID())
+		scope.Logger().Info("Machine instance state is ERROR", "instance-id", instanceStatus.ID())
 		err = fmt.Errorf("instance state %q is unexpected", instanceStatus.State())
 		openStackMachine.SetFailure(capierrors.UpdateMachineError, err)
 		conditions.MarkFalse(openStackMachine, infrav1.InstanceReadyCondition, infrav1.InstanceStateErrorReason, clusterv1.ConditionSeverityError, "")
 		return ctrl.Result{}, nil
 	case infrav1.InstanceStateDeleted:
 		// we should avoid further actions for DELETED VM
-		scope.Logger.Info("Machine instance state is DELETED, no actions")
+		scope.Logger().Info("Machine instance state is DELETED, no actions")
 		conditions.MarkFalse(openStackMachine, infrav1.InstanceReadyCondition, infrav1.InstanceDeletedReason, clusterv1.ConditionSeverityError, "")
 		return ctrl.Result{}, nil
 	default:
 		// The other state is normal (for example, migrating, shutoff) but we don't want to proceed until it's ACTIVE
 		// due to potential conflict or unexpected actions
-		scope.Logger.Info("Waiting for instance to become ACTIVE", "instance-id", instanceStatus.ID(), "status", instanceStatus.State())
+		scope.Logger().Info("Waiting for instance to become ACTIVE", "instance-id", instanceStatus.ID(), "status", instanceStatus.State())
 		conditions.MarkUnknown(openStackMachine, infrav1.InstanceReadyCondition, infrav1.InstanceNotReadyReason, "Instance state is not handled: %s", instanceStatus.State())
 		return ctrl.Result{RequeueAfter: waitForInstanceBecomeActiveToReconcile}, nil
 	}
 
 	if !util.IsControlPlaneMachine(machine) {
-		scope.Logger.Info("Not a Control plane machine, no floating ip reconcile needed, Reconciled Machine create successfully")
+		scope.Logger().Info("Not a Control plane machine, no floating ip reconcile needed, Reconciled Machine create successfully")
 		return ctrl.Result{}, nil
 	}
 
@@ -419,7 +413,7 @@ func (r *OpenStackMachineReconciler) reconcileNormal(ctx context.Context, scope 
 		}
 
 		if fp.PortID != "" {
-			scope.Logger.Info("Floating IP already associated to a port:", "id", fp.ID, "fixed ip", fp.FixedIP, "portID", port.ID)
+			scope.Logger().Info("Floating IP already associated to a port:", "id", fp.ID, "fixed ip", fp.FixedIP, "portID", port.ID)
 		} else {
 			err = networkingService.AssociateFloatingIP(openStackMachine, fp, port.ID)
 			if err != nil {
@@ -430,7 +424,7 @@ func (r *OpenStackMachineReconciler) reconcileNormal(ctx context.Context, scope 
 	}
 	conditions.MarkTrue(openStackMachine, infrav1.APIServerIngressReadyCondition)
 
-	scope.Logger.Info("Reconciled Machine create successfully")
+	scope.Logger().Info("Reconciled Machine create successfully")
 	return ctrl.Result{}, nil
 }
 
@@ -518,7 +512,7 @@ func machineToInstanceSpec(openStackCluster *infrav1.OpenStackCluster, machine *
 	return &instanceSpec
 }
 
-func (r *OpenStackMachineReconciler) reconcileLoadBalancerMember(scope *scope.Scope, openStackCluster *infrav1.OpenStackCluster, machine *clusterv1.Machine, openStackMachine *infrav1.OpenStackMachine, instanceNS *compute.InstanceNetworkStatus, clusterName string) error {
+func (r *OpenStackMachineReconciler) reconcileLoadBalancerMember(scope scope.Scope, openStackCluster *infrav1.OpenStackCluster, machine *clusterv1.Machine, openStackMachine *infrav1.OpenStackMachine, instanceNS *compute.InstanceNetworkStatus, clusterName string) error {
 	ip := instanceNS.IP(openStackCluster.Status.Network.Name)
 	loadbalancerService, err := loadbalancer.NewService(scope)
 	if err != nil {

--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -53,7 +53,6 @@ import (
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/compute"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/loadbalancer"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/networking"
-	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/provider"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
 )
 
@@ -140,7 +139,7 @@ func (r *OpenStackMachineReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 	}()
 
-	osProviderClient, clientOpts, projectID, err := provider.NewClientFromMachine(ctx, r.Client, openStackMachine)
+	osProviderClient, clientOpts, projectID, err := scope.NewClientFromMachine(ctx, r.Client, openStackMachine)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -29,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2/ktesting"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -44,10 +46,14 @@ var (
 	cfg       *rest.Config
 	k8sClient client.Client
 	testEnv   *envtest.Environment
+	logger    logr.Logger
 )
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
+
+	// Use GinkgoLogr when we upgrade to Ginkgo v2
+	logger, _ = ktesting.NewTestContext(t)
 
 	RunSpecs(t, "Controller Suite")
 }

--- a/controllers/util_test.go
+++ b/controllers/util_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
+)
+
+func getManager(ctx context.Context, logger logr.Logger, scheme *runtime.Scheme) (manager.Manager, func(), func()) {
+	ctrl.SetLogger(logger)
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme,
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	ctx, cancel := context.WithCancel(ctx)
+	run := func() {
+		err = mgr.Start(ctx)
+		Expect(err).NotTo(HaveOccurred(), "failed to run manager")
+	}
+
+	return mgr, run, cancel
+}
+
+func addMachineController(mgr manager.Manager, k8sClient client.Client, scopeFactory scope.Factory) { //nolint:unused
+	err := (&OpenStackMachineReconciler{
+		Client:       k8sClient,
+		Recorder:     mgr.GetEventRecorderFor("openstackmachine-controller"),
+		ScopeFactory: scopeFactory,
+	}).SetupWithManager(ctx, mgr, controller.Options{})
+	Expect(err).ToNot(HaveOccurred())
+}
+
+func addClusterController(mgr manager.Manager, k8sClient client.Client, scopeFactory scope.Factory) {
+	err := (&OpenStackClusterReconciler{
+		Client:       k8sClient,
+		Recorder:     mgr.GetEventRecorderFor("openstackcluster-controller"),
+		ScopeFactory: scopeFactory,
+	}).SetupWithManager(ctx, mgr, controller.Options{})
+	Expect(err).ToNot(HaveOccurred())
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-logr/logr v1.2.3
 	github.com/golang/mock v1.6.0
 	github.com/google/gofuzz v1.2.0
+	github.com/google/uuid v1.3.0
 	github.com/gophercloud/gophercloud v1.1.0
 	github.com/gophercloud/utils v0.0.0-20221128194715-5caf33c866da
 	github.com/hashicorp/go-version v1.4.0
@@ -70,7 +71,6 @@ require (
 	github.com/google/go-github/v45 v45.2.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/safetext v0.0.0-20220905092116-b49f7bc46da2 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/huandu/xstrings v1.3.3 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect

--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-openstack/controllers"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/metrics"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/record"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
 	"sigs.k8s.io/cluster-api-provider-openstack/version"
 )
 
@@ -219,6 +220,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 		Client:           mgr.GetClient(),
 		Recorder:         mgr.GetEventRecorderFor("openstackcluster-controller"),
 		WatchFilterValue: watchFilterValue,
+		ScopeFactory:     scope.ScopeFactory,
 	}).SetupWithManager(ctx, mgr, concurrency(openStackClusterConcurrency)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpenStackCluster")
 		os.Exit(1)
@@ -227,6 +229,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 		Client:           mgr.GetClient(),
 		Recorder:         mgr.GetEventRecorderFor("openstackmachine-controller"),
 		WatchFilterValue: watchFilterValue,
+		ScopeFactory:     scope.ScopeFactory,
 	}).SetupWithManager(ctx, mgr, concurrency(openStackMachineConcurrency)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpenStackMachine")
 		os.Exit(1)

--- a/pkg/clients/compute.go
+++ b/pkg/clients/compute.go
@@ -24,10 +24,10 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"github.com/gophercloud/utils/openstack/clientconfig"
 	"github.com/gophercloud/utils/openstack/compute/v2/flavors"
 
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/metrics"
-	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
 )
 
 /*
@@ -63,9 +63,9 @@ type ComputeClient interface {
 type computeClient struct{ client *gophercloud.ServiceClient }
 
 // NewComputeClient returns a new compute client.
-func NewComputeClient(scope *scope.Scope) (ComputeClient, error) {
-	compute, err := openstack.NewComputeV2(scope.ProviderClient, gophercloud.EndpointOpts{
-		Region: scope.ProviderClientOpts.RegionName,
+func NewComputeClient(providerClient *gophercloud.ProviderClient, providerClientOpts *clientconfig.ClientOpts) (ComputeClient, error) {
+	compute, err := openstack.NewComputeV2(providerClient, gophercloud.EndpointOpts{
+		Region: providerClientOpts.RegionName,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create compute service client: %v", err)

--- a/pkg/clients/image.go
+++ b/pkg/clients/image.go
@@ -22,9 +22,9 @@ import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
+	"github.com/gophercloud/utils/openstack/clientconfig"
 
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/metrics"
-	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
 )
 
 type ImageClient interface {
@@ -34,9 +34,9 @@ type ImageClient interface {
 type imageClient struct{ client *gophercloud.ServiceClient }
 
 // NewImageClient returns a new glance client.
-func NewImageClient(scope *scope.Scope) (ImageClient, error) {
-	images, err := openstack.NewImageServiceV2(scope.ProviderClient, gophercloud.EndpointOpts{
-		Region: scope.ProviderClientOpts.RegionName,
+func NewImageClient(providerClient *gophercloud.ProviderClient, providerClientOpts *clientconfig.ClientOpts) (ImageClient, error) {
+	images, err := openstack.NewImageServiceV2(providerClient, gophercloud.EndpointOpts{
+		Region: providerClientOpts.RegionName,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create image service client: %v", err)

--- a/pkg/clients/loadbalancer.go
+++ b/pkg/clients/loadbalancer.go
@@ -27,9 +27,9 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/providers"
+	"github.com/gophercloud/utils/openstack/clientconfig"
 
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/metrics"
-	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
 	capoerrors "sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/errors"
 )
 
@@ -62,9 +62,9 @@ type lbClient struct {
 }
 
 // NewLbClient returns a new loadbalancer client.
-func NewLbClient(scope *scope.Scope) (LbClient, error) {
-	loadbalancerClient, err := openstack.NewLoadBalancerV2(scope.ProviderClient, gophercloud.EndpointOpts{
-		Region: scope.ProviderClientOpts.RegionName,
+func NewLbClient(providerClient *gophercloud.ProviderClient, providerClientOpts *clientconfig.ClientOpts) (LbClient, error) {
+	loadbalancerClient, err := openstack.NewLoadBalancerV2(providerClient, gophercloud.EndpointOpts{
+		Region: providerClientOpts.RegionName,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create load balancer service client: %v", err)

--- a/pkg/clients/networking.go
+++ b/pkg/clients/networking.go
@@ -31,9 +31,9 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
+	"github.com/gophercloud/utils/openstack/clientconfig"
 
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/metrics"
-	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
 )
 
 type NetworkClient interface {
@@ -94,9 +94,9 @@ type networkClient struct {
 }
 
 // NewNetworkClient returns an instance of the networking service.
-func NewNetworkClient(scope *scope.Scope) (NetworkClient, error) {
-	serviceClient, err := openstack.NewNetworkV2(scope.ProviderClient, gophercloud.EndpointOpts{
-		Region: scope.ProviderClientOpts.RegionName,
+func NewNetworkClient(providerClient *gophercloud.ProviderClient, providerClientOpts *clientconfig.ClientOpts) (NetworkClient, error) {
+	serviceClient, err := openstack.NewNetworkV2(providerClient, gophercloud.EndpointOpts{
+		Region: providerClientOpts.RegionName,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create networking service providerClient: %v", err)

--- a/pkg/clients/simulator/compute.go
+++ b/pkg/clients/simulator/compute.go
@@ -1,0 +1,536 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
+	"k8s.io/utils/pointer"
+
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients"
+)
+
+type (
+	ListAvailabilityZonesPreHook    func() (bool, []availabilityzones.AvailabilityZone, error)
+	ListAvailabilityZonesPostHook   func([]availabilityzones.AvailabilityZone, error)
+	GetFlavorIDFromNamePreHook      func(flavor string) (bool, string, error)
+	GetFlavorIDFromNamePostHook     func(string, string, error)
+	CreateServerPreHook             func(createOpts servers.CreateOptsBuilder) (bool, *clients.ServerExt, error)
+	CreateServerPostHook            func(servers.CreateOptsBuilder, *clients.ServerExt, error)
+	DeleteServerPreHook             func(serverID string) (bool, error)
+	DeleteServerPostHook            func(string, error)
+	GetServerPreHook                func(serverID string) (bool, *clients.ServerExt, error)
+	GetServerPostHook               func(string, *clients.ServerExt, error)
+	ListServersPreHook              func(listOpts servers.ListOptsBuilder) (bool, []clients.ServerExt, error)
+	ListServersPostHook             func(servers.ListOptsBuilder, []clients.ServerExt, error)
+	ListAttachedInterfacesPreHook   func(serverID string) (bool, []attachinterfaces.Interface, error)
+	ListAttachedInterfacesPostHook  func(string, []attachinterfaces.Interface, error)
+	DeleteAttachedInterfacePreHook  func(serverID, portID string) (bool, error)
+	DeleteAttachedInterfacePostHook func(string, string, error)
+)
+
+// ServerExt stores only values the code needs to retrieve. The simulator also
+// needs to store important values we set but never retrieve. SimServer is a
+// superset of ServerExt which also holds import set values.
+type SimServer struct {
+	clients.ServerExt
+
+	ConfigDrive *bool
+	UserData    *string
+}
+
+type ComputeSimulator struct {
+	Simulator *OpenStackSimulator
+
+	Servers           []SimServer
+	Flavors           []flavors.Flavor
+	AvailabilityZones []string
+
+	ListAvailabilityZonesPreHook    ListAvailabilityZonesPreHook
+	ListAvailabilityZonesPostHook   ListAvailabilityZonesPostHook
+	GetFlavorIDFromNamePreHook      GetFlavorIDFromNamePreHook
+	GetFlavorIDFromNamePostHook     GetFlavorIDFromNamePostHook
+	CreateServerPreHook             CreateServerPreHook
+	CreateServerPostHook            CreateServerPostHook
+	DeleteServerPreHook             DeleteServerPreHook
+	DeleteServerPostHook            DeleteServerPostHook
+	GetServerPreHook                GetServerPreHook
+	GetServerPostHook               GetServerPostHook
+	ListServersPreHook              ListServersPreHook
+	ListServersPostHook             ListServersPostHook
+	ListAttachedInterfacesPreHook   ListAttachedInterfacesPreHook
+	ListAttachedInterfacesPostHook  ListAttachedInterfacesPostHook
+	DeleteAttachedInterfacePreHook  DeleteAttachedInterfacePreHook
+	DeleteAttachedInterfacePostHook DeleteAttachedInterfacePostHook
+}
+
+func NewComputeSimulator(p *OpenStackSimulator) *ComputeSimulator {
+	c := &ComputeSimulator{Simulator: p}
+
+	c.CreateServerPostHook = c.CallBackCreateServerSetActive
+
+	return c
+}
+
+const (
+	ServerStatusActive       = "ACTIVE"
+	ServerStatusError        = "ERROR"
+	ServerStatusDeleted      = "DELETED"
+	ServerStatusBuild        = "BUILD"
+	ServerStatusRebuild      = "REBUILD"
+	ServerStatusResize       = "RESIZE"
+	ServerStatusVerifyResize = "VERIFY_RESIZE"
+	ServerStatusMigrating    = "MIGRATING"
+)
+
+/*
+ * Simulator implementation methods
+ */
+
+func (c *ComputeSimulator) ImplListAvailabilityZones() ([]availabilityzones.AvailabilityZone, error) {
+	azs := []availabilityzones.AvailabilityZone{}
+	for _, az := range c.AvailabilityZones {
+		azs = append(azs, availabilityzones.AvailabilityZone{
+			ZoneName: az,
+			ZoneState: availabilityzones.ZoneState{
+				Available: true,
+			},
+		})
+	}
+	return azs, nil
+}
+
+func (c *ComputeSimulator) ImplGetFlavorIDFromName(name string) (string, error) {
+	for _, flavor := range c.Flavors {
+		if flavor.Name == name {
+			return flavor.ID, nil
+		}
+	}
+
+	return "", &gophercloud.ErrResourceNotFound{Name: name, ResourceType: "flavor"}
+}
+
+func (c *ComputeSimulator) ImplCreateServer(createOpts servers.CreateOptsBuilder) (*clients.ServerExt, error) {
+	createMap, err := createOpts.ToServerCreateMap()
+	if err != nil {
+		return nil, fmt.Errorf("CreateServer: creating server map: %w", err)
+	}
+	createMap, ok := createMap["server"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("CreateServer: create map does not contain server")
+	}
+
+	server := SimServer{}
+	server.ID = generateUUID()
+	server.Status = ServerStatusBuild
+
+	if flavorRef, ok := createMap["flavorRef"]; ok {
+		flavor := func() *flavors.Flavor {
+			for _, flavor := range c.Flavors {
+				if flavor.ID == flavorRef {
+					return &flavor
+				}
+			}
+			return nil
+		}()
+		if flavor == nil {
+			// XXX: 400 return is a guess
+			return nil, &gophercloud.ErrDefault400{
+				ErrUnexpectedResponseCode: gophercloud.ErrUnexpectedResponseCode{
+					BaseError: gophercloud.BaseError{
+						Info: fmt.Sprintf("Unknown flavorRef: %s", flavorRef),
+					},
+				},
+			}
+		}
+
+		// XXX: This flavor map is not correct. We will need to fix it if we ever have code using it.
+		server.Flavor = make(map[string]interface{})
+		server.Flavor["id"] = flavor.ID
+		server.Flavor["name"] = flavor.Name
+
+		delete(createMap, "flavorRef")
+	} else {
+		// XXX: 400 return is a guess
+		return nil, &gophercloud.ErrDefault400{
+			ErrUnexpectedResponseCode: gophercloud.ErrUnexpectedResponseCode{
+				BaseError: gophercloud.BaseError{
+					Info: "Server create without flavor",
+				},
+			},
+		}
+	}
+
+	if imageRef, ok := createMap["imageRef"]; ok {
+		image := func() *images.Image {
+			for _, image := range c.Simulator.Image.Images {
+				if image.ID == imageRef {
+					return &image
+				}
+			}
+			return nil
+		}()
+		if image == nil {
+			// XXX: 400 return is a guess
+			return nil, &gophercloud.ErrDefault400{
+				ErrUnexpectedResponseCode: gophercloud.ErrUnexpectedResponseCode{
+					BaseError: gophercloud.BaseError{
+						Info: fmt.Sprintf("Unknown imageRef: %s", imageRef),
+					},
+				},
+			}
+		}
+
+		// XXX: This image map is not correct. We will need to fix it if we ever have code using it.
+		server.Image = make(map[string]interface{})
+		server.Image["id"] = image.ID
+		server.Image["name"] = image.Name
+
+		delete(createMap, "imageRef")
+	}
+
+	var ports []*ports.Port
+	for k, v := range createMap {
+		switch k {
+		case "config_drive":
+			server.ConfigDrive = pointer.Bool(v.(bool))
+		case "name":
+			server.Name = v.(string)
+		case "networks":
+			if createMap[k] == nil {
+				break
+			}
+			networks := createMap[k].([]map[string]interface{})
+			for _, networkDef := range networks {
+				for k, v := range networkDef {
+					if k != "port" {
+						panic(fmt.Errorf("CreateServer: simulator only supports networks by port id, given %+v", networkDef))
+					}
+					portID := v.(string)
+					port, err := c.Simulator.Network.GetPort(portID)
+					if err != nil {
+						return nil, fmt.Errorf("CreateServer: %w", err)
+					}
+					ports = append(ports, port)
+				}
+			}
+		case "user_data":
+			server.UserData = v.(*string)
+		case "key_name":
+			server.KeyName = v.(string)
+		case "availability_zone":
+			server.AvailabilityZone = v.(string)
+		default:
+			panic(fmt.Errorf("CreateServer: simulator does not support %s:%+v", k, v))
+		}
+	}
+
+	addresses := make(map[string]interface{})
+	server.Addresses = addresses
+	for _, port := range ports {
+		c.Simulator.Network.SimAttachPort(port.ID, server.ID)
+
+		network, err := c.Simulator.Network.GetNetwork(port.NetworkID)
+		if err != nil {
+			// This should only be a simulator bug
+			panic(fmt.Errorf("CreateServer: port with id %s references network with id %s, which doesn't exist", port.ID, port.NetworkID))
+		}
+
+		networkAddresses := func() []map[string]interface{} {
+			if networkAddresses, ok := addresses[network.Name]; ok {
+				return networkAddresses.([]map[string]interface{})
+			}
+			return nil
+		}()
+
+		for _, fixedIP := range port.FixedIPs {
+			networkAddresses = append(networkAddresses, map[string]interface{}{
+				"addr":            fixedIP.IPAddress,
+				"version":         4,
+				"OS-EXT-IPS:type": "fixed",
+			})
+		}
+		addresses[network.Name] = networkAddresses
+	}
+
+	c.Servers = append(c.Servers, server)
+	return &server.ServerExt, nil
+}
+
+func (c *ComputeSimulator) ImplDeleteServer(serverID string) error {
+	for i := range c.Servers {
+		server := &c.Servers[i]
+		if server.ID == serverID {
+			c.Servers = append(c.Servers[:i], c.Servers[i+1:]...)
+			return nil
+		}
+	}
+
+	err := &gophercloud.ErrDefault404{}
+	err.Info = fmt.Sprintf("DeleteServer: Server %s not found", serverID)
+	return err
+}
+
+func (c *ComputeSimulator) ImplGetServer(serverID string) (*clients.ServerExt, error) {
+	for _, server := range c.Servers {
+		if server.ID == serverID {
+			retCopy := server.ServerExt
+			return &retCopy, nil
+		}
+	}
+
+	return nil, &gophercloud.ErrDefault404{
+		ErrUnexpectedResponseCode: gophercloud.ErrUnexpectedResponseCode{
+			BaseError: gophercloud.BaseError{
+				Info: fmt.Sprintf("no server with ID %s", serverID),
+			},
+		},
+	}
+}
+
+func (c *ComputeSimulator) ImplListServers(listOpts servers.ListOptsBuilder) ([]clients.ServerExt, error) {
+	query, err := listOpts.ToServerListQuery()
+	if err != nil {
+		return nil, fmt.Errorf("creating server list query: %w", err)
+	}
+	name, err := getNameFromQuery(query)
+	if err != nil {
+		return nil, fmt.Errorf("ListServers: %w", err)
+	}
+	nameRegexp, err := regexp.Compile(name)
+	if err != nil {
+		return nil, fmt.Errorf("compiling name regexp in ListServers: %w", err)
+	}
+
+	ret := []clients.ServerExt{}
+	for _, server := range c.Servers {
+		if nameRegexp.MatchString(server.Name) {
+			ret = append(ret, server.ServerExt)
+		}
+	}
+
+	return ret, nil
+}
+
+func (c *ComputeSimulator) ImplListAttachedInterfaces(serverID string) ([]attachinterfaces.Interface, error) {
+	interfaces := []attachinterfaces.Interface{}
+
+	for _, port := range c.Simulator.Network.Ports {
+		if port.DeviceID == serverID {
+			fixedIPs := []attachinterfaces.FixedIP{}
+			for _, fixedIP := range port.FixedIPs {
+				fixedIPs = append(fixedIPs, attachinterfaces.FixedIP{
+					SubnetID: fixedIP.SubnetID,
+				})
+			}
+			interfaces = append(interfaces, attachinterfaces.Interface{
+				PortState: port.Status,
+				FixedIPs:  fixedIPs,
+				PortID:    port.ID,
+				NetID:     port.NetworkID,
+				// MACAddr:   "",
+			})
+		}
+	}
+
+	return interfaces, nil
+}
+
+func (c *ComputeSimulator) ImplDeleteAttachedInterface(serverID, portID string) error {
+	port, err := c.Simulator.Network.GetPort(portID)
+	if err != nil {
+		return fmt.Errorf("DeleteAttachedInterface: %w", err)
+	}
+
+	if port.DeviceID != serverID {
+		return fmt.Errorf("DeleteAttachedInterface: port %s is not attached to server %s", portID, serverID)
+	}
+
+	return c.Simulator.Network.DeletePort(portID)
+}
+
+/*
+ * Callback handler stubs
+ */
+
+func (c *ComputeSimulator) ListAvailabilityZones() ([]availabilityzones.AvailabilityZone, error) {
+	if c.ListAvailabilityZonesPreHook != nil {
+		handled, azs, err := c.ListAvailabilityZonesPreHook()
+		if handled {
+			return azs, err
+		}
+	}
+	azs, err := c.ImplListAvailabilityZones()
+	if c.ListAvailabilityZonesPostHook != nil {
+		c.ListAvailabilityZonesPostHook(azs, err)
+	}
+	return azs, err
+}
+
+func (c *ComputeSimulator) GetFlavorIDFromName(name string) (string, error) {
+	if c.GetFlavorIDFromNamePreHook != nil {
+		handled, flavorID, err := c.GetFlavorIDFromNamePreHook(name)
+		if handled {
+			return flavorID, err
+		}
+	}
+	flavorID, err := c.ImplGetFlavorIDFromName(name)
+	if c.GetFlavorIDFromNamePostHook != nil {
+		c.GetFlavorIDFromNamePostHook(name, flavorID, err)
+	}
+	return flavorID, err
+}
+
+func (c *ComputeSimulator) CreateServer(createOpts servers.CreateOptsBuilder) (*clients.ServerExt, error) {
+	if c.CreateServerPreHook != nil {
+		handled, server, err := c.CreateServerPreHook(createOpts)
+		if handled {
+			return server, err
+		}
+	}
+	server, err := c.ImplCreateServer(createOpts)
+	if c.CreateServerPostHook != nil {
+		c.CreateServerPostHook(createOpts, server, err)
+	}
+	return server, err
+}
+
+func (c *ComputeSimulator) DeleteServer(serverID string) error {
+	if c.DeleteServerPreHook != nil {
+		handled, err := c.DeleteServerPreHook(serverID)
+		if handled {
+			return err
+		}
+	}
+	err := c.ImplDeleteServer(serverID)
+	if c.DeleteServerPostHook != nil {
+		c.DeleteServerPostHook(serverID, err)
+	}
+	return err
+}
+
+func (c *ComputeSimulator) GetServer(serverID string) (*clients.ServerExt, error) {
+	if c.GetServerPreHook != nil {
+		handled, server, err := c.GetServerPreHook(serverID)
+		if handled {
+			return server, err
+		}
+	}
+	server, err := c.ImplGetServer(serverID)
+	if c.GetServerPostHook != nil {
+		c.GetServerPostHook(serverID, server, err)
+	}
+	return server, err
+}
+
+func (c *ComputeSimulator) ListServers(listOpts servers.ListOptsBuilder) ([]clients.ServerExt, error) {
+	if c.ListServersPreHook != nil {
+		handled, servers, err := c.ListServersPreHook(listOpts)
+		if handled {
+			return servers, err
+		}
+	}
+	servers, err := c.ImplListServers(listOpts)
+	if c.ListServersPostHook != nil {
+		c.ListServersPostHook(listOpts, servers, err)
+	}
+	return servers, err
+}
+
+func (c *ComputeSimulator) ListAttachedInterfaces(serverID string) ([]attachinterfaces.Interface, error) {
+	if c.ListAttachedInterfacesPreHook != nil {
+		handled, interfaces, err := c.ListAttachedInterfacesPreHook(serverID)
+		if handled {
+			return interfaces, err
+		}
+	}
+	interfaces, err := c.ImplListAttachedInterfaces(serverID)
+	if c.ListAttachedInterfacesPostHook != nil {
+		c.ListAttachedInterfacesPostHook(serverID, interfaces, err)
+	}
+	return interfaces, err
+}
+
+func (c *ComputeSimulator) DeleteAttachedInterface(serverID, portID string) error {
+	if c.DeleteAttachedInterfacePreHook != nil {
+		handled, err := c.DeleteAttachedInterfacePreHook(serverID, portID)
+		if handled {
+			return err
+		}
+	}
+	err := c.ImplDeleteAttachedInterface(serverID, portID)
+	if c.DeleteAttachedInterfacePostHook != nil {
+		c.DeleteAttachedInterfacePostHook(serverID, portID, err)
+	}
+	return err
+}
+
+/*
+ * Simulator state helpers
+ */
+
+func (c *ComputeSimulator) SimAddFlavor(name, uuid string) {
+	c.Flavors = append(c.Flavors, flavors.Flavor{
+		Name: name,
+		ID:   uuid,
+	})
+}
+
+func (c *ComputeSimulator) SimAddAvailabilityZone(name string) {
+	c.AvailabilityZones = append(c.AvailabilityZones, name)
+}
+
+func (c *ComputeSimulator) SimGetServer(id string) *SimServer {
+	for _, server := range c.Servers {
+		if server.ID == id {
+			return &server
+		}
+	}
+	return nil
+}
+
+/*
+ * Default callbacks
+ */
+
+func (c *ComputeSimulator) CallBackCreateServerSetActive(_ servers.CreateOptsBuilder, createdServer *clients.ServerExt, err error) {
+	if err != nil || createdServer.Status != ServerStatusBuild {
+		return
+	}
+
+	go func() {
+		c.Simulator.DefaultDelay()
+
+		for i := range c.Servers {
+			server := &c.Servers[i]
+			if server.ID == createdServer.ID {
+				if server.Status == ServerStatusBuild {
+					server.Status = ServerStatusActive
+				}
+				return
+			}
+		}
+	}()
+}

--- a/pkg/clients/simulator/image.go
+++ b/pkg/clients/simulator/image.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"fmt"
+
+	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
+)
+
+type (
+	ListImagesPreHook  func(listOpts images.ListOptsBuilder) (bool, []images.Image, error)
+	ListImagesPostHook func(images.ListOptsBuilder, []images.Image, error)
+)
+
+type ImageSimulator struct {
+	Simulator *OpenStackSimulator
+
+	Images []images.Image
+
+	ListImagesPreHook  ListImagesPreHook
+	ListImagesPostHook ListImagesPostHook
+}
+
+func NewImageSimulator(p *OpenStackSimulator) *ImageSimulator {
+	return &ImageSimulator{Simulator: p}
+}
+
+/*
+ * Simulator implementation methods
+ */
+
+func (c *ImageSimulator) ImplListImages(listOpts images.ListOptsBuilder) ([]images.Image, error) {
+	query, err := listOpts.ToImageListQuery()
+	if err != nil {
+		return nil, fmt.Errorf("creating image list query: %w", err)
+	}
+	name, err := getNameFromQuery(query)
+	if err != nil {
+		return nil, fmt.Errorf("ListImages: %w", err)
+	}
+
+	images := []images.Image{}
+	for _, image := range c.Images {
+		if image.Name == name {
+			images = append(images, image)
+		}
+	}
+
+	return images, nil
+}
+
+/*
+ * Callback handler stubs
+ */
+
+func (c *ImageSimulator) ListImages(listOpts images.ListOptsBuilder) ([]images.Image, error) {
+	if c.ListImagesPreHook != nil {
+		handled, images, err := c.ListImagesPreHook(listOpts)
+		if handled {
+			return images, err
+		}
+	}
+
+	images, err := c.ImplListImages(listOpts)
+
+	if c.ListImagesPostHook != nil {
+		c.ListImagesPostHook(listOpts, images, err)
+	}
+
+	return images, err
+}
+
+/*
+ * Simulator state helpers
+ */
+
+func (c *ImageSimulator) SimAddImage(name, id string) {
+	c.Images = append(c.Images, images.Image{
+		Name: name,
+		ID:   id,
+	})
+}

--- a/pkg/clients/simulator/loadbalancer.go
+++ b/pkg/clients/simulator/loadbalancer.go
@@ -1,0 +1,1042 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"fmt"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/apiversions"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/providers"
+)
+
+type (
+	CreateLoadBalancerPreHook         func(loadbalancers.CreateOptsBuilder) (bool, *loadbalancers.LoadBalancer, error)
+	CreateLoadBalancerPostHook        func(loadbalancers.CreateOptsBuilder, *loadbalancers.LoadBalancer, error)
+	ListLoadBalancersPreHook          func(opts loadbalancers.ListOptsBuilder) (bool, []loadbalancers.LoadBalancer, error)
+	ListLoadBalancersPostHook         func(loadbalancers.ListOptsBuilder, []loadbalancers.LoadBalancer, error)
+	GetLoadBalancerPreHook            func(id string) (bool, *loadbalancers.LoadBalancer, error)
+	GetLoadBalancerPostHook           func(string, *loadbalancers.LoadBalancer, error)
+	DeleteLoadBalancerPreHook         func(id string, opts loadbalancers.DeleteOptsBuilder) (bool, error)
+	DeleteLoadBalancerPostHook        func(string, loadbalancers.DeleteOptsBuilder, error)
+	CreateListenerPreHook             func(opts listeners.CreateOptsBuilder) (bool, *listeners.Listener, error)
+	CreateListenerPostHook            func(listeners.CreateOptsBuilder, *listeners.Listener, error)
+	ListListenersPreHook              func(opts listeners.ListOptsBuilder) (bool, []listeners.Listener, error)
+	ListListenersPostHook             func(listeners.ListOptsBuilder, []listeners.Listener, error)
+	UpdateListenerPreHook             func(id string, opts listeners.UpdateOpts) (bool, *listeners.Listener, error)
+	UpdateListenerPostHook            func(string, listeners.UpdateOpts, *listeners.Listener, error)
+	GetListenerPreHook                func(id string) (bool, *listeners.Listener, error)
+	GetListenerPostHook               func(string, *listeners.Listener, error)
+	DeleteListenerPreHook             func(id string) (bool, error)
+	DeleteListenerPostHook            func(string, error)
+	CreatePoolPreHook                 func(opts pools.CreateOptsBuilder) (bool, *pools.Pool, error)
+	CreatePoolPostHook                func(pools.CreateOptsBuilder, *pools.Pool, error)
+	ListPoolsPreHook                  func(opts pools.ListOptsBuilder) (bool, []pools.Pool, error)
+	ListPoolsPostHook                 func(pools.ListOptsBuilder, []pools.Pool, error)
+	GetPoolPreHook                    func(id string) (bool, *pools.Pool, error)
+	GetPoolPostHook                   func(string, *pools.Pool, error)
+	DeletePoolPreHook                 func(id string) (bool, error)
+	DeletePoolPostHook                func(string, error)
+	CreatePoolMemberPreHook           func(poolID string, opts pools.CreateMemberOptsBuilder) (bool, *pools.Member, error)
+	CreatePoolMemberPostHook          func(string, pools.CreateMemberOptsBuilder, *pools.Member, error)
+	ListPoolMemberPreHook             func(poolID string, opts pools.ListMembersOptsBuilder) (bool, []pools.Member, error)
+	ListPoolMemberPostHook            func(string, pools.ListMembersOptsBuilder, []pools.Member, error)
+	DeletePoolMemberPreHook           func(poolID string, lbMemberID string) (bool, error)
+	DeletePoolMemberPostHook          func(string, string, error)
+	CreateMonitorPreHook              func(opts monitors.CreateOptsBuilder) (bool, *monitors.Monitor, error)
+	CreateMonitorPostHook             func(monitors.CreateOptsBuilder, *monitors.Monitor, error)
+	ListMonitorsPreHook               func(opts monitors.ListOptsBuilder) (bool, []monitors.Monitor, error)
+	ListMonitorsPostHook              func(monitors.ListOptsBuilder, []monitors.Monitor, error)
+	DeleteMonitorPreHook              func(id string) (bool, error)
+	DeleteMonitorPostHook             func(string, error)
+	ListLoadBalancerProvidersPreHook  func() (bool, []providers.Provider, error)
+	ListLoadBalancerProvidersPostHook func([]providers.Provider, error)
+	ListOctaviaVersionsPreHook        func() (bool, []apiversions.APIVersion, error)
+	ListOctaviaVersionsPostHook       func([]apiversions.APIVersion, error)
+)
+
+type LbSimulator struct {
+	Simulator *OpenStackSimulator
+
+	Listeners             []listeners.Listener
+	LoadBalancers         []loadbalancers.LoadBalancer
+	Monitors              []monitors.Monitor
+	Pools                 []pools.Pool
+	Providers             []providers.Provider
+	OctaviaCurrentVersion string
+
+	CreateLoadBalancerPreHook         CreateLoadBalancerPreHook
+	CreateLoadBalancerPostHook        CreateLoadBalancerPostHook
+	ListLoadBalancersPreHook          ListLoadBalancersPreHook
+	ListLoadBalancersPostHook         ListLoadBalancersPostHook
+	GetLoadBalancerPreHook            GetLoadBalancerPreHook
+	GetLoadBalancerPostHook           GetLoadBalancerPostHook
+	DeleteLoadBalancerPreHook         DeleteLoadBalancerPreHook
+	DeleteLoadBalancerPostHook        DeleteLoadBalancerPostHook
+	CreateListenerPreHook             CreateListenerPreHook
+	CreateListenerPostHook            CreateListenerPostHook
+	ListListenersPreHook              ListListenersPreHook
+	ListListenersPostHook             ListListenersPostHook
+	UpdateListenerPreHook             UpdateListenerPreHook
+	UpdateListenerPostHook            UpdateListenerPostHook
+	GetListenerPreHook                GetListenerPreHook
+	GetListenerPostHook               GetListenerPostHook
+	DeleteListenerPreHook             DeleteListenerPreHook
+	DeleteListenerPostHook            DeleteListenerPostHook
+	CreatePoolPreHook                 CreatePoolPreHook
+	CreatePoolPostHook                CreatePoolPostHook
+	ListPoolsPreHook                  ListPoolsPreHook
+	ListPoolsPostHook                 ListPoolsPostHook
+	GetPoolPreHook                    GetPoolPreHook
+	GetPoolPostHook                   GetPoolPostHook
+	DeletePoolPreHook                 DeletePoolPreHook
+	DeletePoolPostHook                DeletePoolPostHook
+	CreatePoolMemberPreHook           CreatePoolMemberPreHook
+	CreatePoolMemberPostHook          CreatePoolMemberPostHook
+	ListPoolMemberPreHook             ListPoolMemberPreHook
+	ListPoolMemberPostHook            ListPoolMemberPostHook
+	DeletePoolMemberPreHook           DeletePoolMemberPreHook
+	DeletePoolMemberPostHook          DeletePoolMemberPostHook
+	CreateMonitorPreHook              CreateMonitorPreHook
+	CreateMonitorPostHook             CreateMonitorPostHook
+	ListMonitorsPreHook               ListMonitorsPreHook
+	ListMonitorsPostHook              ListMonitorsPostHook
+	DeleteMonitorPreHook              DeleteMonitorPreHook
+	DeleteMonitorPostHook             DeleteMonitorPostHook
+	ListLoadBalancerProvidersPreHook  ListLoadBalancerProvidersPreHook
+	ListLoadBalancerProvidersPostHook ListLoadBalancerProvidersPostHook
+	ListOctaviaVersionsPreHook        ListOctaviaVersionsPreHook
+	ListOctaviaVersionsPostHook       ListOctaviaVersionsPostHook
+}
+
+const (
+	OperatingStatusOnline           = "ONLINE"
+	OperatingStatusDraining         = "DRAINING"
+	OperatingStatusOffline          = "OFFLINE"
+	OperatingStatusDegraded         = "DEGRADED"
+	OperatingStatusError            = "ERROR"
+	OperatingStatusNoMonitor        = "NO_MONITOR"
+	ProvisioningStatusActive        = "ACTIVE"
+	ProvisioningStatusDeleted       = "DELETED"
+	ProvisioningStatusError         = "ERROR"
+	ProvisioningStatusPendingCreate = "PENDING_CREATE"
+	ProvisioningStatusPendingUpdate = "PENDING_UPDATE"
+	ProvisioningStatusPendingDelete = "PENDING_DELETE"
+)
+
+func NewLbSimulator(p *OpenStackSimulator) *LbSimulator {
+	s := LbSimulator{Simulator: p}
+
+	s.SimAddLoadBalancerProvider("amphora")
+	s.SimSetOctaviaCurrentVersion("v2.14")
+	s.CreateLoadBalancerPostHook = s.CallBackCreateLoadbalancerSetActive
+	s.CreateListenerPostHook = s.CallBackCreateListenerSetActive
+
+	return &s
+}
+
+/*
+ * Simulator implementation methods
+ */
+
+func (c *LbSimulator) ImplCreateLoadBalancer(opts loadbalancers.CreateOptsBuilder) (*loadbalancers.LoadBalancer, error) {
+	createMap, err := opts.ToLoadBalancerCreateMap()
+	if err != nil {
+		return nil, fmt.Errorf("CreateLoadBalancer: creating loadbalancer map: %w", err)
+	}
+	createMap, ok := createMap["loadbalancer"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("CreateLoadBalancer: create map doesn't contain loadbalancer")
+	}
+
+	loadBalancer := loadbalancers.LoadBalancer{}
+	loadBalancer.ID = generateUUID()
+	loadBalancer.ProvisioningStatus = ProvisioningStatusPendingCreate
+
+	for k, v := range createMap {
+		switch k {
+		case "description":
+			loadBalancer.Description = v.(string)
+		case "name":
+			loadBalancer.Name = v.(string)
+		case "provider":
+			loadBalancer.Provider = v.(string)
+		case "vip_subnet_id":
+			subnet, err := c.Simulator.Network.GetSubnet(v.(string))
+			if err != nil {
+				return nil, fmt.Errorf("CreateLoadBalancer: getting VIP subnet: %w", err)
+			}
+
+			loadBalancer.VipSubnetID = subnet.ID
+		default:
+			panic(fmt.Errorf("CreateLoadBalancer: unsupported create parameter %s", k))
+		}
+	}
+
+	c.LoadBalancers = append(c.LoadBalancers, loadBalancer)
+	return &loadBalancer, nil
+}
+
+func (c *LbSimulator) ImplListLoadBalancers(opts loadbalancers.ListOptsBuilder) ([]loadbalancers.LoadBalancer, error) {
+	query, err := opts.ToLoadBalancerListQuery()
+	if err != nil {
+		return nil, fmt.Errorf("ListLoadBalancers: creating loadbalancer query: %w", err)
+	}
+	values, err := getValuesFromQuery(query)
+	if err != nil {
+		return nil, fmt.Errorf("ListLoadBalancers: %w", err)
+	}
+
+	ret := []loadbalancers.LoadBalancer{}
+loadbalancers:
+	for _, lb := range c.LoadBalancers {
+		for k, v := range values {
+			switch k {
+			case "name":
+				if lb.Name != v {
+					continue loadbalancers
+				}
+			default:
+				panic(fmt.Errorf("ListLoadBalancers: unsupported query parameter %s", k))
+			}
+		}
+
+		ret = append(ret, lb)
+	}
+
+	return ret, nil
+}
+
+func (c *LbSimulator) ImplGetLoadBalancer(id string) (*loadbalancers.LoadBalancer, error) {
+	for _, lb := range c.LoadBalancers {
+		if lb.ID == id {
+			retCopy := lb
+			return &retCopy, nil
+		}
+	}
+
+	return nil, &gophercloud.ErrDefault404{
+		ErrUnexpectedResponseCode: gophercloud.ErrUnexpectedResponseCode{
+			BaseError: gophercloud.BaseError{
+				Info: fmt.Sprintf("GetLoadBalancer: Loadbalancer %s not found", id),
+			},
+		},
+	}
+}
+
+func (c *LbSimulator) ImplDeleteLoadBalancer(id string, opts loadbalancers.DeleteOptsBuilder) error {
+	query, err := opts.ToLoadBalancerDeleteQuery()
+	if err != nil {
+		return fmt.Errorf("DeleteLoadBalancer: creating loadbalancer delete opts: %w", err)
+	}
+	values, err := getValuesFromQuery(query)
+	if err != nil {
+		return fmt.Errorf("DeleteLoadBalancer: %w", err)
+	}
+
+	getListeners := func() []listeners.Listener {
+		var listeners []listeners.Listener
+		for _, listener := range c.Listeners {
+			for _, lb := range listener.Loadbalancers {
+				if lb.ID == id {
+					listeners = append(listeners, listener)
+				}
+			}
+		}
+		return listeners
+	}
+
+	getPools := func() []pools.Pool {
+		var pools []pools.Pool
+		for _, pool := range c.Pools {
+			for _, lb := range pool.Loadbalancers {
+				if lb.ID == id {
+					pools = append(pools, pool)
+				}
+			}
+		}
+		return pools
+	}
+
+	// XXX: Does cascade delete anything else? Monitors?
+	// Are there any cases where we wouldn't delete resources because they are shared?
+	cascade := func() error {
+		for _, listener := range getListeners() {
+			err := c.DeleteListener(listener.ID)
+			if err != nil {
+				return fmt.Errorf("DeleteLoadBalancer: deleting listener %s: %w", listener.ID, err)
+			}
+		}
+
+		for _, pool := range getPools() {
+			err := c.DeletePool(pool.ID)
+			if err != nil {
+				return fmt.Errorf("DeleteLoadBalancer: deleting pool %s: %w", pool.ID, err)
+			}
+		}
+
+		return nil
+	}
+
+	for k, v := range values {
+		switch k {
+		case "cascade":
+			if v == "true" {
+				err = cascade()
+				if err != nil {
+					return fmt.Errorf("DeleteLoadBalancer: %w", err)
+				}
+			}
+		default:
+			panic(fmt.Errorf("DeleteLoadBalancer: unsupported query parameter %s", k))
+		}
+	}
+
+	if len(getPools()) > 0 || len(getListeners()) > 0 {
+		return &gophercloud.ErrDefault409{
+			ErrUnexpectedResponseCode: gophercloud.ErrUnexpectedResponseCode{
+				BaseError: gophercloud.BaseError{
+					Info: fmt.Sprintf("DeleteLoadBalancer: Loadbalancer %s has associated resources", id),
+				},
+			},
+		}
+	}
+
+	for i, lb := range c.LoadBalancers {
+		if lb.ID == id {
+			c.LoadBalancers = append(c.LoadBalancers[:i], c.LoadBalancers[i+1:]...)
+			return nil
+		}
+	}
+
+	return &gophercloud.ErrDefault404{
+		ErrUnexpectedResponseCode: gophercloud.ErrUnexpectedResponseCode{
+			BaseError: gophercloud.BaseError{
+				Info: fmt.Sprintf("DeleteLoadBalancer: Loadbalancer %s not found", id),
+			},
+		},
+	}
+}
+
+func (c *LbSimulator) ImplCreateListener(opts listeners.CreateOptsBuilder) (*listeners.Listener, error) {
+	createMap, err := opts.ToListenerCreateMap()
+	if err != nil {
+		return nil, fmt.Errorf("CreateListener: creating listener map: %w", err)
+	}
+	createMap, ok := createMap["listener"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("CreateListener: create map doesn't contain listener")
+	}
+
+	listener := listeners.Listener{}
+	listener.ID = generateUUID()
+	listener.ProvisioningStatus = ProvisioningStatusPendingCreate
+
+	for k, v := range createMap {
+		switch k {
+		case "loadbalancer_id":
+			lb, err := c.GetLoadBalancer(v.(string))
+			if err != nil {
+				return nil, fmt.Errorf("CreateListener: %w", err)
+			}
+			// Not sure why this is a list
+			listener.Loadbalancers = []listeners.LoadBalancerID{{ID: lb.ID}}
+		case "name":
+			listener.Name = v.(string)
+		case "protocol":
+			listener.Protocol = v.(string)
+		case "protocol_port":
+			listener.ProtocolPort = int(v.(float64))
+		default:
+			panic(fmt.Errorf("CreateListener: unsupported create parameter %s", k))
+		}
+	}
+
+	c.Listeners = append(c.Listeners, listener)
+	return &listener, nil
+}
+
+func (c *LbSimulator) ImplListListeners(opts listeners.ListOptsBuilder) ([]listeners.Listener, error) {
+	query, err := opts.ToListenerListQuery()
+	if err != nil {
+		return nil, fmt.Errorf("ListListeners: creating listener query: %w", err)
+	}
+	values, err := getValuesFromQuery(query)
+	if err != nil {
+		return nil, fmt.Errorf("ListListeners: %w", err)
+	}
+
+	listeners := []listeners.Listener{}
+listeners:
+	for _, listener := range c.Listeners {
+		for k, v := range values {
+			switch k {
+			case "name":
+				if listener.Name != v {
+					continue listeners
+				}
+			default:
+				panic(fmt.Errorf("ListListeners: unsupported query parameter %s", k))
+			}
+		}
+		listeners = append(listeners, listener)
+	}
+
+	return listeners, nil
+}
+
+func (c *LbSimulator) ImplUpdateListener(id string, opts listeners.UpdateOpts) (*listeners.Listener, error) {
+	panic(fmt.Errorf("UpdateListener not implemented"))
+}
+
+func (c *LbSimulator) ImplGetListener(id string) (*listeners.Listener, error) {
+	for _, listener := range c.Listeners {
+		if listener.ID == id {
+			retCopy := listener
+			return &retCopy, nil
+		}
+	}
+
+	return nil, &gophercloud.ErrDefault404{
+		ErrUnexpectedResponseCode: gophercloud.ErrUnexpectedResponseCode{
+			BaseError: gophercloud.BaseError{
+				Info: fmt.Sprintf("GetListener: Listener %s not found", id),
+			},
+		},
+	}
+}
+
+func (c *LbSimulator) ImplDeleteListener(id string) error {
+	for i, listener := range c.Listeners {
+		if listener.ID == id {
+			c.Listeners = append(c.Listeners[:i], c.Listeners[i+1:]...)
+			return nil
+		}
+	}
+
+	return &gophercloud.ErrDefault404{
+		ErrUnexpectedResponseCode: gophercloud.ErrUnexpectedResponseCode{
+			BaseError: gophercloud.BaseError{
+				Info: fmt.Sprintf("DeleteListener: Listener %s not found", id),
+			},
+		},
+	}
+}
+
+func (c *LbSimulator) ImplCreatePool(opts pools.CreateOptsBuilder) (*pools.Pool, error) {
+	createMap, err := opts.ToPoolCreateMap()
+	if err != nil {
+		return nil, fmt.Errorf("CreatePool: creating pool map: %w", err)
+	}
+	createMap, ok := createMap["pool"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("CreatePool: create map doesn't contain pool")
+	}
+
+	pool := pools.Pool{}
+	pool.ID = generateUUID()
+	pool.ProvisioningStatus = ProvisioningStatusPendingCreate
+
+	for k, v := range createMap {
+		switch k {
+		case "name":
+			pool.Name = v.(string)
+		case "protocol":
+			pool.Protocol = v.(string)
+		case "lb_algorithm":
+			pool.LBMethod = v.(string)
+		case "listener_id":
+			listener, err := c.GetListener(v.(string))
+			if err != nil {
+				return nil, fmt.Errorf("CreatePool: %w", err)
+			}
+			pool.Listeners = []pools.ListenerID{{ID: listener.ID}}
+		default:
+			panic(fmt.Errorf("CreatePool: unsupported create parameter %s", k))
+		}
+	}
+
+	c.Pools = append(c.Pools, pool)
+	return &pool, nil
+}
+
+func (c *LbSimulator) ImplListPools(opts pools.ListOptsBuilder) ([]pools.Pool, error) {
+	query, err := opts.ToPoolListQuery()
+	if err != nil {
+		return nil, fmt.Errorf("ListPools: creating pool query: %w", err)
+	}
+	values, err := getValuesFromQuery(query)
+	if err != nil {
+		return nil, fmt.Errorf("ListPools: %w", err)
+	}
+
+	pools := []pools.Pool{}
+pools:
+	for _, pool := range c.Pools {
+		for k, v := range values {
+			switch k {
+			case "name":
+				if pool.Name != v {
+					continue pools
+				}
+			default:
+				panic(fmt.Errorf("ListPools: unsupported query parameter %s", k))
+			}
+		}
+		pools = append(pools, pool)
+	}
+
+	return pools, nil
+}
+
+func (c *LbSimulator) ImplGetPool(id string) (*pools.Pool, error) {
+	for _, pool := range c.Pools {
+		if pool.ID == id {
+			retCopy := pool
+			return &retCopy, nil
+		}
+	}
+
+	return nil, &gophercloud.ErrDefault404{
+		ErrUnexpectedResponseCode: gophercloud.ErrUnexpectedResponseCode{
+			BaseError: gophercloud.BaseError{
+				Info: fmt.Sprintf("GetPool: Pool %s not found", id),
+			},
+		},
+	}
+}
+
+func (c *LbSimulator) ImplDeletePool(id string) error {
+	for i, pool := range c.Pools {
+		if pool.ID == id {
+			c.Pools = append(c.Pools[:i], c.Pools[i+1:]...)
+			return nil
+		}
+	}
+
+	return &gophercloud.ErrDefault404{
+		ErrUnexpectedResponseCode: gophercloud.ErrUnexpectedResponseCode{
+			BaseError: gophercloud.BaseError{
+				Info: fmt.Sprintf("DeletePool: Pool %s not found", id),
+			},
+		},
+	}
+}
+
+func (c *LbSimulator) ImplCreatePoolMember(poolID string, opts pools.CreateMemberOptsBuilder) (*pools.Member, error) {
+	panic(fmt.Errorf("CreatePoolMember not implemented"))
+}
+
+func (c *LbSimulator) ImplListPoolMember(poolID string, opts pools.ListMembersOptsBuilder) ([]pools.Member, error) {
+	panic(fmt.Errorf("ListPoolMember not implemented"))
+}
+
+func (c *LbSimulator) ImplDeletePoolMember(poolID string, lbMemberID string) error {
+	panic(fmt.Errorf("DeletePoolMember not implemented"))
+}
+
+func (c *LbSimulator) ImplCreateMonitor(opts monitors.CreateOptsBuilder) (*monitors.Monitor, error) {
+	createMap, err := opts.ToMonitorCreateMap()
+	if err != nil {
+		return nil, fmt.Errorf("CreateMonitor: creating monitor map: %w", err)
+	}
+	createMap, ok := createMap["healthmonitor"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("CreateMonitor: create map doesn't contain healthmonitor")
+	}
+
+	monitor := monitors.Monitor{}
+	monitor.ID = generateUUID()
+	monitor.ProvisioningStatus = ProvisioningStatusPendingCreate
+
+	for k, v := range createMap {
+		switch k {
+		case "name":
+			monitor.Name = v.(string)
+		case "type":
+			monitor.Type = v.(string)
+		case "delay":
+			monitor.Delay = int(v.(float64))
+		case "timeout":
+			monitor.Timeout = int(v.(float64))
+		case "max_retries":
+			monitor.MaxRetries = int(v.(float64))
+		case "max_retries_down":
+			monitor.MaxRetriesDown = int(v.(float64))
+		case "http_method":
+			monitor.HTTPMethod = v.(string)
+		case "url_path":
+			monitor.URLPath = v.(string)
+		case "expected_codes":
+			monitor.ExpectedCodes = v.(string)
+		case "pool_id":
+			pool, err := c.GetPool(v.(string))
+			if err != nil {
+				return nil, fmt.Errorf("CreateMonitor: %w", err)
+			}
+			monitor.Pools = []monitors.PoolID{{ID: pool.ID}}
+		default:
+			panic(fmt.Errorf("CreateMonitor: unsupported create parameter %s", k))
+		}
+	}
+
+	c.Monitors = append(c.Monitors, monitor)
+	return &monitor, nil
+}
+
+func (c *LbSimulator) ImplListMonitors(opts monitors.ListOptsBuilder) ([]monitors.Monitor, error) {
+	query, err := opts.ToMonitorListQuery()
+	if err != nil {
+		return nil, fmt.Errorf("ListMonitors: creating monitor query: %w", err)
+	}
+	values, err := getValuesFromQuery(query)
+	if err != nil {
+		return nil, fmt.Errorf("ListMonitors: %w", err)
+	}
+
+	monitors := []monitors.Monitor{}
+monitors:
+	for _, monitor := range c.Monitors {
+		for k, v := range values {
+			switch k {
+			case "name":
+				if monitor.Name != v {
+					continue monitors
+				}
+			default:
+				panic(fmt.Errorf("ListMonitors: unsupported query parameter %s", k))
+			}
+		}
+		monitors = append(monitors, monitor)
+	}
+
+	return monitors, nil
+}
+
+func (c *LbSimulator) ImplDeleteMonitor(id string) error {
+	panic(fmt.Errorf("DeleteMonitor not implemented"))
+}
+
+func (c *LbSimulator) ImplListLoadBalancerProviders() ([]providers.Provider, error) {
+	providers := []providers.Provider{}
+	providers = append(providers, c.Providers...)
+
+	return providers, nil
+}
+
+func (c *LbSimulator) ImplListOctaviaVersions() ([]apiversions.APIVersion, error) {
+	// This list can be obtained with the following command:
+	// curl -s (openstack catalog show octavia -f json | jq -re '.endpoints | map(select(.interface=="public")) | .[0].url')
+	versions := []string{
+		"v2.0",
+		"v2.1",
+		"v2.2",
+		"v2.3",
+		"v2.4",
+		"v2.5",
+		"v2.6",
+		"v2.7",
+		"v2.8",
+		"v2.9",
+		"v2.10",
+		"v2.11",
+		"v2.12",
+		"v2.13",
+		"v2.14",
+	}
+
+	foundCurrent := false
+	ret := []apiversions.APIVersion{}
+	for _, v := range versions {
+		apiversion := apiversions.APIVersion{ID: v}
+		if v == c.OctaviaCurrentVersion {
+			apiversion.Status = "CURRENT"
+			foundCurrent = true
+			break
+		} else {
+			apiversion.Status = "SUPPORTED"
+		}
+		ret = append(ret, apiversion)
+	}
+
+	if !foundCurrent {
+		panic(fmt.Errorf("ListOctaviaVersions: current version %s not found in list of supported versions", c.OctaviaCurrentVersion))
+	}
+
+	return ret, nil
+}
+
+/*
+ * Callback handler stubs
+ */
+
+func (c *LbSimulator) CreateLoadBalancer(opts loadbalancers.CreateOptsBuilder) (*loadbalancers.LoadBalancer, error) {
+	if c.CreateLoadBalancerPreHook != nil {
+		handled, lb, err := c.CreateLoadBalancerPreHook(opts)
+		if handled {
+			return lb, err
+		}
+	}
+	lb, err := c.ImplCreateLoadBalancer(opts)
+	if c.CreateLoadBalancerPostHook != nil {
+		c.CreateLoadBalancerPostHook(opts, lb, err)
+	}
+	return lb, err
+}
+
+func (c *LbSimulator) ListLoadBalancers(opts loadbalancers.ListOptsBuilder) ([]loadbalancers.LoadBalancer, error) {
+	if c.ListLoadBalancersPreHook != nil {
+		handled, lbs, err := c.ListLoadBalancersPreHook(opts)
+		if handled {
+			return lbs, err
+		}
+	}
+	lbs, err := c.ImplListLoadBalancers(opts)
+	if c.ListLoadBalancersPostHook != nil {
+		c.ListLoadBalancersPostHook(opts, lbs, err)
+	}
+	return lbs, err
+}
+
+func (c *LbSimulator) GetLoadBalancer(id string) (*loadbalancers.LoadBalancer, error) {
+	if c.GetLoadBalancerPreHook != nil {
+		handled, lb, err := c.GetLoadBalancerPreHook(id)
+		if handled {
+			return lb, err
+		}
+	}
+	lb, err := c.ImplGetLoadBalancer(id)
+	if c.GetLoadBalancerPostHook != nil {
+		c.GetLoadBalancerPostHook(id, lb, err)
+	}
+	return lb, err
+}
+
+func (c *LbSimulator) DeleteLoadBalancer(id string, opts loadbalancers.DeleteOptsBuilder) error {
+	if c.DeleteLoadBalancerPreHook != nil {
+		handled, err := c.DeleteLoadBalancerPreHook(id, opts)
+		if handled {
+			return err
+		}
+	}
+	err := c.ImplDeleteLoadBalancer(id, opts)
+	if c.DeleteLoadBalancerPostHook != nil {
+		c.DeleteLoadBalancerPostHook(id, opts, err)
+	}
+	return nil
+}
+
+func (c *LbSimulator) CreateListener(opts listeners.CreateOptsBuilder) (*listeners.Listener, error) {
+	if c.CreateListenerPreHook != nil {
+		handled, listener, err := c.CreateListenerPreHook(opts)
+		if handled {
+			return listener, err
+		}
+	}
+	listener, err := c.ImplCreateListener(opts)
+	if c.CreateListenerPostHook != nil {
+		c.CreateListenerPostHook(opts, listener, err)
+	}
+	return listener, err
+}
+
+func (c *LbSimulator) ListListeners(opts listeners.ListOptsBuilder) ([]listeners.Listener, error) {
+	if c.ListListenersPreHook != nil {
+		handled, listeners, err := c.ListListenersPreHook(opts)
+		if handled {
+			return listeners, err
+		}
+	}
+	listeners, err := c.ImplListListeners(opts)
+	if c.ListListenersPostHook != nil {
+		c.ListListenersPostHook(opts, listeners, err)
+	}
+	return listeners, err
+}
+
+func (c *LbSimulator) UpdateListener(id string, opts listeners.UpdateOpts) (*listeners.Listener, error) {
+	if c.UpdateListenerPreHook != nil {
+		handled, listener, err := c.UpdateListenerPreHook(id, opts)
+		if handled {
+			return listener, err
+		}
+	}
+	listener, err := c.ImplUpdateListener(id, opts)
+	if c.UpdateListenerPostHook != nil {
+		c.UpdateListenerPostHook(id, opts, listener, err)
+	}
+	return listener, err
+}
+
+func (c *LbSimulator) GetListener(id string) (*listeners.Listener, error) {
+	if c.GetListenerPreHook != nil {
+		handled, listener, err := c.GetListenerPreHook(id)
+		if handled {
+			return listener, err
+		}
+	}
+	listener, err := c.ImplGetListener(id)
+	if c.GetListenerPostHook != nil {
+		c.GetListenerPostHook(id, listener, err)
+	}
+	return listener, err
+}
+
+func (c *LbSimulator) DeleteListener(id string) error {
+	if c.DeleteListenerPreHook != nil {
+		handled, err := c.DeleteListenerPreHook(id)
+		if handled {
+			return err
+		}
+	}
+	err := c.ImplDeleteListener(id)
+	if c.DeleteListenerPostHook != nil {
+		c.DeleteListenerPostHook(id, err)
+	}
+	return err
+}
+
+func (c *LbSimulator) CreatePool(opts pools.CreateOptsBuilder) (*pools.Pool, error) {
+	if c.CreatePoolPreHook != nil {
+		handled, pool, err := c.CreatePoolPreHook(opts)
+		if handled {
+			return pool, err
+		}
+	}
+	pool, err := c.ImplCreatePool(opts)
+	if c.CreatePoolPostHook != nil {
+		c.CreatePoolPostHook(opts, pool, err)
+	}
+	return pool, nil
+}
+
+func (c *LbSimulator) ListPools(opts pools.ListOptsBuilder) ([]pools.Pool, error) {
+	if c.ListPoolsPreHook != nil {
+		handled, pools, err := c.ListPoolsPreHook(opts)
+		if handled {
+			return pools, err
+		}
+	}
+	pools, err := c.ImplListPools(opts)
+	if c.ListPoolsPostHook != nil {
+		c.ListPoolsPostHook(opts, pools, err)
+	}
+	return pools, err
+}
+
+func (c *LbSimulator) GetPool(id string) (*pools.Pool, error) {
+	if c.GetPoolPreHook != nil {
+		handled, pool, err := c.GetPoolPreHook(id)
+		if handled {
+			return pool, err
+		}
+	}
+	pool, err := c.ImplGetPool(id)
+	if c.GetPoolPostHook != nil {
+		c.GetPoolPostHook(id, pool, err)
+	}
+	return pool, err
+}
+
+func (c *LbSimulator) DeletePool(id string) error {
+	if c.DeletePoolPreHook != nil {
+		handled, err := c.DeletePoolPreHook(id)
+		if handled {
+			return err
+		}
+	}
+	err := c.ImplDeletePool(id)
+	if c.DeletePoolPostHook != nil {
+		c.DeletePoolPostHook(id, err)
+	}
+	return err
+}
+
+func (c *LbSimulator) CreatePoolMember(poolID string, opts pools.CreateMemberOptsBuilder) (*pools.Member, error) {
+	if c.CreatePoolMemberPreHook != nil {
+		handled, member, err := c.CreatePoolMemberPreHook(poolID, opts)
+		if handled {
+			return member, err
+		}
+	}
+	member, err := c.ImplCreatePoolMember(poolID, opts)
+	if c.CreatePoolMemberPostHook != nil {
+		c.CreatePoolMemberPostHook(poolID, opts, member, err)
+	}
+	return member, err
+}
+
+func (c *LbSimulator) ListPoolMember(poolID string, opts pools.ListMembersOptsBuilder) ([]pools.Member, error) {
+	if c.ListPoolMemberPreHook != nil {
+		handled, members, err := c.ListPoolMemberPreHook(poolID, opts)
+		if handled {
+			return members, err
+		}
+	}
+	members, err := c.ImplListPoolMember(poolID, opts)
+	if c.ListPoolMemberPostHook != nil {
+		c.ListPoolMemberPostHook(poolID, opts, members, err)
+	}
+	return members, err
+}
+
+func (c *LbSimulator) DeletePoolMember(poolID string, lbMemberID string) error {
+	if c.DeletePoolMemberPreHook != nil {
+		handled, err := c.DeletePoolMemberPreHook(poolID, lbMemberID)
+		if handled {
+			return err
+		}
+	}
+	err := c.ImplDeletePoolMember(poolID, lbMemberID)
+	if c.DeletePoolMemberPostHook != nil {
+		c.DeletePoolMemberPostHook(poolID, lbMemberID, err)
+	}
+	return err
+}
+
+func (c *LbSimulator) CreateMonitor(opts monitors.CreateOptsBuilder) (*monitors.Monitor, error) {
+	if c.CreateMonitorPreHook != nil {
+		handled, monitor, err := c.CreateMonitorPreHook(opts)
+		if handled {
+			return monitor, err
+		}
+	}
+	monitor, err := c.ImplCreateMonitor(opts)
+	if c.CreateMonitorPostHook != nil {
+		c.CreateMonitorPostHook(opts, monitor, err)
+	}
+	return monitor, err
+}
+
+func (c *LbSimulator) ListMonitors(opts monitors.ListOptsBuilder) ([]monitors.Monitor, error) {
+	if c.ListMonitorsPreHook != nil {
+		handled, monitors, err := c.ListMonitorsPreHook(opts)
+		if handled {
+			return monitors, err
+		}
+	}
+	monitors, err := c.ImplListMonitors(opts)
+	if c.ListMonitorsPostHook != nil {
+		c.ListMonitorsPostHook(opts, monitors, err)
+	}
+	return monitors, err
+}
+
+func (c *LbSimulator) DeleteMonitor(id string) error {
+	if c.DeleteMonitorPreHook != nil {
+		handled, err := c.DeleteMonitorPreHook(id)
+		if handled {
+			return err
+		}
+	}
+	err := c.ImplDeleteMonitor(id)
+	if c.DeleteMonitorPostHook != nil {
+		c.DeleteMonitorPostHook(id, err)
+	}
+	return err
+}
+
+func (c *LbSimulator) ListLoadBalancerProviders() ([]providers.Provider, error) {
+	if c.ListLoadBalancerProvidersPreHook != nil {
+		handled, providers, err := c.ListLoadBalancerProvidersPreHook()
+		if handled {
+			return providers, err
+		}
+	}
+	providers, err := c.ImplListLoadBalancerProviders()
+	if c.ListLoadBalancerProvidersPostHook != nil {
+		c.ListLoadBalancerProvidersPostHook(providers, err)
+	}
+	return providers, err
+}
+
+func (c *LbSimulator) ListOctaviaVersions() ([]apiversions.APIVersion, error) {
+	if c.ListOctaviaVersionsPreHook != nil {
+		handled, versions, err := c.ListOctaviaVersionsPreHook()
+		if handled {
+			return versions, err
+		}
+	}
+	versions, err := c.ImplListOctaviaVersions()
+	if c.ListOctaviaVersionsPostHook != nil {
+		c.ListOctaviaVersionsPostHook(versions, err)
+	}
+	return versions, err
+}
+
+/*
+ * Simulator state helpers
+ */
+
+func (c *LbSimulator) SimAddLoadBalancerProvider(name string) {
+	c.Providers = append(c.Providers, providers.Provider{
+		Name: name,
+	})
+}
+
+func (c *LbSimulator) SimSetOctaviaCurrentVersion(version string) {
+	c.OctaviaCurrentVersion = version
+}
+
+/*
+ * Default callbacks
+ */
+
+func (c *LbSimulator) CallBackCreateLoadbalancerSetActive(_ loadbalancers.CreateOptsBuilder, createdLb *loadbalancers.LoadBalancer, err error) {
+	if err != nil || createdLb.ProvisioningStatus != ProvisioningStatusPendingCreate {
+		return
+	}
+
+	go func() {
+		c.Simulator.DefaultDelay()
+
+		for i := range c.LoadBalancers {
+			lb := &c.LoadBalancers[i]
+			if lb.ID == createdLb.ID {
+				if lb.ProvisioningStatus == ProvisioningStatusPendingCreate {
+					lb.ProvisioningStatus = ProvisioningStatusActive
+					lb.OperatingStatus = OperatingStatusOnline
+				}
+				return
+			}
+		}
+	}()
+}
+
+func (c *LbSimulator) CallBackCreateListenerSetActive(_ listeners.CreateOptsBuilder, createdListener *listeners.Listener, err error) {
+	if err != nil || createdListener.ProvisioningStatus != ProvisioningStatusPendingCreate {
+		return
+	}
+
+	go func() {
+		c.Simulator.DefaultDelay()
+
+		for i := range c.Listeners {
+			listener := &c.Listeners[i]
+			if listener.ID == createdListener.ID {
+				if listener.ProvisioningStatus == ProvisioningStatusPendingCreate {
+					listener.ProvisioningStatus = ProvisioningStatusActive
+				}
+				return
+			}
+		}
+	}()
+}

--- a/pkg/clients/simulator/networking.go
+++ b/pkg/clients/simulator/networking.go
@@ -1,0 +1,2201 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"fmt"
+	"net"
+	"regexp"
+	"strconv"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/trunks"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
+	netutils "k8s.io/utils/net"
+	"k8s.io/utils/pointer"
+
+	capoerrors "sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/errors"
+)
+
+type (
+	ListFloatingIPPreHook            func(opts floatingips.ListOptsBuilder) (bool, []floatingips.FloatingIP, error)
+	ListFloatingIPPostHook           func(floatingips.ListOptsBuilder, []floatingips.FloatingIP, error)
+	CreateFloatingIPPreHook          func(opts floatingips.CreateOptsBuilder) (bool, *floatingips.FloatingIP, error)
+	CreateFloatingIPPostHook         func(floatingips.CreateOptsBuilder, *floatingips.FloatingIP, error)
+	DeleteFloatingIPPreHook          func(id string) (bool, error)
+	DeleteFloatingIPPostHook         func(string, error)
+	GetFloatingIPPreHook             func(id string) (bool, *floatingips.FloatingIP, error)
+	GetFloatingIPPostHook            func(string, *floatingips.FloatingIP, error)
+	UpdateFloatingIPPreHook          func(id string, opts floatingips.UpdateOptsBuilder) (bool, *floatingips.FloatingIP, error)
+	UpdateFloatingIPPostHook         func(string, floatingips.UpdateOptsBuilder, *floatingips.FloatingIP, error)
+	ListPortPreHook                  func(opts ports.ListOptsBuilder) (bool, []ports.Port, error)
+	ListPortPostHook                 func(ports.ListOptsBuilder, []ports.Port, error)
+	CreatePortPreHook                func(opts ports.CreateOptsBuilder) (bool, *ports.Port, error)
+	CreatePortPostHook               func(ports.CreateOptsBuilder, *ports.Port, error)
+	DeletePortPreHook                func(id string) (bool, error)
+	DeletePortPostHook               func(string, error)
+	GetPortPreHook                   func(id string) (bool, *ports.Port, error)
+	GetPortPostHook                  func(string, *ports.Port, error)
+	UpdatePortPreHook                func(id string, opts ports.UpdateOptsBuilder) (bool, *ports.Port, error)
+	UpdatePortPostHook               func(string, ports.UpdateOptsBuilder, *ports.Port, error)
+	ListTrunkPreHook                 func(opts trunks.ListOptsBuilder) (bool, []trunks.Trunk, error)
+	ListTrunkPostHook                func(trunks.ListOptsBuilder, []trunks.Trunk, error)
+	CreateTrunkPreHook               func(opts trunks.CreateOptsBuilder) (bool, *trunks.Trunk, error)
+	CreateTrunkPostHook              func(trunks.CreateOptsBuilder, *trunks.Trunk, error)
+	DeleteTrunkPreHook               func(id string) (bool, error)
+	DeleteTrunkPostHook              func(string, error)
+	ListRouterPreHook                func(opts routers.ListOpts) (bool, []routers.Router, error)
+	ListRouterPostHook               func(routers.ListOpts, []routers.Router, error)
+	CreateRouterPreHook              func(opts routers.CreateOptsBuilder) (bool, *routers.Router, error)
+	CreateRouterPostHook             func(routers.CreateOptsBuilder, *routers.Router, error)
+	DeleteRouterPreHook              func(id string) (bool, error)
+	DeleteRouterPostHook             func(string, error)
+	GetRouterPreHook                 func(id string) (bool, *routers.Router, error)
+	GetRouterPostHook                func(string, *routers.Router, error)
+	UpdateRouterPreHook              func(id string, opts routers.UpdateOptsBuilder) (bool, *routers.Router, error)
+	UpdateRouterPostHook             func(string, routers.UpdateOptsBuilder, *routers.Router, error)
+	AddRouterInterfacePreHook        func(id string, opts routers.AddInterfaceOptsBuilder) (bool, *routers.InterfaceInfo, error)
+	AddRouterInterfacePostHook       func(string, routers.AddInterfaceOptsBuilder, *routers.InterfaceInfo, error)
+	RemoveRouterInterfacePreHook     func(id string, opts routers.RemoveInterfaceOptsBuilder) (bool, *routers.InterfaceInfo, error)
+	RemoveRouterInterfacePostHook    func(string, routers.RemoveInterfaceOptsBuilder, *routers.InterfaceInfo, error)
+	ListSecGroupPreHook              func(opts groups.ListOpts) (bool, []groups.SecGroup, error)
+	ListSecGroupPostHook             func(groups.ListOpts, []groups.SecGroup, error)
+	CreateSecGroupPreHook            func(opts groups.CreateOptsBuilder) (bool, *groups.SecGroup, error)
+	CreateSecGroupPostHook           func(groups.CreateOptsBuilder, *groups.SecGroup, error)
+	DeleteSecGroupPreHook            func(id string) (bool, error)
+	DeleteSecGroupPostHook           func(string, error)
+	GetSecGroupPreHook               func(id string) (bool, *groups.SecGroup, error)
+	GetSecGroupPostHook              func(string, *groups.SecGroup, error)
+	UpdateSecGroupPreHook            func(id string, opts groups.UpdateOptsBuilder) (bool, *groups.SecGroup, error)
+	UpdateSecGroupPostHook           func(string, groups.UpdateOptsBuilder, *groups.SecGroup, error)
+	ListSecGroupRulePreHook          func(opts rules.ListOpts) (bool, []rules.SecGroupRule, error)
+	ListSecGroupRulePostHook         func(rules.ListOpts, []rules.SecGroupRule, error)
+	CreateSecGroupRulePreHook        func(opts rules.CreateOptsBuilder) (bool, *rules.SecGroupRule, error)
+	CreateSecGroupRulePostHook       func(rules.CreateOptsBuilder, *rules.SecGroupRule, error)
+	DeleteSecGroupRulePreHook        func(id string) (bool, error)
+	DeleteSecGroupRulePostHook       func(string, error)
+	GetSecGroupRulePreHook           func(id string) (bool, *rules.SecGroupRule, error)
+	GetSecGroupRulePostHook          func(string, *rules.SecGroupRule, error)
+	ListNetworkPreHook               func(opts networks.ListOptsBuilder) (bool, []networks.Network, error)
+	ListNetworkPostHook              func(networks.ListOptsBuilder, []networks.Network, error)
+	CreateNetworkPreHook             func(opts networks.CreateOptsBuilder) (bool, *networks.Network, error)
+	CreateNetworkPostHook            func(networks.CreateOptsBuilder, *networks.Network, error)
+	DeleteNetworkPreHook             func(id string) (bool, error)
+	DeleteNetworkPostHook            func(string, error)
+	GetNetworkPreHook                func(id string) (bool, *networks.Network, error)
+	GetNetworkPostHook               func(string, *networks.Network, error)
+	UpdateNetworkPreHook             func(id string, opts networks.UpdateOptsBuilder) (bool, *networks.Network, error)
+	UpdateNetworkPostHook            func(string, networks.UpdateOptsBuilder, *networks.Network, error)
+	ListSubnetPreHook                func(opts subnets.ListOptsBuilder) (bool, []subnets.Subnet, error)
+	ListSubnetPostHook               func(subnets.ListOptsBuilder, []subnets.Subnet, error)
+	CreateSubnetPreHook              func(opts subnets.CreateOptsBuilder) (bool, *subnets.Subnet, error)
+	CreateSubnetPostHook             func(subnets.CreateOptsBuilder, *subnets.Subnet, error)
+	DeleteSubnetPreHook              func(id string) (bool, error)
+	DeleteSubnetPostHook             func(string, error)
+	GetSubnetPreHook                 func(id string) (bool, *subnets.Subnet, error)
+	GetSubnetPostHook                func(string, *subnets.Subnet, error)
+	UpdateSubnetPreHook              func(id string, opts subnets.UpdateOptsBuilder) (bool, *subnets.Subnet, error)
+	UpdateSubnetPostHook             func(string, subnets.UpdateOptsBuilder, *subnets.Subnet, error)
+	ListExtensionsPreHook            func() (bool, []extensions.Extension, error)
+	ListExtensionsPostHook           func([]extensions.Extension, error)
+	ReplaceAllAttributesTagsPreHook  func(resourceType string, resourceID string, opts attributestags.ReplaceAllOptsBuilder) (bool, []string, error)
+	ReplaceAllAttributesTagsPostHook func(string, string, attributestags.ReplaceAllOptsBuilder, []string, error)
+)
+
+type SimNetwork struct {
+	networks.Network
+	external.NetworkExternalExt
+}
+
+type SimSubnet struct {
+	subnets.Subnet
+
+	SimIPNet  *net.IPNet
+	SimLastIP int
+}
+
+type NetworkSimulator struct {
+	Simulator *OpenStackSimulator
+
+	Extensions       []extensions.Extension
+	FloatingIPs      []floatingips.FloatingIP
+	Networks         []SimNetwork
+	Ports            []ports.Port
+	Routers          []routers.Router
+	RouterInterfaces map[string][]string
+	SecGroupRules    []rules.SecGroupRule
+	SecGroups        []groups.SecGroup
+	Subnets          []SimSubnet
+	Trunks           []trunks.Trunk
+
+	ListFloatingIPPreHook            ListFloatingIPPreHook
+	ListFloatingIPPostHook           ListFloatingIPPostHook
+	CreateFloatingIPPreHook          CreateFloatingIPPreHook
+	CreateFloatingIPPostHook         CreateFloatingIPPostHook
+	DeleteFloatingIPPreHook          DeleteFloatingIPPreHook
+	DeleteFloatingIPPostHook         DeleteFloatingIPPostHook
+	GetFloatingIPPreHook             GetFloatingIPPreHook
+	GetFloatingIPPostHook            GetFloatingIPPostHook
+	UpdateFloatingIPPreHook          UpdateFloatingIPPreHook
+	UpdateFloatingIPPostHook         UpdateFloatingIPPostHook
+	ListPortPreHook                  ListPortPreHook
+	ListPortPostHook                 ListPortPostHook
+	CreatePortPreHook                CreatePortPreHook
+	CreatePortPostHook               CreatePortPostHook
+	DeletePortPreHook                DeletePortPreHook
+	DeletePortPostHook               DeletePortPostHook
+	GetPortPreHook                   GetPortPreHook
+	GetPortPostHook                  GetPortPostHook
+	UpdatePortPreHook                UpdatePortPreHook
+	UpdatePortPostHook               UpdatePortPostHook
+	ListTrunkPreHook                 ListTrunkPreHook
+	ListTrunkPostHook                ListTrunkPostHook
+	CreateTrunkPreHook               CreateTrunkPreHook
+	CreateTrunkPostHook              CreateTrunkPostHook
+	DeleteTrunkPreHook               DeleteTrunkPreHook
+	DeleteTrunkPostHook              DeleteTrunkPostHook
+	ListRouterPreHook                ListRouterPreHook
+	ListRouterPostHook               ListRouterPostHook
+	CreateRouterPreHook              CreateRouterPreHook
+	CreateRouterPostHook             CreateRouterPostHook
+	DeleteRouterPreHook              DeleteRouterPreHook
+	DeleteRouterPostHook             DeleteRouterPostHook
+	GetRouterPreHook                 GetRouterPreHook
+	GetRouterPostHook                GetRouterPostHook
+	UpdateRouterPreHook              UpdateRouterPreHook
+	UpdateRouterPostHook             UpdateRouterPostHook
+	AddRouterInterfacePreHook        AddRouterInterfacePreHook
+	AddRouterInterfacePostHook       AddRouterInterfacePostHook
+	RemoveRouterInterfacePreHook     RemoveRouterInterfacePreHook
+	RemoveRouterInterfacePostHook    RemoveRouterInterfacePostHook
+	ListSecGroupPreHook              ListSecGroupPreHook
+	ListSecGroupPostHook             ListSecGroupPostHook
+	CreateSecGroupPreHook            CreateSecGroupPreHook
+	CreateSecGroupPostHook           CreateSecGroupPostHook
+	DeleteSecGroupPreHook            DeleteSecGroupPreHook
+	DeleteSecGroupPostHook           DeleteSecGroupPostHook
+	GetSecGroupPreHook               GetSecGroupPreHook
+	GetSecGroupPostHook              GetSecGroupPostHook
+	UpdateSecGroupPreHook            UpdateSecGroupPreHook
+	UpdateSecGroupPostHook           UpdateSecGroupPostHook
+	ListSecGroupRulePreHook          ListSecGroupRulePreHook
+	ListSecGroupRulePostHook         ListSecGroupRulePostHook
+	CreateSecGroupRulePreHook        CreateSecGroupRulePreHook
+	CreateSecGroupRulePostHook       CreateSecGroupRulePostHook
+	DeleteSecGroupRulePreHook        DeleteSecGroupRulePreHook
+	DeleteSecGroupRulePostHook       DeleteSecGroupRulePostHook
+	GetSecGroupRulePreHook           GetSecGroupRulePreHook
+	GetSecGroupRulePostHook          GetSecGroupRulePostHook
+	ListNetworkPreHook               ListNetworkPreHook
+	ListNetworkPostHook              ListNetworkPostHook
+	CreateNetworkPreHook             CreateNetworkPreHook
+	CreateNetworkPostHook            CreateNetworkPostHook
+	DeleteNetworkPreHook             DeleteNetworkPreHook
+	DeleteNetworkPostHook            DeleteNetworkPostHook
+	GetNetworkPreHook                GetNetworkPreHook
+	GetNetworkPostHook               GetNetworkPostHook
+	UpdateNetworkPreHook             UpdateNetworkPreHook
+	UpdateNetworkPostHook            UpdateNetworkPostHook
+	ListSubnetPreHook                ListSubnetPreHook
+	ListSubnetPostHook               ListSubnetPostHook
+	CreateSubnetPreHook              CreateSubnetPreHook
+	CreateSubnetPostHook             CreateSubnetPostHook
+	DeleteSubnetPreHook              DeleteSubnetPreHook
+	DeleteSubnetPostHook             DeleteSubnetPostHook
+	GetSubnetPreHook                 GetSubnetPreHook
+	GetSubnetPostHook                GetSubnetPostHook
+	UpdateSubnetPreHook              UpdateSubnetPreHook
+	UpdateSubnetPostHook             UpdateSubnetPostHook
+	ListExtensionsPreHook            ListExtensionsPreHook
+	ListExtensionsPostHook           ListExtensionsPostHook
+	ReplaceAllAttributesTagsPreHook  ReplaceAllAttributesTagsPreHook
+	ReplaceAllAttributesTagsPostHook ReplaceAllAttributesTagsPostHook
+}
+
+const (
+	FloatingIPStatusActive = "ACTIVE"
+	FloatingIPStatusDown   = "DOWN"
+	FloatingIPStatusError  = "ERROR"
+)
+
+func NewNetworkSimulator(p *OpenStackSimulator) *NetworkSimulator {
+	sim := &NetworkSimulator{
+		Simulator:        p,
+		RouterInterfaces: make(map[string][]string),
+	}
+
+	sim.UpdateFloatingIPPostHook = sim.CallBackFloatingIPSetActiveAfterAssociate
+	return sim
+}
+
+/*
+ * Simulator implementation methods
+ */
+
+func (c *NetworkSimulator) ImplListFloatingIP(opts floatingips.ListOptsBuilder) ([]floatingips.FloatingIP, error) {
+	query, err := opts.ToFloatingIPListQuery()
+	if err != nil {
+		return nil, err
+	}
+	values, err := getValuesFromQuery(query)
+	if err != nil {
+		return nil, fmt.Errorf("ListFloatingIP: %w", err)
+	}
+
+	var result []floatingips.FloatingIP
+fips:
+	for _, fip := range c.FloatingIPs {
+		for k, v := range values {
+			switch k {
+			case "floating_ip_address":
+				if fip.FloatingIP != v {
+					continue fips
+				}
+			default:
+				panic(fmt.Sprintf("ListFloatingIP: unknown query parameter: %s:%+v", k, v))
+			}
+		}
+		result = append(result, fip)
+	}
+
+	return result, nil
+}
+
+func (c *NetworkSimulator) ImplCreateFloatingIP(opts floatingips.CreateOptsBuilder) (*floatingips.FloatingIP, error) {
+	createMap, err := opts.ToFloatingIPCreateMap()
+	if err != nil {
+		return nil, fmt.Errorf("CreateFloatingIP: creating floating ip map: %w", err)
+	}
+	createMap, ok := createMap["floatingip"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("CreateFloatingIP: create map doesn't contain floatingip: %w", err)
+	}
+
+	floatingip := floatingips.FloatingIP{}
+	floatingip.ID = generateUUID()
+	floatingip.Status = FloatingIPStatusDown
+
+	for k, v := range createMap {
+		switch k {
+		case "description":
+			floatingip.Description = v.(string)
+		case "floating_network_id":
+			floatingip.FloatingNetworkID = v.(string)
+		default:
+			panic(fmt.Errorf("CreateFloatingIP: unsupported field %s", k))
+		}
+	}
+
+	subnet := c.firstSubnetForNetwork(floatingip.FloatingNetworkID)
+	if subnet == nil {
+		panic(fmt.Errorf("CreateFloatingIP: no subnet for network %s", floatingip.FloatingNetworkID))
+	}
+	ip, err := c.SimNextIPForSubnet(subnet.ID)
+	if err != nil {
+		return nil, fmt.Errorf("CreateFloatingIP: getting next ip for subnet %s: %w", subnet.ID, err)
+	}
+	floatingip.FloatingIP = ip
+
+	c.FloatingIPs = append(c.FloatingIPs, floatingip)
+	return &floatingip, nil
+}
+
+func (c *NetworkSimulator) ImplDeleteFloatingIP(id string) error {
+	var fip *floatingips.FloatingIP
+	for i := range c.FloatingIPs {
+		o := &c.FloatingIPs[i]
+		if o.ID == id {
+			c.FloatingIPs = append(c.FloatingIPs[:i], c.FloatingIPs[i+1:]...)
+			fip = o
+			break
+		}
+	}
+
+	if fip == nil {
+		err := &gophercloud.ErrDefault404{}
+		err.Info = fmt.Sprintf("DeleteFloatingIP: Floating IP %s not found", id)
+		return err
+	}
+
+	if fip.PortID == "" {
+		return nil
+	}
+
+	var port *ports.Port
+	for i := range c.Ports {
+		o := &c.Ports[i]
+		if o.ID == fip.PortID {
+			port = o
+			break
+		}
+	}
+	if port == nil {
+		panic(fmt.Errorf("DeleteFloatingIP: referenced port %s not found", fip.PortID))
+	}
+	if port.DeviceID == "" {
+		return nil
+	}
+
+	var server *SimServer
+	for i := range c.Simulator.Compute.Servers {
+		o := &c.Simulator.Compute.Servers[i]
+		if o.ID == port.DeviceID {
+			server = o
+			break
+		}
+	}
+	if server == nil {
+		panic(fmt.Errorf("DeleteFloatingIP: referenced server %s not found", port.DeviceID))
+	}
+	if server.Addresses == nil {
+		return nil
+	}
+
+	networkName := func() string {
+		for _, n := range c.Networks {
+			if n.ID == port.NetworkID {
+				return n.Name
+			}
+		}
+		panic(fmt.Errorf("DeleteFloatingIP: referenced network %s not found", port.NetworkID))
+	}()
+
+	ifAddresses := server.Addresses[networkName].([]map[string]interface{})
+	for i := range ifAddresses {
+		ifAddress := ifAddresses[i]
+		if ifAddress["OS-EXT-IPS:type"] == "floating" && ifAddress["addr"] == fip.FloatingIP {
+			ifAddresses = append(ifAddresses[:i], ifAddresses[i+1:]...)
+			break
+		}
+	}
+	server.Addresses[networkName] = ifAddresses
+
+	return nil
+}
+
+func (c *NetworkSimulator) ImplGetFloatingIP(id string) (*floatingips.FloatingIP, error) {
+	for _, floatingip := range c.FloatingIPs {
+		if floatingip.ID == id {
+			return &floatingip, nil
+		}
+	}
+
+	err := &gophercloud.ErrDefault404{}
+	err.Info = fmt.Sprintf("GetFloatingIP: Floating IP %s not found", id)
+	return nil, err
+}
+
+func (c *NetworkSimulator) ImplUpdateFloatingIP(id string, opts floatingips.UpdateOptsBuilder) (*floatingips.FloatingIP, error) {
+	updateMap, err := opts.ToFloatingIPUpdateMap()
+	if err != nil {
+		return nil, fmt.Errorf("UpdateFloatingIP: creating floating ip update map: %w", err)
+	}
+	updateMap, ok := updateMap["floatingip"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("UpdateFloatingIP: update map doesn't contain floatingip: %w", err)
+	}
+
+	floatingip := func() *floatingips.FloatingIP {
+		for i := range c.FloatingIPs {
+			if c.FloatingIPs[i].ID == id {
+				return &c.FloatingIPs[i]
+			}
+		}
+		return nil
+	}()
+	if floatingip == nil {
+		err := &gophercloud.ErrDefault404{}
+		err.Info = fmt.Sprintf("UpdateFloatingIP: Floating IP %s not found", id)
+		return nil, err
+	}
+
+	portAddFloatingIP := func(portID string) error {
+		port := func() *ports.Port {
+			for i := range c.Ports {
+				if c.Ports[i].ID == portID {
+					return &c.Ports[i]
+				}
+			}
+			return nil
+		}()
+		if port == nil {
+			err := &gophercloud.ErrDefault404{}
+			err.Info = fmt.Sprintf("UpdateFloatingIP: Port %s not found", portID)
+			return err
+		}
+
+		port.FixedIPs = append(port.FixedIPs, ports.IP{
+			SubnetID:  id,
+			IPAddress: floatingip.FloatingIP,
+		})
+
+		// Add the port to an attached server
+		// See also population of server.Addresses in CreateServer
+		if port.DeviceID != "" {
+			server := func() *SimServer {
+				for i := range c.Simulator.Compute.Servers {
+					server := &c.Simulator.Compute.Servers[i]
+					if server.ID == port.DeviceID {
+						return server
+					}
+				}
+				return nil
+			}()
+			if server == nil {
+				panic(fmt.Errorf("UpdateFloatingIP: port referenced server %s not found", port.DeviceID))
+			}
+
+			networkName := func() string {
+				for _, network := range c.Networks {
+					if network.ID == port.NetworkID {
+						return network.Name
+					}
+				}
+				panic(fmt.Sprintf("UpdateFloatingIP: port %s has network %s, but no such network", port.ID, port.NetworkID))
+			}()
+			if server.Addresses == nil {
+				server.Addresses = make(map[string]interface{})
+			}
+			addresses := func() []map[string]interface{} {
+				if addresses, ok := server.Addresses[networkName]; ok {
+					return addresses.([]map[string]interface{})
+				}
+				return nil
+			}()
+			addresses = append(addresses, map[string]interface{}{
+				"addr":            floatingip.FloatingIP,
+				"version":         4,
+				"OS-EXT-IPS:type": "floating",
+			})
+			server.Addresses[networkName] = addresses
+		}
+		return nil
+	}
+
+	for k, v := range updateMap {
+		switch k {
+		case "port_id":
+			portID := v.(string)
+			err = portAddFloatingIP(portID)
+			if err != nil {
+				return nil, fmt.Errorf("UpdateFloatingIP: adding floating ip to port: %w", err)
+			}
+			floatingip.PortID = portID
+		default:
+			panic(fmt.Errorf("UpdateFloatingIP: unsupported field %s", k))
+		}
+	}
+
+	retCopy := *floatingip
+	return &retCopy, nil
+}
+
+func (c *NetworkSimulator) ImplListPort(opts ports.ListOptsBuilder) ([]ports.Port, error) {
+	query, err := opts.ToPortListQuery()
+	if err != nil {
+		return nil, fmt.Errorf("creating port list query: %w", err)
+	}
+	queryValues, err := getValuesFromQuery(query)
+	if err != nil {
+		return nil, fmt.Errorf("ListPort: parsing values from query: %w", err)
+	}
+
+	limit, err := func() (int, error) {
+		limit, ok := queryValues["limit"]
+		if !ok {
+			return 0, nil
+		}
+		delete(queryValues, "limit")
+
+		limitInt, err := strconv.Atoi(limit)
+		if err != nil {
+			return 0, fmt.Errorf("ListPort: parsing limit: %w", err)
+		}
+		return limitInt, nil
+	}()
+	if err != nil {
+		return nil, &gophercloud.ErrDefault400{
+			ErrUnexpectedResponseCode: gophercloud.ErrUnexpectedResponseCode{
+				BaseError: gophercloud.BaseError{
+					Info: err.Error(),
+				},
+			},
+		}
+	}
+
+	ret := []ports.Port{}
+ports:
+	for _, port := range c.Ports {
+		for k, v := range queryValues {
+			switch k {
+			case "name":
+				if port.Name != v {
+					continue ports
+				}
+			case "network_id":
+				if port.NetworkID != v {
+					continue ports
+				}
+			case "device_id":
+				if port.DeviceID != v {
+					continue ports
+				}
+			case "fixed_ips":
+				// Port must have all of the fixed IPs specified in the query
+				// I don't know what the query format is except
+				// for a single entry containing an ip address,
+				// so for now we panic on anything else
+				ipaddress := regexp.MustCompile(`^ip_address=([0-9.]+)$`)
+				matches := ipaddress.FindStringSubmatch(v)
+				if len(matches) != 2 {
+					panic(fmt.Errorf("ListPort: unsupported fixed_ips query: %s", v))
+				}
+				findip := func() bool {
+					for _, fixedip := range port.FixedIPs {
+						if fixedip.IPAddress == matches[1] {
+							return true
+						}
+					}
+					return false
+				}
+				if !findip() {
+					continue ports
+				}
+			default:
+				panic(fmt.Errorf("ListPort: unsupported query parameter %s:%+v", k, v))
+			}
+		}
+
+		ret = append(ret, port)
+		if len(ret) == limit {
+			break
+		}
+	}
+
+	return ret, nil
+}
+
+func (c *NetworkSimulator) ImplCreatePort(opts ports.CreateOptsBuilder) (*ports.Port, error) {
+	createMap, err := opts.ToPortCreateMap()
+	if err != nil {
+		return nil, fmt.Errorf("CreatePort: creating port map: %w", err)
+	}
+	createMap, ok := createMap["port"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("CreatePort: create map does not contain port")
+	}
+
+	port := ports.Port{}
+	port.ID = generateUUID()
+	for k, v := range createMap {
+		switch k {
+		case "description":
+			port.Description = v.(string)
+		case "name":
+			port.Name = v.(string)
+		case "network_id":
+			networkID := v.(string)
+			_, err = c.GetNetwork(networkID)
+			if err != nil {
+				return nil, fmt.Errorf("CreatePort: %w", err)
+			}
+			port.NetworkID = networkID
+		case "security_groups":
+			if v == nil {
+				continue
+			}
+
+			var sgs []string
+			for _, sg := range v.([]interface{}) {
+				sgs = append(sgs, sg.(string))
+			}
+			port.SecurityGroups = sgs
+		case "fixed_ips":
+			for _, fixedIP := range v.([]interface{}) {
+				params := fixedIP.(map[string]interface{})
+				ip := ports.IP{}
+				for k, v := range params {
+					switch k {
+					case "ip_address":
+						ip.IPAddress = v.(string)
+					case "subnet_id":
+						subnet, err := c.GetSubnet(v.(string))
+						if err != nil {
+							return nil, fmt.Errorf("CreatePort: %w", err)
+						}
+						ip.SubnetID = subnet.ID
+					default:
+						panic(fmt.Errorf("CreatePort: unsupported fixed IP field %s", k))
+					}
+				}
+				port.FixedIPs = append(port.FixedIPs, ip)
+			}
+		case "device_id":
+			port.DeviceID = v.(string)
+		default:
+			panic(fmt.Errorf("CreatePort: unsupported create parameter: %s:%+v", k, v))
+		}
+	}
+
+	// If no fixed IPs were requested explicitly, create one implicitly from the first subnet on the given network
+	if len(port.FixedIPs) == 0 {
+		subnet := c.firstSubnetForNetwork(port.NetworkID)
+		if subnet != nil {
+			port.FixedIPs = append(port.FixedIPs, ports.IP{SubnetID: subnet.ID})
+		}
+	}
+
+	// Allocate IP addresses for all fixed IPs
+	for i := range port.FixedIPs {
+		fixedIP := &port.FixedIPs[i]
+		if fixedIP.IPAddress != "" {
+			continue
+		}
+
+		ip, err := c.SimNextIPForSubnet(fixedIP.SubnetID)
+		if err != nil {
+			return nil, fmt.Errorf("CreatePort: %w", err)
+		}
+		fixedIP.IPAddress = ip
+	}
+
+	c.Ports = append(c.Ports, port)
+	return &port, nil
+}
+
+func (c *NetworkSimulator) ImplDeletePort(id string) error {
+	for i := range c.Ports {
+		if c.Ports[i].ID == id {
+			c.Ports = append(c.Ports[:i], c.Ports[i+i:]...)
+			return nil
+		}
+	}
+	return &gophercloud.ErrDefault404{
+		ErrUnexpectedResponseCode: gophercloud.ErrUnexpectedResponseCode{
+			BaseError: gophercloud.BaseError{
+				Info: fmt.Sprintf("DeletePort: port with id %s not found", id),
+			},
+		},
+	}
+}
+
+func (c *NetworkSimulator) ImplGetPort(id string) (*ports.Port, error) {
+	for _, port := range c.Ports {
+		if port.ID == id {
+			retCopy := port
+			return &retCopy, nil
+		}
+	}
+
+	return nil, &gophercloud.ErrDefault404{
+		ErrUnexpectedResponseCode: gophercloud.ErrUnexpectedResponseCode{
+			BaseError: gophercloud.BaseError{
+				Info: fmt.Sprintf("GetPort: port with id %s not found", id),
+			},
+		},
+	}
+}
+
+func (c *NetworkSimulator) ImplUpdatePort(id string, opts ports.UpdateOptsBuilder) (*ports.Port, error) {
+	panic(fmt.Errorf("UpdatePort not implemented"))
+}
+
+func (c *NetworkSimulator) ImplListTrunk(opts trunks.ListOptsBuilder) ([]trunks.Trunk, error) {
+	query, err := opts.ToTrunkListQuery()
+	if err != nil {
+		return nil, fmt.Errorf("ListTrunk: create list query: %w", err)
+	}
+	queryValues, err := getValuesFromQuery(query)
+	if err != nil {
+		return nil, fmt.Errorf("ListTrunk: %w", err)
+	}
+
+	var ret []trunks.Trunk
+trunks:
+	for _, trunk := range c.Trunks {
+		for k, v := range queryValues {
+			switch k {
+			case "port_id":
+				if trunk.PortID != v {
+					continue trunks
+				}
+			case "name":
+				if trunk.Name != v {
+					continue trunks
+				}
+			default:
+				panic(fmt.Errorf("ListTrunk: simulator doesn't support query by %s", k))
+			}
+		}
+		ret = append(ret, trunk)
+	}
+
+	return ret, nil
+}
+
+func (c *NetworkSimulator) ImplCreateTrunk(opts trunks.CreateOptsBuilder) (*trunks.Trunk, error) {
+	panic(fmt.Errorf("CreateTrunk not implemented"))
+}
+
+func (c *NetworkSimulator) ImplDeleteTrunk(id string) error {
+	panic(fmt.Errorf("DeleteTrunk not implemented"))
+}
+
+func (c *NetworkSimulator) ImplListRouter(opts routers.ListOpts) ([]routers.Router, error) {
+	ret := []routers.Router{}
+	for _, router := range c.Routers {
+		if opts.ID != "" && router.ID != opts.ID {
+			continue
+		}
+		if opts.Name != "" && router.Name != opts.Name {
+			continue
+		}
+		if opts.Description != "" && router.Description != opts.Description {
+			continue
+		}
+		if opts.AdminStateUp != nil && router.AdminStateUp != *opts.AdminStateUp {
+			continue
+		}
+		if opts.Distributed != nil && router.Distributed != *opts.Distributed {
+			continue
+		}
+		if opts.Status != "" && router.Status != opts.Status {
+			continue
+		}
+		if opts.TenantID != "" && router.TenantID != opts.TenantID {
+			continue
+		}
+		if opts.ProjectID != "" && router.ProjectID != opts.ProjectID {
+			continue
+		}
+		if opts.Tags != "" || opts.TagsAny != "" ||
+			opts.NotTags != "" || opts.NotTagsAny != "" ||
+			opts.Limit != 0 || opts.Marker != "" ||
+			opts.SortKey != "" || opts.SortDir != "" {
+			panic(fmt.Errorf("ListRouter: simulator doesn't support query by tags, limit, marker, sort_key, or sort_dir"))
+		}
+
+		ret = append(ret, router)
+	}
+
+	return ret, nil
+}
+
+func (c *NetworkSimulator) ImplCreateRouter(opts routers.CreateOptsBuilder) (*routers.Router, error) {
+	createMap, err := opts.ToRouterCreateMap()
+	if err != nil {
+		return nil, fmt.Errorf("CreateRouter: %w", err)
+	}
+	createMap, ok := createMap["router"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("CreateRouter: router not found in create map")
+	}
+
+	router := routers.Router{}
+	router.ID = generateUUID()
+
+	for k, v := range createMap {
+		switch k {
+		case "name":
+			router.Name = v.(string)
+		case "admin_state_up":
+			router.AdminStateUp = v.(bool)
+		case "distributed":
+			router.Distributed = v.(bool)
+		case "availability_zone_hints":
+			router.AvailabilityZoneHints = v.([]string)
+		case "external_gateway_info":
+			for k1, v1 := range v.(map[string]interface{}) {
+				switch k1 {
+				case "network_id":
+					network, err := c.GetNetwork(v1.(string))
+					if err != nil {
+						return nil, fmt.Errorf("CreateRouter: %w", err)
+					}
+					router.GatewayInfo.NetworkID = network.ID
+				case "enable_snat":
+					router.GatewayInfo.EnableSNAT = pointer.Bool(v1.(bool))
+				default:
+					panic(fmt.Errorf("CreateRouter: simulator doesn't support external_gateway_info.%s", k1))
+				}
+			}
+		case "tags":
+			router.Tags = v.([]string)
+		case "tenant_id":
+			router.TenantID = v.(string)
+		case "project_id":
+			router.ProjectID = v.(string)
+		case "description":
+			router.Description = v.(string)
+		default:
+			panic(fmt.Errorf("CreateRouter: unsupported create parameter: %s:%+v", k, v))
+		}
+	}
+
+	c.Routers = append(c.Routers, router)
+	return &router, nil
+}
+
+func (c *NetworkSimulator) ImplDeleteRouter(id string) error {
+	for _, portID := range c.RouterInterfaces[id] {
+		port, err := c.GetPort(portID)
+		if err != nil && !capoerrors.IsNotFound(err) {
+			return fmt.Errorf("DeleteRouter: %w", err)
+		}
+		if port != nil {
+			err := &gophercloud.ErrDefault404{}
+			err.Info = fmt.Sprintf("Router %s still has ports", id)
+			return err
+		}
+	}
+
+	for i, router := range c.Routers {
+		if router.ID == id {
+			c.Routers = append(c.Routers[:i], c.Routers[i+1:]...)
+			return nil
+		}
+	}
+
+	err := &gophercloud.ErrDefault404{}
+	err.Info = fmt.Sprintf("Router %s not found", id)
+	return err
+}
+
+func (c *NetworkSimulator) ImplGetRouter(id string) (*routers.Router, error) {
+	for _, router := range c.Routers {
+		if router.ID == id {
+			retCopy := router
+			return &retCopy, nil
+		}
+	}
+
+	err := &gophercloud.ErrDefault404{}
+	err.Info = fmt.Sprintf("GetRouter: Router %s not found", id)
+	return nil, err
+}
+
+func (c *NetworkSimulator) ImplUpdateRouter(id string, opts routers.UpdateOptsBuilder) (*routers.Router, error) {
+	panic(fmt.Errorf("UpdateRouter not implemented"))
+}
+
+func (c *NetworkSimulator) ImplAddRouterInterface(id string, opts routers.AddInterfaceOptsBuilder) (*routers.InterfaceInfo, error) {
+	_, err := c.GetRouter(id)
+	if err != nil {
+		return nil, fmt.Errorf("AddRouterInterface: %w", err)
+	}
+
+	createMap, err := opts.ToRouterAddInterfaceMap()
+	if err != nil {
+		return nil, fmt.Errorf("AddRouterInterface: creating router interface map: %w", err)
+	}
+
+	interfaceInfo := routers.InterfaceInfo{}
+	for k, v := range createMap {
+		switch k {
+		case "subnet_id":
+			interfaceInfo.SubnetID = v.(string)
+		case "port_id":
+			interfaceInfo.PortID = v.(string)
+		default:
+			panic(fmt.Errorf("AddRouterInterface: simulator doesn't support %s", k))
+		}
+	}
+
+	var port *ports.Port
+	if interfaceInfo.PortID != "" {
+		port, err = c.GetPort(interfaceInfo.PortID)
+		if err != nil {
+			return nil, fmt.Errorf("AddRouterInterface: %w", err)
+		}
+	} else if interfaceInfo.SubnetID != "" {
+		subnet, err := c.GetSubnet(interfaceInfo.SubnetID)
+		if err != nil {
+			return nil, fmt.Errorf("AddRouterInterface: %w", err)
+		}
+		var createOpts ports.CreateOptsBuilder = ports.CreateOpts{
+			Name:      fmt.Sprintf("router %s port", id),
+			FixedIPs:  []ports.IP{{SubnetID: interfaceInfo.SubnetID}},
+			NetworkID: subnet.NetworkID,
+			DeviceID:  id,
+		}
+
+		port, err = c.CreatePort(createOpts)
+		if err != nil {
+			return nil, fmt.Errorf("AddRouterInterface: %w", err)
+		}
+	} else {
+		err := &gophercloud.ErrDefault400{}
+		err.Info = "AddRouterInterface: port_id or subnet_id must be specified"
+		return nil, err
+	}
+
+	routerInterfaces := c.RouterInterfaces[id]
+	routerInterfaces = append(routerInterfaces, port.ID)
+	c.RouterInterfaces[id] = routerInterfaces
+
+	return &interfaceInfo, nil
+}
+
+func (c *NetworkSimulator) ImplRemoveRouterInterface(id string, opts routers.RemoveInterfaceOptsBuilder) (*routers.InterfaceInfo, error) {
+	router, err := c.GetRouter(id)
+	if err != nil {
+		return nil, fmt.Errorf("RemoveRouterInterface: %w", err)
+	}
+
+	removeMap, err := opts.ToRouterRemoveInterfaceMap()
+	if err != nil {
+		return nil, fmt.Errorf("RemoveRouterInterface: creating router interface map: %w", err)
+	}
+
+	interfaceInfo := routers.InterfaceInfo{}
+	for k, v := range removeMap {
+		switch k {
+		case "subnet_id":
+			interfaceInfo.SubnetID = v.(string)
+		case "port_id":
+			interfaceInfo.PortID = v.(string)
+		default:
+			panic(fmt.Errorf("RemoveRouterInterface: simulator doesn't support %s", k))
+		}
+	}
+
+	portIDs := c.RouterInterfaces[router.ID]
+	i, err := func() (int, error) {
+		for i, portID := range portIDs {
+			port, err := c.GetPort(portID)
+			if err != nil && !capoerrors.IsNotFound(err) {
+				return -1, fmt.Errorf("RemoveRouterInterface: %w", err)
+			}
+			if port == nil {
+				continue
+			}
+
+			matchSubnet := func() bool {
+				// Check if any of the port's fixed IPs match the subnet ID
+				for _, fixedIP := range port.FixedIPs {
+					if fixedIP.SubnetID == interfaceInfo.SubnetID {
+						return true
+					}
+				}
+				return false
+			}
+
+			if (interfaceInfo.PortID != "" && interfaceInfo.PortID != port.ID) ||
+				(interfaceInfo.SubnetID != "" && !matchSubnet()) {
+				continue
+			}
+
+			return i, nil
+		}
+		return -1, nil
+	}()
+	if err != nil {
+		return nil, err
+	}
+
+	if i == -1 {
+		err := &gophercloud.ErrDefault404{}
+		err.Info = fmt.Sprintf("RemoveRouterInterface: Router interface %+v for router %s not found", removeMap, id)
+		return nil, err
+	}
+
+	c.RouterInterfaces[router.ID] = append(portIDs[:i], portIDs[i+1:]...)
+	return &interfaceInfo, nil
+}
+
+func (c *NetworkSimulator) ImplListSecGroup(opts groups.ListOpts) ([]groups.SecGroup, error) {
+	ret := []groups.SecGroup{}
+	for _, secGroup := range c.SecGroups {
+		if opts.ID != "" && secGroup.ID != opts.ID {
+			continue
+		}
+		if opts.Name != "" && secGroup.Name != opts.Name {
+			continue
+		}
+		if opts.Description != "" && secGroup.Description != opts.Description {
+			continue
+		}
+		if opts.TenantID != "" && secGroup.TenantID != opts.TenantID {
+			continue
+		}
+		if opts.ProjectID != "" && secGroup.ProjectID != opts.ProjectID {
+			continue
+		}
+
+		unsup := func(f string) {
+			panic(fmt.Errorf("ListSecGroup: unsupported query parameter %s", f))
+		}
+		if opts.Tags != "" {
+			unsup("tags")
+		}
+		if opts.TagsAny != "" {
+			unsup("tags-any")
+		}
+		if opts.NotTags != "" {
+			unsup("not-tags")
+		}
+		if opts.NotTagsAny != "" {
+			unsup("not-tags-any")
+		}
+		if opts.Limit != 0 {
+			unsup("limit")
+		}
+		if opts.Marker != "" {
+			unsup("marker")
+		}
+		if opts.SortKey != "" {
+			unsup("sortkey")
+		}
+		if opts.SortDir != "" {
+			unsup("sortdir")
+		}
+
+		ret = append(ret, secGroup)
+	}
+
+	return ret, nil
+}
+
+func (c *NetworkSimulator) ImplCreateSecGroup(opts groups.CreateOptsBuilder) (*groups.SecGroup, error) {
+	createMap, err := opts.ToSecGroupCreateMap()
+	if err != nil {
+		return nil, fmt.Errorf("CreateSecGroup: creating secgroup map: %w", err)
+	}
+	createMap, ok := createMap["security_group"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("CreateSecGroup: create map does not contain security_group")
+	}
+
+	secGroup := groups.SecGroup{}
+	secGroup.ID = generateUUID()
+
+	for k, v := range createMap {
+		switch k {
+		case "description":
+			secGroup.Description = v.(string)
+		case "name":
+			secGroup.Name = v.(string)
+		default:
+			panic(fmt.Errorf("CreateSecGroup: unsupported create parameter %s", k))
+		}
+	}
+
+	c.SecGroups = append(c.SecGroups, secGroup)
+	return &secGroup, nil
+}
+
+func (c *NetworkSimulator) ImplDeleteSecGroup(id string) error {
+	for i, secGroup := range c.SecGroups {
+		if secGroup.ID == id {
+			c.SecGroups = append(c.SecGroups[:i], c.SecGroups[i+1:]...)
+			return nil
+		}
+	}
+
+	return &gophercloud.ErrDefault404{
+		ErrUnexpectedResponseCode: gophercloud.ErrUnexpectedResponseCode{
+			BaseError: gophercloud.BaseError{
+				Info: fmt.Sprintf("DeleteSecGroup: secgroup %s not found", id),
+			},
+		},
+	}
+}
+
+func (c *NetworkSimulator) ImplGetSecGroup(id string) (*groups.SecGroup, error) {
+	for _, secGroup := range c.SecGroups {
+		if secGroup.ID == id {
+			retCopy := secGroup
+			return &retCopy, nil
+		}
+	}
+
+	return nil, &gophercloud.ErrDefault404{
+		ErrUnexpectedResponseCode: gophercloud.ErrUnexpectedResponseCode{
+			BaseError: gophercloud.BaseError{
+				Info: fmt.Sprintf("GetSecGroup: secgroup with id %s does not exist", id),
+			},
+		},
+	}
+}
+
+func (c *NetworkSimulator) ImplUpdateSecGroup(id string, opts groups.UpdateOptsBuilder) (*groups.SecGroup, error) {
+	panic(fmt.Errorf("UpdateSecGroup not implemented"))
+}
+
+func (c *NetworkSimulator) ImplListSecGroupRule(opts rules.ListOpts) ([]rules.SecGroupRule, error) {
+	panic(fmt.Errorf("ListSecGroupRule not implemented"))
+}
+
+func (c *NetworkSimulator) ImplCreateSecGroupRule(opts rules.CreateOptsBuilder) (*rules.SecGroupRule, error) {
+	createMap, err := opts.ToSecGroupRuleCreateMap()
+	if err != nil {
+		return nil, fmt.Errorf("CreateSecGroupRule: creating secgrouprule map: %w", err)
+	}
+	createMap, ok := createMap["security_group_rule"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("CreateSecGroupRule: create map does not contain security_group_rule")
+	}
+
+	secGroupRule := rules.SecGroupRule{}
+	secGroupRule.ID = generateUUID()
+
+	for k, v := range createMap {
+		switch k {
+		case "description":
+			secGroupRule.Description = v.(string)
+		case "direction":
+			secGroupRule.Direction = v.(string)
+		case "ethertype":
+			secGroupRule.EtherType = v.(string)
+		case "security_group_id":
+			secGroupRule.SecGroupID = v.(string)
+		case "port_range_min":
+			secGroupRule.PortRangeMin = int(v.(float64))
+		case "port_range_max":
+			secGroupRule.PortRangeMax = int(v.(float64))
+		case "protocol":
+			secGroupRule.Protocol = v.(string)
+		case "remote_group_id":
+			secGroupRule.RemoteGroupID = v.(string)
+		default:
+			panic(fmt.Errorf("CreateSecGroupRule: unsupported create parameter: %s", k))
+		}
+	}
+
+	_, err = c.GetSecGroup(secGroupRule.SecGroupID)
+	if err != nil {
+		return nil, fmt.Errorf("CreateSecGroupRule: %w", err)
+	}
+
+	c.SecGroupRules = append(c.SecGroupRules, secGroupRule)
+	return &secGroupRule, nil
+}
+
+func (c *NetworkSimulator) ImplDeleteSecGroupRule(id string) error {
+	panic(fmt.Errorf("DeleteSecGroupRule not implemented"))
+}
+
+func (c *NetworkSimulator) ImplGetSecGroupRule(id string) (*rules.SecGroupRule, error) {
+	panic(fmt.Errorf("GetSecGroupRule not implemented"))
+}
+
+func (c *NetworkSimulator) ImplListNetwork(opts networks.ListOptsBuilder) ([]networks.Network, error) {
+	query, err := opts.ToNetworkListQuery()
+	if err != nil {
+		return nil, fmt.Errorf("ListNetwork: creating network query: %w", err)
+	}
+	values, err := getValuesFromQuery(query)
+	if err != nil {
+		return nil, fmt.Errorf("ListNetwork: %w", err)
+	}
+
+	networks := []networks.Network{}
+networks:
+	for _, network := range c.Networks {
+		for k, v := range values {
+			switch k {
+			case "id":
+				if network.ID != v {
+					continue networks
+				}
+			case "name":
+				if network.Name != v {
+					continue networks
+				}
+			case "router:external":
+				external := v == "true"
+				if network.External != external {
+					continue networks
+				}
+			default:
+				panic(fmt.Errorf("ListNetwork: unsupported query param %s", k))
+			}
+		}
+
+		networks = append(networks, network.Network)
+	}
+
+	return networks, nil
+}
+
+func (c *NetworkSimulator) ImplCreateNetwork(opts networks.CreateOptsBuilder) (*networks.Network, error) {
+	createMap, err := opts.ToNetworkCreateMap()
+	if err != nil {
+		return nil, fmt.Errorf("CreateNetwork: creating network map: %w", err)
+	}
+	createMap, ok := createMap["network"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("CreateNetwork: create map does not contain network")
+	}
+
+	network := SimNetwork{}
+	network.ID = generateUUID()
+	network.External = false
+
+	for k, v := range createMap {
+		switch k {
+		case "admin_state_up":
+			network.AdminStateUp = v.(bool)
+		case "name":
+			network.Name = v.(string)
+		default:
+			panic(fmt.Errorf("CreateNetwork: unsupported create parameter %s", k))
+		}
+	}
+
+	c.Networks = append(c.Networks, network)
+	return &network.Network, nil
+}
+
+func (c *NetworkSimulator) ImplDeleteNetwork(id string) error {
+	for i, network := range c.Networks {
+		if network.ID == id {
+			c.Networks = append(c.Networks[:i], c.Networks[i+1:]...)
+			return nil
+		}
+	}
+
+	return &gophercloud.ErrDefault404{
+		ErrUnexpectedResponseCode: gophercloud.ErrUnexpectedResponseCode{
+			BaseError: gophercloud.BaseError{
+				Info: fmt.Sprintf("DeleteNetwork: network with id %s does not exist", id),
+			},
+		},
+	}
+}
+
+func (c *NetworkSimulator) ImplGetNetwork(id string) (*networks.Network, error) {
+	for _, network := range c.Networks {
+		if network.ID == id {
+			retCopy := network.Network
+			return &retCopy, nil
+		}
+	}
+
+	return nil, &gophercloud.ErrDefault404{
+		ErrUnexpectedResponseCode: gophercloud.ErrUnexpectedResponseCode{
+			BaseError: gophercloud.BaseError{
+				Info: fmt.Sprintf("GetNetwork: network with id %s does not exist", id),
+			},
+		},
+	}
+}
+
+func (c *NetworkSimulator) ImplUpdateNetwork(id string, opts networks.UpdateOptsBuilder) (*networks.Network, error) {
+	panic(fmt.Errorf("UpdateNetwork not implemented"))
+}
+
+func (c *NetworkSimulator) ImplListSubnet(opts subnets.ListOptsBuilder) ([]subnets.Subnet, error) {
+	query, err := opts.ToSubnetListQuery()
+	if err != nil {
+		return nil, fmt.Errorf("ListSubnet: creating subnet query: %w", err)
+	}
+	values, err := getValuesFromQuery(query)
+	if err != nil {
+		return nil, fmt.Errorf("ListSubnet: %w", err)
+	}
+
+	ret := []subnets.Subnet{}
+subnets:
+	for _, subnet := range c.Subnets {
+		for k, v := range values {
+			switch k {
+			case "name":
+				if subnet.Name != v {
+					continue subnets
+				}
+			case "cidr":
+				if subnet.CIDR != v {
+					continue subnets
+				}
+			case "network_id":
+				if subnet.NetworkID != v {
+					continue subnets
+				}
+			default:
+				panic(fmt.Errorf("ListSubnet: unsupported parameter %s", k))
+			}
+		}
+
+		ret = append(ret, subnet.Subnet)
+	}
+
+	return ret, nil
+}
+
+func (c *NetworkSimulator) ImplCreateSubnet(opts subnets.CreateOptsBuilder) (*subnets.Subnet, error) {
+	createMap, err := opts.ToSubnetCreateMap()
+	if err != nil {
+		return nil, fmt.Errorf("CreateSubnet: creating subnet map: %w", err)
+	}
+	createMap, ok := createMap["subnet"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("CreateSubnet: create map does not contain subnet")
+	}
+
+	subnet := SimSubnet{}
+	subnet.ID = generateUUID()
+
+	for k, v := range createMap {
+		switch k {
+		case "cidr":
+			subnet.CIDR = v.(string)
+			_, ipNet, err := netutils.ParseCIDRSloppy(subnet.CIDR)
+			if err != nil {
+				return nil, fmt.Errorf("CreateSubnet: parsing cidr: %w", err)
+			}
+			subnet.SimIPNet = ipNet
+		case "description":
+			subnet.Description = v.(string)
+		case "dns_nameservers":
+			var nameservers []string
+			for _, v := range v.([]interface{}) {
+				nameservers = append(nameservers, v.(string))
+			}
+			subnet.DNSNameservers = nameservers
+		case "ip_version":
+			subnet.IPVersion = int(v.(float64))
+		case "name":
+			subnet.Name = v.(string)
+		case "network_id":
+			subnet.NetworkID = v.(string)
+		default:
+			panic(fmt.Errorf("CreateSubnet: unsupported create parameter %s", k))
+		}
+	}
+
+	_, err = c.GetNetwork(subnet.NetworkID)
+	if err != nil {
+		return nil, fmt.Errorf("CreateSubnet: %w", err)
+	}
+
+	c.Subnets = append(c.Subnets, subnet)
+	return &subnet.Subnet, nil
+}
+
+func (c *NetworkSimulator) ImplDeleteSubnet(id string) error {
+	panic(fmt.Errorf("DeleteSubnet not implemented"))
+}
+
+func (c *NetworkSimulator) ImplGetSubnet(id string) (*subnets.Subnet, error) {
+	for _, subnet := range c.Subnets {
+		if subnet.ID == id {
+			retCopy := subnet.Subnet
+			return &retCopy, nil
+		}
+	}
+
+	return nil, &gophercloud.ErrDefault404{
+		ErrUnexpectedResponseCode: gophercloud.ErrUnexpectedResponseCode{
+			BaseError: gophercloud.BaseError{
+				Info: fmt.Sprintf("GetSubnet: subnet with id %s does not exist", id),
+			},
+		},
+	}
+}
+
+func (c *NetworkSimulator) ImplUpdateSubnet(id string, opts subnets.UpdateOptsBuilder) (*subnets.Subnet, error) {
+	panic(fmt.Errorf("UpdateSubnet not implemented"))
+}
+
+func (c *NetworkSimulator) ImplListExtensions() ([]extensions.Extension, error) {
+	return c.Extensions, nil
+}
+
+func (c *NetworkSimulator) ImplReplaceAllAttributesTags(resourceType string, resourceID string, opts attributestags.ReplaceAllOptsBuilder) ([]string, error) {
+	tagOpts, err := opts.ToAttributeTagsReplaceAllMap()
+	if err != nil {
+		return nil, fmt.Errorf("ReplaceAllAttributesTags: creating tags map: %w", err)
+	}
+	tags, ok := tagOpts["tags"].([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("ReplaceAllAttributesTags: tags map does not contain tags")
+	}
+	tagStrings := []string{}
+	for _, tag := range tags {
+		tagStrings = append(tagStrings, tag.(string))
+	}
+
+	tagNetwork := func() ([]string, error) {
+		for i := range c.Networks {
+			network := &c.Networks[i]
+			if network.ID == resourceID {
+				oldTags := network.Tags
+				network.Tags = tagStrings
+				return oldTags, nil
+			}
+		}
+
+		err := &gophercloud.ErrDefault404{}
+		err.Info = fmt.Sprintf("ReplaceAllAttributesTags: network with id %s does not exist", resourceID)
+		return nil, err
+	}
+
+	tagSubnets := func() ([]string, error) {
+		for i := range c.Subnets {
+			subnet := &c.Subnets[i]
+			if subnet.ID == resourceID {
+				oldTags := subnet.Tags
+				subnet.Tags = tagStrings
+				return oldTags, nil
+			}
+		}
+
+		err := &gophercloud.ErrDefault404{}
+		err.Info = fmt.Sprintf("ReplaceAllAttributesTags: subnet with id %s does not exist", resourceID)
+		return nil, err
+	}
+
+	tagRouters := func() ([]string, error) {
+		for i := range c.Routers {
+			router := &c.Routers[i]
+			if router.ID == resourceID {
+				oldTags := router.Tags
+				router.Tags = tagStrings
+				return oldTags, nil
+			}
+		}
+
+		err := &gophercloud.ErrDefault404{}
+		err.Info = fmt.Sprintf("ReplaceAllAttributesTags: router with id %s does not exist", resourceID)
+		return nil, err
+	}
+
+	tagSecurityGroups := func() ([]string, error) {
+		for i := range c.SecGroups {
+			securityGroup := &c.SecGroups[i]
+			if securityGroup.ID == resourceID {
+				oldTags := securityGroup.Tags
+				securityGroup.Tags = tagStrings
+				return oldTags, nil
+			}
+		}
+
+		err := &gophercloud.ErrDefault404{}
+		err.Info = fmt.Sprintf("ReplaceAllAttributesTags: security group with id %s does not exist", resourceID)
+		return nil, err
+	}
+
+	tagFloatingIPs := func() ([]string, error) {
+		for i := range c.FloatingIPs {
+			floatingIP := &c.FloatingIPs[i]
+			if floatingIP.ID == resourceID {
+				oldTags := floatingIP.Tags
+				floatingIP.Tags = tagStrings
+				return oldTags, nil
+			}
+		}
+
+		err := &gophercloud.ErrDefault404{}
+		err.Info = fmt.Sprintf("ReplaceAllAttributesTags: floating IP with id %s does not exist", resourceID)
+		return nil, err
+	}
+
+	switch resourceType {
+	case "networks":
+		return tagNetwork()
+	case "subnets":
+		return tagSubnets()
+	case "routers":
+		return tagRouters()
+	case "security-groups":
+		return tagSecurityGroups()
+	case "floatingips":
+		return tagFloatingIPs()
+	default:
+		panic(fmt.Errorf("ReplaceAllAttributesTags: unsupported resource type %s", resourceType))
+	}
+}
+
+/*
+ * Callback handler stubs
+ */
+
+func (c *NetworkSimulator) ListFloatingIP(opts floatingips.ListOptsBuilder) ([]floatingips.FloatingIP, error) {
+	if c.ListFloatingIPPreHook != nil {
+		handled, fips, err := c.ListFloatingIPPreHook(opts)
+		if handled {
+			return fips, err
+		}
+	}
+	fips, err := c.ImplListFloatingIP(opts)
+	if c.ListFloatingIPPostHook != nil {
+		c.ListFloatingIPPostHook(opts, fips, err)
+	}
+	return fips, err
+}
+
+func (c *NetworkSimulator) CreateFloatingIP(opts floatingips.CreateOptsBuilder) (*floatingips.FloatingIP, error) {
+	if c.CreateFloatingIPPreHook != nil {
+		handled, fip, err := c.CreateFloatingIPPreHook(opts)
+		if handled {
+			return fip, err
+		}
+	}
+	fip, err := c.ImplCreateFloatingIP(opts)
+	if c.CreateFloatingIPPostHook != nil {
+		c.CreateFloatingIPPostHook(opts, fip, err)
+	}
+	return fip, err
+}
+
+func (c *NetworkSimulator) DeleteFloatingIP(id string) error {
+	if c.DeleteFloatingIPPreHook != nil {
+		handled, err := c.DeleteFloatingIPPreHook(id)
+		if handled {
+			return err
+		}
+	}
+	err := c.ImplDeleteFloatingIP(id)
+	if c.DeleteFloatingIPPostHook != nil {
+		c.DeleteFloatingIPPostHook(id, err)
+	}
+	return err
+}
+
+func (c *NetworkSimulator) GetFloatingIP(id string) (*floatingips.FloatingIP, error) {
+	if c.GetFloatingIPPreHook != nil {
+		handled, fip, err := c.GetFloatingIPPreHook(id)
+		if handled {
+			return fip, err
+		}
+	}
+	fip, err := c.ImplGetFloatingIP(id)
+	if c.GetFloatingIPPostHook != nil {
+		c.GetFloatingIPPostHook(id, fip, err)
+	}
+	return fip, err
+}
+
+func (c *NetworkSimulator) UpdateFloatingIP(id string, opts floatingips.UpdateOptsBuilder) (*floatingips.FloatingIP, error) {
+	if c.UpdateFloatingIPPreHook != nil {
+		handled, fip, err := c.UpdateFloatingIPPreHook(id, opts)
+		if handled {
+			return fip, err
+		}
+	}
+	fip, err := c.ImplUpdateFloatingIP(id, opts)
+	if c.UpdateFloatingIPPostHook != nil {
+		c.UpdateFloatingIPPostHook(id, opts, fip, err)
+	}
+	return fip, err
+}
+
+func (c *NetworkSimulator) ListPort(opts ports.ListOptsBuilder) ([]ports.Port, error) {
+	if c.ListPortPreHook != nil {
+		handled, ports, err := c.ListPortPreHook(opts)
+		if handled {
+			return ports, err
+		}
+	}
+	ports, err := c.ImplListPort(opts)
+	if c.ListPortPostHook != nil {
+		c.ListPortPostHook(opts, ports, err)
+	}
+	return ports, err
+}
+
+func (c *NetworkSimulator) CreatePort(opts ports.CreateOptsBuilder) (*ports.Port, error) {
+	if c.CreatePortPreHook != nil {
+		handled, port, err := c.CreatePortPreHook(opts)
+		if handled {
+			return port, err
+		}
+	}
+	port, err := c.ImplCreatePort(opts)
+	if c.CreatePortPostHook != nil {
+		c.CreatePortPostHook(opts, port, err)
+	}
+	return port, err
+}
+
+func (c *NetworkSimulator) DeletePort(id string) error {
+	if c.DeletePortPreHook != nil {
+		handled, err := c.DeletePortPreHook(id)
+		if handled {
+			return err
+		}
+	}
+	err := c.ImplDeletePort(id)
+	if c.DeletePortPostHook != nil {
+		c.DeletePortPostHook(id, err)
+	}
+	return err
+}
+
+func (c *NetworkSimulator) GetPort(id string) (*ports.Port, error) {
+	if c.GetPortPreHook != nil {
+		handled, port, err := c.GetPortPreHook(id)
+		if handled {
+			return port, err
+		}
+	}
+	port, err := c.ImplGetPort(id)
+	if c.GetPortPostHook != nil {
+		c.GetPortPostHook(id, port, err)
+	}
+	return port, err
+}
+
+func (c *NetworkSimulator) UpdatePort(id string, opts ports.UpdateOptsBuilder) (*ports.Port, error) {
+	if c.UpdatePortPreHook != nil {
+		handled, port, err := c.UpdatePortPreHook(id, opts)
+		if handled {
+			return port, err
+		}
+	}
+	port, err := c.ImplUpdatePort(id, opts)
+	if c.UpdatePortPostHook != nil {
+		c.UpdatePortPostHook(id, opts, port, err)
+	}
+	return port, err
+}
+
+func (c *NetworkSimulator) ListTrunk(opts trunks.ListOptsBuilder) ([]trunks.Trunk, error) {
+	if c.ListTrunkPreHook != nil {
+		handled, trunks, err := c.ListTrunkPreHook(opts)
+		if handled {
+			return trunks, err
+		}
+	}
+	trunks, err := c.ImplListTrunk(opts)
+	if c.ListTrunkPostHook != nil {
+		c.ListTrunkPostHook(opts, trunks, err)
+	}
+	return trunks, err
+}
+
+func (c *NetworkSimulator) CreateTrunk(opts trunks.CreateOptsBuilder) (*trunks.Trunk, error) {
+	if c.CreateTrunkPreHook != nil {
+		handled, trunk, err := c.CreateTrunkPreHook(opts)
+		if handled {
+			return trunk, err
+		}
+	}
+	trunk, err := c.ImplCreateTrunk(opts)
+	if c.CreateTrunkPostHook != nil {
+		c.CreateTrunkPostHook(opts, trunk, err)
+	}
+	return trunk, err
+}
+
+func (c *NetworkSimulator) DeleteTrunk(id string) error {
+	if c.DeleteTrunkPreHook != nil {
+		handled, err := c.DeleteTrunkPreHook(id)
+		if handled {
+			return err
+		}
+	}
+	err := c.ImplDeleteTrunk(id)
+	if c.DeleteTrunkPostHook != nil {
+		c.DeleteTrunkPostHook(id, err)
+	}
+	return err
+}
+
+func (c *NetworkSimulator) ListRouter(opts routers.ListOpts) ([]routers.Router, error) {
+	if c.ListRouterPreHook != nil {
+		handled, routers, err := c.ListRouterPreHook(opts)
+		if handled {
+			return routers, err
+		}
+	}
+	routers, err := c.ImplListRouter(opts)
+	if c.ListRouterPostHook != nil {
+		c.ListRouterPostHook(opts, routers, err)
+	}
+	return routers, err
+}
+
+func (c *NetworkSimulator) CreateRouter(opts routers.CreateOptsBuilder) (*routers.Router, error) {
+	if c.CreateRouterPreHook != nil {
+		handled, router, err := c.CreateRouterPreHook(opts)
+		if handled {
+			return router, err
+		}
+	}
+	router, err := c.ImplCreateRouter(opts)
+	if c.CreateRouterPostHook != nil {
+		c.CreateRouterPostHook(opts, router, err)
+	}
+	return router, err
+}
+
+func (c *NetworkSimulator) DeleteRouter(id string) error {
+	if c.DeleteRouterPreHook != nil {
+		handled, err := c.DeleteRouterPreHook(id)
+		if handled {
+			return err
+		}
+	}
+	err := c.ImplDeleteRouter(id)
+	if c.DeleteRouterPostHook != nil {
+		c.DeleteRouterPostHook(id, err)
+	}
+	return err
+}
+
+func (c *NetworkSimulator) GetRouter(id string) (*routers.Router, error) {
+	if c.GetRouterPreHook != nil {
+		handled, router, err := c.GetRouterPreHook(id)
+		if handled {
+			return router, err
+		}
+	}
+	router, err := c.ImplGetRouter(id)
+	if c.GetRouterPostHook != nil {
+		c.GetRouterPostHook(id, router, err)
+	}
+	return router, err
+}
+
+func (c *NetworkSimulator) UpdateRouter(id string, opts routers.UpdateOptsBuilder) (*routers.Router, error) {
+	if c.UpdateRouterPreHook != nil {
+		handled, router, err := c.UpdateRouterPreHook(id, opts)
+		if handled {
+			return router, err
+		}
+	}
+	router, err := c.ImplUpdateRouter(id, opts)
+	if c.UpdateRouterPostHook != nil {
+		c.UpdateRouterPostHook(id, opts, router, err)
+	}
+	return router, err
+}
+
+func (c *NetworkSimulator) AddRouterInterface(id string, opts routers.AddInterfaceOptsBuilder) (*routers.InterfaceInfo, error) {
+	if c.AddRouterInterfacePreHook != nil {
+		handled, info, err := c.AddRouterInterfacePreHook(id, opts)
+		if handled {
+			return info, err
+		}
+	}
+	info, err := c.ImplAddRouterInterface(id, opts)
+	if c.AddRouterInterfacePostHook != nil {
+		c.AddRouterInterfacePostHook(id, opts, info, err)
+	}
+	return info, err
+}
+
+func (c *NetworkSimulator) RemoveRouterInterface(id string, opts routers.RemoveInterfaceOptsBuilder) (*routers.InterfaceInfo, error) {
+	if c.RemoveRouterInterfacePreHook != nil {
+		handled, ifInfo, err := c.RemoveRouterInterfacePreHook(id, opts)
+		if handled {
+			return ifInfo, err
+		}
+	}
+	ifInfo, err := c.ImplRemoveRouterInterface(id, opts)
+	if c.RemoveRouterInterfacePostHook != nil {
+		c.RemoveRouterInterfacePostHook(id, opts, ifInfo, err)
+	}
+	return ifInfo, err
+}
+
+func (c *NetworkSimulator) ListSecGroup(opts groups.ListOpts) ([]groups.SecGroup, error) {
+	if c.ListSecGroupPreHook != nil {
+		handled, groups, err := c.ListSecGroupPreHook(opts)
+		if handled {
+			return groups, err
+		}
+	}
+	groups, err := c.ImplListSecGroup(opts)
+	if c.ListSecGroupPostHook != nil {
+		c.ListSecGroupPostHook(opts, groups, err)
+	}
+	return groups, err
+}
+
+func (c *NetworkSimulator) CreateSecGroup(opts groups.CreateOptsBuilder) (*groups.SecGroup, error) {
+	if c.CreateSecGroupPreHook != nil {
+		handled, group, err := c.CreateSecGroupPreHook(opts)
+		if handled {
+			return group, err
+		}
+	}
+	group, err := c.ImplCreateSecGroup(opts)
+	if c.CreateSecGroupPostHook != nil {
+		c.CreateSecGroupPostHook(opts, group, err)
+	}
+	return group, err
+}
+
+func (c *NetworkSimulator) DeleteSecGroup(id string) error {
+	if c.DeleteSecGroupPreHook != nil {
+		handled, err := c.DeleteSecGroupPreHook(id)
+		if handled {
+			return err
+		}
+	}
+	err := c.ImplDeleteSecGroup(id)
+	if c.DeleteSecGroupPostHook != nil {
+		c.DeleteSecGroupPostHook(id, err)
+	}
+	return err
+}
+
+func (c *NetworkSimulator) GetSecGroup(id string) (*groups.SecGroup, error) {
+	if c.GetSecGroupPreHook != nil {
+		handled, group, err := c.GetSecGroupPreHook(id)
+		if handled {
+			return group, err
+		}
+	}
+	group, err := c.ImplGetSecGroup(id)
+	if c.GetSecGroupPostHook != nil {
+		c.GetSecGroupPostHook(id, group, err)
+	}
+	return group, err
+}
+
+func (c *NetworkSimulator) UpdateSecGroup(id string, opts groups.UpdateOptsBuilder) (*groups.SecGroup, error) {
+	if c.UpdateSecGroupPreHook != nil {
+		handled, group, err := c.UpdateSecGroupPreHook(id, opts)
+		if handled {
+			return group, err
+		}
+	}
+	group, err := c.ImplUpdateSecGroup(id, opts)
+	if c.UpdateSecGroupPostHook != nil {
+		c.UpdateSecGroupPostHook(id, opts, group, err)
+	}
+	return group, err
+}
+
+func (c *NetworkSimulator) ListSecGroupRule(opts rules.ListOpts) ([]rules.SecGroupRule, error) {
+	if c.ListSecGroupRulePreHook != nil {
+		handled, rules, err := c.ListSecGroupRulePreHook(opts)
+		if handled {
+			return rules, err
+		}
+	}
+	rules, err := c.ImplListSecGroupRule(opts)
+	if c.ListSecGroupRulePostHook != nil {
+		c.ListSecGroupRulePostHook(opts, rules, err)
+	}
+	return rules, err
+}
+
+func (c *NetworkSimulator) CreateSecGroupRule(opts rules.CreateOptsBuilder) (*rules.SecGroupRule, error) {
+	if c.CreateSecGroupRulePreHook != nil {
+		handled, rule, err := c.CreateSecGroupRulePreHook(opts)
+		if handled {
+			return rule, err
+		}
+	}
+	rule, err := c.ImplCreateSecGroupRule(opts)
+	if c.CreateSecGroupRulePostHook != nil {
+		c.CreateSecGroupRulePostHook(opts, rule, err)
+	}
+	return rule, err
+}
+
+func (c *NetworkSimulator) DeleteSecGroupRule(id string) error {
+	if c.DeleteSecGroupRulePreHook != nil {
+		handled, err := c.DeleteSecGroupRulePreHook(id)
+		if handled {
+			return err
+		}
+	}
+	err := c.ImplDeleteSecGroupRule(id)
+	if c.DeleteSecGroupRulePostHook != nil {
+		c.DeleteSecGroupRulePostHook(id, err)
+	}
+	return err
+}
+
+func (c *NetworkSimulator) GetSecGroupRule(id string) (*rules.SecGroupRule, error) {
+	if c.GetSecGroupRulePreHook != nil {
+		handled, rule, err := c.GetSecGroupRulePreHook(id)
+		if handled {
+			return rule, err
+		}
+	}
+	rule, err := c.ImplGetSecGroupRule(id)
+	if c.GetSecGroupRulePostHook != nil {
+		c.GetSecGroupRulePostHook(id, rule, err)
+	}
+	return rule, err
+}
+
+func (c *NetworkSimulator) ListNetwork(opts networks.ListOptsBuilder) ([]networks.Network, error) {
+	if c.ListNetworkPreHook != nil {
+		handled, networks, err := c.ListNetworkPreHook(opts)
+		if handled {
+			return networks, err
+		}
+	}
+	networks, err := c.ImplListNetwork(opts)
+	if c.ListNetworkPostHook != nil {
+		c.ListNetworkPostHook(opts, networks, err)
+	}
+	return networks, err
+}
+
+func (c *NetworkSimulator) CreateNetwork(opts networks.CreateOptsBuilder) (*networks.Network, error) {
+	if c.CreateNetworkPreHook != nil {
+		handled, network, err := c.CreateNetworkPreHook(opts)
+		if handled {
+			return network, err
+		}
+	}
+	network, err := c.ImplCreateNetwork(opts)
+	if c.CreateNetworkPostHook != nil {
+		c.CreateNetworkPostHook(opts, network, err)
+	}
+	return network, err
+}
+
+func (c *NetworkSimulator) DeleteNetwork(id string) error {
+	if c.DeleteNetworkPreHook != nil {
+		handled, err := c.DeleteNetworkPreHook(id)
+		if handled {
+			return err
+		}
+	}
+	err := c.ImplDeleteNetwork(id)
+	if c.DeleteNetworkPostHook != nil {
+		c.DeleteNetworkPostHook(id, err)
+	}
+	return err
+}
+
+func (c *NetworkSimulator) GetNetwork(id string) (*networks.Network, error) {
+	if c.GetNetworkPreHook != nil {
+		handled, network, err := c.GetNetworkPreHook(id)
+		if handled {
+			return network, err
+		}
+	}
+	network, err := c.ImplGetNetwork(id)
+	if c.GetNetworkPostHook != nil {
+		c.GetNetworkPostHook(id, network, err)
+	}
+	return network, err
+}
+
+func (c *NetworkSimulator) UpdateNetwork(id string, opts networks.UpdateOptsBuilder) (*networks.Network, error) {
+	if c.UpdateNetworkPreHook != nil {
+		handled, network, err := c.UpdateNetworkPreHook(id, opts)
+		if handled {
+			return network, err
+		}
+	}
+	network, err := c.ImplUpdateNetwork(id, opts)
+	if c.UpdateNetworkPostHook != nil {
+		c.UpdateNetworkPostHook(id, opts, network, err)
+	}
+	return network, err
+}
+
+func (c *NetworkSimulator) ListSubnet(opts subnets.ListOptsBuilder) ([]subnets.Subnet, error) {
+	if c.ListSubnetPreHook != nil {
+		handled, subnets, err := c.ListSubnetPreHook(opts)
+		if handled {
+			return subnets, err
+		}
+	}
+	subnets, err := c.ImplListSubnet(opts)
+	if c.ListSubnetPostHook != nil {
+		c.ListSubnetPostHook(opts, subnets, err)
+	}
+	return subnets, err
+}
+
+func (c *NetworkSimulator) CreateSubnet(opts subnets.CreateOptsBuilder) (*subnets.Subnet, error) {
+	if c.CreateSubnetPreHook != nil {
+		handled, subnet, err := c.CreateSubnetPreHook(opts)
+		if handled {
+			return subnet, err
+		}
+	}
+	subnet, err := c.ImplCreateSubnet(opts)
+	if c.CreateSubnetPostHook != nil {
+		c.CreateSubnetPostHook(opts, subnet, err)
+	}
+	return subnet, err
+}
+
+func (c *NetworkSimulator) DeleteSubnet(id string) error {
+	if c.DeleteSubnetPreHook != nil {
+		handled, err := c.DeleteSubnetPreHook(id)
+		if handled {
+			return err
+		}
+	}
+	err := c.ImplDeleteSubnet(id)
+	if c.DeleteSubnetPostHook != nil {
+		c.DeleteSubnetPostHook(id, err)
+	}
+	return err
+}
+
+func (c *NetworkSimulator) GetSubnet(id string) (*subnets.Subnet, error) {
+	if c.GetSubnetPreHook != nil {
+		handled, subnet, err := c.GetSubnetPreHook(id)
+		if handled {
+			return subnet, err
+		}
+	}
+	subnet, err := c.ImplGetSubnet(id)
+	if c.GetSubnetPostHook != nil {
+		c.GetSubnetPostHook(id, subnet, err)
+	}
+	return subnet, err
+}
+
+func (c *NetworkSimulator) UpdateSubnet(id string, opts subnets.UpdateOptsBuilder) (*subnets.Subnet, error) {
+	if c.UpdateSubnetPreHook != nil {
+		handled, subnet, err := c.UpdateSubnetPreHook(id, opts)
+		if handled {
+			return subnet, err
+		}
+	}
+	subnet, err := c.ImplUpdateSubnet(id, opts)
+	if c.UpdateSubnetPostHook != nil {
+		c.UpdateSubnetPostHook(id, opts, subnet, err)
+	}
+	return subnet, err
+}
+
+func (c *NetworkSimulator) ListExtensions() ([]extensions.Extension, error) {
+	if c.ListExtensionsPreHook != nil {
+		handled, extensions, err := c.ListExtensionsPreHook()
+		if handled {
+			return extensions, err
+		}
+	}
+	extensions, err := c.ImplListExtensions()
+	if c.ListExtensionsPostHook != nil {
+		c.ListExtensionsPostHook(extensions, err)
+	}
+	return extensions, err
+}
+
+func (c *NetworkSimulator) ReplaceAllAttributesTags(resourceType string, resourceID string, opts attributestags.ReplaceAllOptsBuilder) ([]string, error) {
+	if c.ReplaceAllAttributesTagsPreHook != nil {
+		handled, tags, err := c.ReplaceAllAttributesTagsPreHook(resourceType, resourceID, opts)
+		if handled {
+			return tags, err
+		}
+	}
+	tags, err := c.ImplReplaceAllAttributesTags(resourceType, resourceID, opts)
+	if c.ReplaceAllAttributesTagsPostHook != nil {
+		c.ReplaceAllAttributesTagsPostHook(resourceType, resourceID, opts, tags, err)
+	}
+	return tags, err
+}
+
+/*
+ * Simulator state helpers
+ */
+
+func (c *NetworkSimulator) firstSubnetForNetwork(networkID string) *SimSubnet {
+	for _, subnet := range c.Subnets {
+		if subnet.NetworkID == networkID {
+			return &subnet
+		}
+	}
+	return nil
+}
+
+func (c *NetworkSimulator) SimAttachPort(portID, deviceID string) {
+	for i := range c.Ports {
+		port := &c.Ports[i]
+		if port.ID == portID {
+			port.DeviceID = deviceID
+			return
+		}
+	}
+}
+
+func (c *NetworkSimulator) SimAddTrunkSupport() {
+	trunkExtension := extensions.Extension{}
+	trunkExtension.Alias = "trunk"
+
+	c.Extensions = append(c.Extensions, trunkExtension)
+}
+
+func (c *NetworkSimulator) SimAddNetworkWithSubnet(name, uuid string, cidr string, external bool) {
+	network := SimNetwork{}
+	network.Name = name
+	network.ID = uuid
+	network.External = external
+
+	subnet := SimSubnet{}
+	subnet.Name = fmt.Sprintf("%s-subnet", name)
+	subnet.NetworkID = uuid
+	subnet.CIDR = cidr
+	_, ipNet, err := netutils.ParseCIDRSloppy(subnet.CIDR)
+	if err != nil {
+		panic(err)
+	}
+	subnet.SimIPNet = ipNet
+
+	c.Subnets = append(c.Subnets, subnet)
+	c.Networks = append(c.Networks, network)
+}
+
+func (c *NetworkSimulator) SimNextIPForSubnet(id string) (string, error) {
+	for i := range c.Subnets {
+		subnet := &c.Subnets[i]
+		if subnet.ID == id {
+			subnet.SimLastIP++
+			ip, err := netutils.GetIndexedIP(subnet.SimIPNet, subnet.SimLastIP)
+			if err != nil {
+				return "", err
+			}
+			return ip.String(), nil
+		}
+	}
+
+	// This is an error in the simulator or the test
+	panic("Subnet not found")
+}
+
+func (c *NetworkSimulator) SimSetActiveFloatingIP(id string) {
+	for i := range c.FloatingIPs {
+		fip := &c.FloatingIPs[i]
+		if fip.ID == id {
+			fip.Status = FloatingIPStatusActive
+			return
+		}
+	}
+}
+
+/*
+ * Default callbacks
+ */
+
+func (c *NetworkSimulator) CallBackFloatingIPSetActiveAfterAssociate(floatingIP string, _ floatingips.UpdateOptsBuilder, _ *floatingips.FloatingIP, err error) {
+	if err != nil {
+		return
+	}
+
+	go func() {
+		c.Simulator.DefaultDelay()
+		c.SimSetActiveFloatingIP(floatingIP)
+	}()
+}

--- a/pkg/clients/simulator/simulator.go
+++ b/pkg/clients/simulator/simulator.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"time"
+
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients"
+)
+
+type OpenStackSimulator struct {
+	Compute *ComputeSimulator
+	Image   *ImageSimulator
+	Lb      *LbSimulator
+	Network *NetworkSimulator
+	Volume  VolumeSimulator
+
+	DefaultDelay func()
+}
+
+func NewOpenStackSimulator() *OpenStackSimulator {
+	s := OpenStackSimulator{}
+	s.Compute = NewComputeSimulator(&s)
+	s.Image = NewImageSimulator(&s)
+	s.Lb = NewLbSimulator(&s)
+	s.Network = NewNetworkSimulator(&s)
+
+	s.DefaultDelay = func() {
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	return &s
+}
+
+func (s *OpenStackSimulator) NewComputeClient() (clients.ComputeClient, error) {
+	return s.Compute, nil
+}
+
+func (s *OpenStackSimulator) NewImageClient() (clients.ImageClient, error) {
+	return s.Image, nil
+}
+
+func (s *OpenStackSimulator) NewLbClient() (clients.LbClient, error) {
+	return s.Lb, nil
+}
+
+func (s *OpenStackSimulator) NewNetworkClient() (clients.NetworkClient, error) {
+	return s.Network, nil
+}
+
+func (s *OpenStackSimulator) NewVolumeClient() (clients.VolumeClient, error) {
+	return &s.Volume, nil
+}

--- a/pkg/clients/simulator/util.go
+++ b/pkg/clients/simulator/util.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+func getNameFromQuery(query string) (string, error) {
+	queryValues, err := getValuesFromQuery(query)
+	if err != nil {
+		return "", fmt.Errorf("parsing query: %w", err)
+	}
+
+	name, ok := queryValues["name"]
+	if !ok {
+		return "", fmt.Errorf("simulator only supports lookup by name. name not provided")
+	}
+	if len(queryValues) != 1 {
+		keys := []string{}
+		for k := range queryValues {
+			keys = append(keys, k)
+		}
+		return "", fmt.Errorf("simulator only supports lookup by name. Additional parameters given: %s", strings.Join(keys, " "))
+	}
+
+	return name, nil
+}
+
+func getValuesFromQuery(query string) (map[string]string, error) {
+	queryParsed, err := url.Parse(query)
+	if err != nil {
+		return nil, fmt.Errorf("parsing query: %w", err)
+	}
+
+	ret := make(map[string]string)
+
+	queryValues := queryParsed.Query()
+	for k, v := range queryValues {
+		switch {
+		case len(v) == 1:
+			ret[k] = v[0]
+		case len(v) > 1:
+			return nil, fmt.Errorf("multiple query values for %s", k)
+		}
+	}
+
+	return ret, nil
+}
+
+func generateUUID() string {
+	uuid, err := uuid.NewRandom()
+	if err != nil {
+		// Don't know why this would fail, but if it did it would be a simulator issue
+		panic(err)
+	}
+
+	return uuid.String()
+}

--- a/pkg/clients/simulator/volume.go
+++ b/pkg/clients/simulator/volume.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"fmt"
+
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
+)
+
+type VolumeSimulator struct{}
+
+func (c *VolumeSimulator) ListVolumes(opts volumes.ListOptsBuilder) ([]volumes.Volume, error) {
+	panic(fmt.Errorf("ListVolumes not implemented"))
+}
+
+func (c *VolumeSimulator) CreateVolume(opts volumes.CreateOptsBuilder) (*volumes.Volume, error) {
+	panic(fmt.Errorf("CreateVolume not implemented"))
+}
+
+func (c *VolumeSimulator) DeleteVolume(volumeID string, opts volumes.DeleteOptsBuilder) error {
+	panic(fmt.Errorf("DeleteVolume not implemented"))
+}
+
+func (c *VolumeSimulator) GetVolume(volumeID string) (*volumes.Volume, error) {
+	panic(fmt.Errorf("GetVolume not implemented"))
+}

--- a/pkg/clients/volume.go
+++ b/pkg/clients/volume.go
@@ -22,9 +22,9 @@ import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
+	"github.com/gophercloud/utils/openstack/clientconfig"
 
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/metrics"
-	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
 )
 
 type VolumeClient interface {
@@ -37,9 +37,9 @@ type VolumeClient interface {
 type volumeClient struct{ client *gophercloud.ServiceClient }
 
 // NewVolumeClient returns a new cinder client.
-func NewVolumeClient(scope *scope.Scope) (VolumeClient, error) {
-	volume, err := openstack.NewBlockStorageV3(scope.ProviderClient, gophercloud.EndpointOpts{
-		Region: scope.ProviderClientOpts.RegionName,
+func NewVolumeClient(providerClient *gophercloud.ProviderClient, providerClientOpts *clientconfig.ClientOpts) (VolumeClient, error) {
+	volume, err := openstack.NewBlockStorageV3(providerClient, gophercloud.EndpointOpts{
+		Region: providerClientOpts.RegionName,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create volume service client: %v", err)

--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -151,7 +151,7 @@ func (s *Service) createInstanceImpl(eventObject runtime.Object, openStackCluste
 		}
 
 		if err := s.deletePorts(eventObject, portList); err != nil {
-			s.scope.Logger.V(4).Error(err, "Failed to clean up ports after failure")
+			s.scope.Logger().V(4).Error(err, "Failed to clean up ports after failure")
 		}
 	}()
 
@@ -307,7 +307,7 @@ func (s *Service) getVolumeByName(name string) (*volumes.Volume, error) {
 	listOpts := volumes.ListOpts{
 		AllTenants: false,
 		Name:       name,
-		TenantID:   s.scope.ProjectID,
+		TenantID:   s.scope.ProjectID(),
 	}
 	volumeList, err := s.getVolumeClient().ListVolumes(listOpts)
 	if err != nil {
@@ -340,7 +340,7 @@ func (s *Service) getOrCreateRootVolume(eventObject runtime.Object, instanceSpec
 			return nil, fmt.Errorf("exected to find volume %s with size %d; found size %d", name, size, volume.Size)
 		}
 
-		s.scope.Logger.Info("using existing root volume %s", name)
+		s.scope.Logger().Info("using existing root volume %s", name)
 		return volume, nil
 	}
 
@@ -572,7 +572,7 @@ func (s *Service) DeleteInstance(eventObject runtime.Object, instanceStatus *Ins
 				return nil
 			}
 
-			s.scope.Logger.Info("deleting dangling root volume %s(%s)", volume.Name, volume.ID)
+			s.scope.Logger().Info("deleting dangling root volume %s(%s)", volume.Name, volume.ID)
 			return s.getVolumeClient().DeleteVolume(volume.ID, volumes.DeleteOpts{})
 		}
 
@@ -707,7 +707,7 @@ func (s *Service) GetInstanceStatus(resourceID string) (instance *InstanceStatus
 		return nil, fmt.Errorf("get server %q detail failed: %v", resourceID, err)
 	}
 
-	return &InstanceStatus{server, s.scope.Logger}, nil
+	return &InstanceStatus{server, s.scope.Logger()}, nil
 }
 
 func (s *Service) GetInstanceStatusByName(eventObject runtime.Object, name string) (instance *InstanceStatus, err error) {
@@ -734,7 +734,7 @@ func (s *Service) GetInstanceStatusByName(eventObject runtime.Object, name strin
 
 	// Return the first returned server, if any
 	for i := range serverList {
-		return &InstanceStatus{&serverList[i], s.scope.Logger}, nil
+		return &InstanceStatus{&serverList[i], s.scope.Logger()}, nil
 	}
 	return nil, nil
 }

--- a/pkg/cloud/services/compute/instance_test.go
+++ b/pkg/cloud/services/compute/instance_test.go
@@ -495,10 +495,7 @@ func TestService_getImageID(t *testing.T) {
 			tt.expect(mockImageClient.EXPECT())
 
 			s := Service{
-				scope: &scope.Scope{
-					ProjectID: "",
-					Logger:    logr.Discard(),
-				},
+				scope:              scope.NewTestScope("", logr.Discard()),
 				_imageClient:       mockImageClient,
 				_networkingService: &networking.Service{},
 			}
@@ -1004,10 +1001,7 @@ func TestService_ReconcileInstance(t *testing.T) {
 			tt.expect(&recorders{computeRecorder, imageRecorder, networkRecorder, volumeRecorder})
 
 			s := Service{
-				scope: &scope.Scope{
-					Logger:    logr.Discard(),
-					ProjectID: "",
-				},
+				scope:          scope.NewTestScope("", logr.Discard()),
 				_computeClient: mockComputeClient,
 				_imageClient:   mockImageClient,
 				_networkingService: networking.NewTestService(
@@ -1120,10 +1114,7 @@ func TestService_DeleteInstance(t *testing.T) {
 			tt.expect(&recorders{computeRecorder, networkRecorder, volumeRecorder})
 
 			s := Service{
-				scope: &scope.Scope{
-					ProjectID: "",
-					Logger:    logr.Discard(),
-				},
+				scope:          scope.NewTestScope("", logr.Discard()),
 				_computeClient: mockComputeClient,
 				_networkingService: networking.NewTestService(
 					"", mockNetworkClient, logr.Discard(),

--- a/pkg/cloud/services/compute/service.go
+++ b/pkg/cloud/services/compute/service.go
@@ -25,7 +25,7 @@ import (
 )
 
 type Service struct {
-	scope              *scope.Scope
+	scope              scope.Scope
 	_computeClient     clients.ComputeClient
 	_volumeClient      clients.VolumeClient
 	_imageClient       clients.ImageClient
@@ -33,11 +33,7 @@ type Service struct {
 }
 
 // NewService returns an instance of the compute service.
-func NewService(scope *scope.Scope) (*Service, error) {
-	if scope.ProviderClientOpts.AuthInfo == nil {
-		return nil, fmt.Errorf("authInfo must be set")
-	}
-
+func NewService(scope scope.Scope) (*Service, error) {
 	return &Service{
 		scope: scope,
 	}, nil
@@ -45,7 +41,7 @@ func NewService(scope *scope.Scope) (*Service, error) {
 
 func (s Service) getComputeClient() clients.ComputeClient {
 	if s._computeClient == nil {
-		computeClient, err := clients.NewComputeClient(s.scope.ProviderClient, s.scope.ProviderClientOpts)
+		computeClient, err := s.scope.NewComputeClient()
 		if err != nil {
 			return clients.NewComputeErrorClient(err)
 		}
@@ -58,7 +54,7 @@ func (s Service) getComputeClient() clients.ComputeClient {
 
 func (s Service) getVolumeClient() clients.VolumeClient {
 	if s._volumeClient == nil {
-		volumeClient, err := clients.NewVolumeClient(s.scope.ProviderClient, s.scope.ProviderClientOpts)
+		volumeClient, err := s.scope.NewVolumeClient()
 		if err != nil {
 			return clients.NewVolumeErrorClient(err)
 		}
@@ -71,7 +67,7 @@ func (s Service) getVolumeClient() clients.VolumeClient {
 
 func (s Service) getImageClient() clients.ImageClient {
 	if s._imageClient == nil {
-		imageClient, err := clients.NewImageClient(s.scope.ProviderClient, s.scope.ProviderClientOpts)
+		imageClient, err := s.scope.NewImageClient()
 		if err != nil {
 			return clients.NewImageErrorClient(err)
 		}

--- a/pkg/cloud/services/compute/service.go
+++ b/pkg/cloud/services/compute/service.go
@@ -45,7 +45,7 @@ func NewService(scope *scope.Scope) (*Service, error) {
 
 func (s Service) getComputeClient() clients.ComputeClient {
 	if s._computeClient == nil {
-		computeClient, err := clients.NewComputeClient(s.scope)
+		computeClient, err := clients.NewComputeClient(s.scope.ProviderClient, s.scope.ProviderClientOpts)
 		if err != nil {
 			return clients.NewComputeErrorClient(err)
 		}
@@ -58,7 +58,7 @@ func (s Service) getComputeClient() clients.ComputeClient {
 
 func (s Service) getVolumeClient() clients.VolumeClient {
 	if s._volumeClient == nil {
-		volumeClient, err := clients.NewVolumeClient(s.scope)
+		volumeClient, err := clients.NewVolumeClient(s.scope.ProviderClient, s.scope.ProviderClientOpts)
 		if err != nil {
 			return clients.NewVolumeErrorClient(err)
 		}
@@ -71,7 +71,7 @@ func (s Service) getVolumeClient() clients.VolumeClient {
 
 func (s Service) getImageClient() clients.ImageClient {
 	if s._imageClient == nil {
-		imageClient, err := clients.NewImageClient(s.scope)
+		imageClient, err := clients.NewImageClient(s.scope.ProviderClient, s.scope.ProviderClientOpts)
 		if err != nil {
 			return clients.NewImageErrorClient(err)
 		}

--- a/pkg/cloud/services/loadbalancer/loadbalancer.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer.go
@@ -49,7 +49,7 @@ const loadBalancerProvisioningStatusActive = "ACTIVE"
 
 func (s *Service) ReconcileLoadBalancer(openStackCluster *infrav1.OpenStackCluster, clusterName string, apiServerPort int) error {
 	loadBalancerName := getLoadBalancerName(clusterName)
-	s.scope.Logger.Info("Reconciling load balancer", "name", loadBalancerName)
+	s.scope.Logger().Info("Reconciling load balancer", "name", loadBalancerName)
 
 	var fixedIPAddress string
 	switch {
@@ -164,7 +164,7 @@ func (s *Service) getOrCreateLoadBalancer(openStackCluster *infrav1.OpenStackClu
 		return lb, nil
 	}
 
-	s.scope.Logger.Info(fmt.Sprintf("Creating load balancer in subnet: %q", subnetID), "name", loadBalancerName)
+	s.scope.Logger().Info(fmt.Sprintf("Creating load balancer in subnet: %q", subnetID), "name", loadBalancerName)
 
 	lbCreateOpts := loadbalancers.CreateOpts{
 		Name:        loadBalancerName,
@@ -193,7 +193,7 @@ func (s *Service) getOrCreateListener(openStackCluster *infrav1.OpenStackCluster
 		return listener, nil
 	}
 
-	s.scope.Logger.Info("Creating load balancer listener", "name", listenerName, "lb-id", lbID)
+	s.scope.Logger().Info("Creating load balancer listener", "name", listenerName, "lb-id", lbID)
 
 	listenerCreateOpts := listeners.CreateOpts{
 		Name:           listenerName,
@@ -296,7 +296,7 @@ func (s *Service) getOrCreatePool(openStackCluster *infrav1.OpenStackCluster, po
 		return pool, nil
 	}
 
-	s.scope.Logger.Info(fmt.Sprintf("Creating load balancer pool for listener %q", listenerID), "name", poolName, "lb-id", lbID)
+	s.scope.Logger().Info(fmt.Sprintf("Creating load balancer pool for listener %q", listenerID), "name", poolName, "lb-id", lbID)
 
 	poolCreateOpts := pools.CreateOpts{
 		Name:       poolName,
@@ -329,7 +329,7 @@ func (s *Service) getOrCreateMonitor(openStackCluster *infrav1.OpenStackCluster,
 		return nil
 	}
 
-	s.scope.Logger.Info(fmt.Sprintf("Creating load balancer monitor for pool %q", poolID), "name", monitorName, "lb-id", lbID)
+	s.scope.Logger().Info(fmt.Sprintf("Creating load balancer monitor for pool %q", poolID), "name", monitorName, "lb-id", lbID)
 
 	monitorCreateOpts := monitors.CreateOpts{
 		Name:           monitorName,
@@ -367,7 +367,7 @@ func (s *Service) ReconcileLoadBalancerMember(openStackCluster *infrav1.OpenStac
 	}
 
 	loadBalancerName := getLoadBalancerName(clusterName)
-	s.scope.Logger.Info("Reconciling load balancer member", "name", loadBalancerName)
+	s.scope.Logger().Info("Reconciling load balancer member", "name", loadBalancerName)
 
 	lbID := openStackCluster.Status.Network.APIServerLoadBalancer.ID
 	portList := []int{int(openStackCluster.Spec.ControlPlaneEndpoint.Port)}
@@ -396,7 +396,7 @@ func (s *Service) ReconcileLoadBalancerMember(openStackCluster *infrav1.OpenStac
 				continue
 			}
 
-			s.scope.Logger.Info("Deleting load balancer member (because the IP of the machine changed)", "name", name)
+			s.scope.Logger().Info("Deleting load balancer member (because the IP of the machine changed)", "name", name)
 
 			// lb member changed so let's delete it so we can create it again with the correct IP
 			err = s.waitForLoadBalancerActive(lbID)
@@ -412,7 +412,7 @@ func (s *Service) ReconcileLoadBalancerMember(openStackCluster *infrav1.OpenStac
 			}
 		}
 
-		s.scope.Logger.Info("Creating load balancer member", "name", name)
+		s.scope.Logger().Info("Creating load balancer member", "name", name)
 
 		// if we got to this point we should either create or re-create the lb member
 		lbMemberOpts := pools.CreateMemberOpts{
@@ -466,7 +466,7 @@ func (s *Service) DeleteLoadBalancer(openStackCluster *infrav1.OpenStackCluster,
 	deleteOpts := loadbalancers.DeleteOpts{
 		Cascade: true,
 	}
-	s.scope.Logger.Info("Deleting load balancer", "name", loadBalancerName, "cascade", deleteOpts.Cascade)
+	s.scope.Logger().Info("Deleting load balancer", "name", loadBalancerName, "cascade", deleteOpts.Cascade)
 	err = s.loadbalancerClient.DeleteLoadBalancer(lb.ID, deleteOpts)
 	if err != nil && !capoerrors.IsNotFound(err) {
 		record.Warnf(openStackCluster, "FailedDeleteLoadBalancer", "Failed to delete load balancer %s with id %s: %v", lb.Name, lb.ID, err)
@@ -505,7 +505,7 @@ func (s *Service) DeleteLoadBalancerMember(openStackCluster *infrav1.OpenStackCl
 			return err
 		}
 		if pool == nil {
-			s.scope.Logger.Info("Load balancer pool does not exist", "name", lbPortObjectsName)
+			s.scope.Logger().Info("Load balancer pool does not exist", "name", lbPortObjectsName)
 			continue
 		}
 
@@ -600,7 +600,7 @@ var backoff = wait.Backoff{
 
 // Possible LoadBalancer states are documented here: https://docs.openstack.org/api-ref/load-balancer/v2/index.html#prov-status
 func (s *Service) waitForLoadBalancerActive(id string) error {
-	s.scope.Logger.Info("Waiting for load balancer", "id", id, "targetStatus", "ACTIVE")
+	s.scope.Logger().Info("Waiting for load balancer", "id", id, "targetStatus", "ACTIVE")
 	return wait.ExponentialBackoff(backoff, func() (bool, error) {
 		lb, err := s.loadbalancerClient.GetLoadBalancer(id)
 		if err != nil {
@@ -611,7 +611,7 @@ func (s *Service) waitForLoadBalancerActive(id string) error {
 }
 
 func (s *Service) waitForListener(id, target string) error {
-	s.scope.Logger.Info("Waiting for load balancer listener", "id", id, "targetStatus", target)
+	s.scope.Logger().Info("Waiting for load balancer listener", "id", id, "targetStatus", target)
 	return wait.ExponentialBackoff(backoff, func() (bool, error) {
 		_, err := s.loadbalancerClient.GetListener(id)
 		if err != nil {

--- a/pkg/cloud/services/loadbalancer/service.go
+++ b/pkg/cloud/services/loadbalancer/service.go
@@ -28,15 +28,14 @@ import (
 
 // Service interfaces with the OpenStack Neutron LBaaS v2 API.
 type Service struct {
-	projectID          string
-	scope              *scope.Scope
+	scope              scope.Scope
 	loadbalancerClient clients.LbClient
 	networkingService  *networking.Service
 }
 
 // NewService returns an instance of the loadbalancer service.
-func NewService(scope *scope.Scope) (*Service, error) {
-	loadbalancerClient, err := clients.NewLbClient(scope.ProviderClient, scope.ProviderClientOpts)
+func NewService(scope scope.Scope) (*Service, error) {
+	loadbalancerClient, err := scope.NewLbClient()
 	if err != nil {
 		return nil, err
 	}
@@ -57,10 +56,7 @@ func NewService(scope *scope.Scope) (*Service, error) {
 // It helps to mock the load balancer service in other packages.
 func NewLoadBalancerTestService(projectID string, lbClient clients.LbClient, client *networking.Service, logger logr.Logger) *Service {
 	return &Service{
-		projectID: projectID,
-		scope: &scope.Scope{
-			Logger: logger,
-		},
+		scope:              scope.NewTestScope(projectID, logger),
 		loadbalancerClient: lbClient,
 		networkingService:  client,
 	}

--- a/pkg/cloud/services/loadbalancer/service.go
+++ b/pkg/cloud/services/loadbalancer/service.go
@@ -36,7 +36,7 @@ type Service struct {
 
 // NewService returns an instance of the loadbalancer service.
 func NewService(scope *scope.Scope) (*Service, error) {
-	loadbalancerClient, err := clients.NewLbClient(scope)
+	loadbalancerClient, err := clients.NewLbClient(scope.ProviderClient, scope.ProviderClientOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloud/services/networking/floatingip.go
+++ b/pkg/cloud/services/networking/floatingip.go
@@ -121,10 +121,10 @@ var backoff = wait.Backoff{
 }
 
 func (s *Service) AssociateFloatingIP(eventObject runtime.Object, fp *floatingips.FloatingIP, portID string) error {
-	s.scope.Logger.Info("Associating floating IP", "id", fp.ID, "ip", fp.FloatingIP)
+	s.scope.Logger().Info("Associating floating IP", "id", fp.ID, "ip", fp.FloatingIP)
 
 	if fp.PortID == portID {
-		s.scope.Logger.Info("Floating IP already associated:", "id", fp.ID, "ip", fp.FloatingIP)
+		s.scope.Logger().Info("Floating IP already associated:", "id", fp.ID, "ip", fp.FloatingIP)
 		return nil
 	}
 
@@ -153,11 +153,11 @@ func (s *Service) DisassociateFloatingIP(eventObject runtime.Object, ip string) 
 		return err
 	}
 	if fip == nil || fip.FloatingIP == "" {
-		s.scope.Logger.Info("Floating IP not associated", "ip", ip)
+		s.scope.Logger().Info("Floating IP not associated", "ip", ip)
 		return nil
 	}
 
-	s.scope.Logger.Info("Disassociating floating IP", "id", fip.ID, "ip", fip.FloatingIP)
+	s.scope.Logger().Info("Disassociating floating IP", "id", fip.ID, "ip", fip.FloatingIP)
 
 	fpUpdateOpts := &floatingips.UpdateOpts{
 		PortID: nil,
@@ -179,7 +179,7 @@ func (s *Service) DisassociateFloatingIP(eventObject runtime.Object, ip string) 
 }
 
 func (s *Service) waitForFloatingIP(id, target string) error {
-	s.scope.Logger.Info("Waiting for floating IP", "id", id, "targetStatus", target)
+	s.scope.Logger().Info("Waiting for floating IP", "id", id, "targetStatus", target)
 	return wait.ExponentialBackoff(backoff, func() (bool, error) {
 		fip, err := s.client.GetFloatingIP(id)
 		if err != nil {

--- a/pkg/cloud/services/networking/network.go
+++ b/pkg/cloud/services/networking/network.go
@@ -74,7 +74,7 @@ func (s *Service) ReconcileExternalNetwork(openStackCluster *infrav1.OpenStackCl
 	case 0:
 		// Not finding an external network is fine
 		openStackCluster.Status.ExternalNetwork = &infrav1.Network{}
-		s.scope.Logger.Info("No external network found - proceeding with internal network only")
+		s.scope.Logger().Info("No external network found - proceeding with internal network only")
 		return nil
 	case 1:
 		openStackCluster.Status.ExternalNetwork = &infrav1.Network{
@@ -82,7 +82,7 @@ func (s *Service) ReconcileExternalNetwork(openStackCluster *infrav1.OpenStackCl
 			Name: networkList[0].Name,
 			Tags: networkList[0].Tags,
 		}
-		s.scope.Logger.Info("External network found", "network id", networkList[0].ID)
+		s.scope.Logger().Info("External network found", "network id", networkList[0].ID)
 		return nil
 	}
 	return fmt.Errorf("found %d external networks, which should not happen", len(networkList))
@@ -90,7 +90,7 @@ func (s *Service) ReconcileExternalNetwork(openStackCluster *infrav1.OpenStackCl
 
 func (s *Service) ReconcileNetwork(openStackCluster *infrav1.OpenStackCluster, clusterName string) error {
 	networkName := getNetworkName(clusterName)
-	s.scope.Logger.Info("Reconciling network", "name", networkName)
+	s.scope.Logger().Info("Reconciling network", "name", networkName)
 
 	res, err := s.getNetworkByName(networkName)
 	if err != nil {
@@ -105,7 +105,7 @@ func (s *Service) ReconcileNetwork(openStackCluster *infrav1.OpenStackCluster, c
 			Tags: res.Tags,
 		}
 		sInfo := fmt.Sprintf("Reuse Existing Network %s with id %s", res.Name, res.ID)
-		s.scope.Logger.V(6).Info(sInfo)
+		s.scope.Logger().V(6).Info(sInfo)
 		return nil
 	}
 
@@ -169,12 +169,12 @@ func (s *Service) DeleteNetwork(openStackCluster *infrav1.OpenStackCluster, clus
 
 func (s *Service) ReconcileSubnet(openStackCluster *infrav1.OpenStackCluster, clusterName string) error {
 	if openStackCluster.Status.Network == nil || openStackCluster.Status.Network.ID == "" {
-		s.scope.Logger.V(4).Info("No need to reconcile network components since no network exists.")
+		s.scope.Logger().V(4).Info("No need to reconcile network components since no network exists.")
 		return nil
 	}
 
 	subnetName := getSubnetName(clusterName)
-	s.scope.Logger.Info("Reconciling subnet", "name", subnetName)
+	s.scope.Logger().Info("Reconciling subnet", "name", subnetName)
 
 	subnetList, err := s.client.ListSubnet(subnets.ListOpts{
 		NetworkID: openStackCluster.Status.Network.ID,
@@ -197,7 +197,7 @@ func (s *Service) ReconcileSubnet(openStackCluster *infrav1.OpenStackCluster, cl
 		}
 	} else if len(subnetList) == 1 {
 		subnet = &subnetList[0]
-		s.scope.Logger.V(6).Info(fmt.Sprintf("Reuse existing subnet %s with id %s", subnetName, subnet.ID))
+		s.scope.Logger().V(6).Info(fmt.Sprintf("Reuse existing subnet %s with id %s", subnetName, subnet.ID))
 	}
 
 	openStackCluster.Status.Network.Subnet = &infrav1.Subnet{

--- a/pkg/cloud/services/networking/router.go
+++ b/pkg/cloud/services/networking/router.go
@@ -32,20 +32,20 @@ import (
 
 func (s *Service) ReconcileRouter(openStackCluster *infrav1.OpenStackCluster, clusterName string) error {
 	if openStackCluster.Status.Network == nil || openStackCluster.Status.Network.ID == "" {
-		s.scope.Logger.V(3).Info("No need to reconcile router since no network exists.")
+		s.scope.Logger().V(3).Info("No need to reconcile router since no network exists.")
 		return nil
 	}
 	if openStackCluster.Status.Network.Subnet == nil || openStackCluster.Status.Network.Subnet.ID == "" {
-		s.scope.Logger.V(4).Info("No need to reconcile router since no subnet exists.")
+		s.scope.Logger().V(4).Info("No need to reconcile router since no subnet exists.")
 		return nil
 	}
 	if openStackCluster.Status.ExternalNetwork == nil || openStackCluster.Status.ExternalNetwork.ID == "" {
-		s.scope.Logger.V(3).Info("No need to create router, due to missing ExternalNetworkID.")
+		s.scope.Logger().V(3).Info("No need to create router, due to missing ExternalNetworkID.")
 		return nil
 	}
 
 	routerName := getRouterName(clusterName)
-	s.scope.Logger.Info("Reconciling router", "name", routerName)
+	s.scope.Logger().Info("Reconciling router", "name", routerName)
 
 	routerList, err := s.client.ListRouter(routers.ListOpts{
 		Name: routerName,
@@ -67,7 +67,7 @@ func (s *Service) ReconcileRouter(openStackCluster *infrav1.OpenStackCluster, cl
 		}
 	} else {
 		router = &routerList[0]
-		s.scope.Logger.V(6).Info(fmt.Sprintf("Reuse existing Router %s with id %s", routerName, router.ID))
+		s.scope.Logger().V(6).Info(fmt.Sprintf("Reuse existing Router %s with id %s", routerName, router.ID))
 	}
 
 	routerIPs := []string{}
@@ -107,14 +107,14 @@ INTERFACE_LOOP:
 
 	// ... and create a router interface for our subnet.
 	if createInterface {
-		s.scope.Logger.V(4).Info("Creating RouterInterface", "routerID", router.ID, "subnetID", openStackCluster.Status.Network.Subnet.ID)
+		s.scope.Logger().V(4).Info("Creating RouterInterface", "routerID", router.ID, "subnetID", openStackCluster.Status.Network.Subnet.ID)
 		routerInterface, err := s.client.AddRouterInterface(router.ID, routers.AddInterfaceOpts{
 			SubnetID: openStackCluster.Status.Network.Subnet.ID,
 		})
 		if err != nil {
 			return fmt.Errorf("unable to create router interface: %v", err)
 		}
-		s.scope.Logger.V(4).Info("Created RouterInterface", "id", routerInterface.ID)
+		s.scope.Logger().V(4).Info("Created RouterInterface", "id", routerInterface.ID)
 	}
 	return nil
 }
@@ -207,9 +207,9 @@ func (s *Service) DeleteRouter(openStackCluster *infrav1.OpenStackCluster, clust
 			if !capoerrors.IsNotFound(err) {
 				return fmt.Errorf("unable to remove router interface: %v", err)
 			}
-			s.scope.Logger.V(4).Info("Router Interface already removed, nothing to do", "id", router.ID)
+			s.scope.Logger().V(4).Info("Router Interface already removed, nothing to do", "id", router.ID)
 		} else {
-			s.scope.Logger.V(4).Info("Removed RouterInterface of Router", "id", router.ID)
+			s.scope.Logger().V(4).Info("Removed RouterInterface of Router", "id", router.ID)
 		}
 	}
 

--- a/pkg/cloud/services/networking/securitygroups.go
+++ b/pkg/cloud/services/networking/securitygroups.go
@@ -37,9 +37,9 @@ const (
 
 // ReconcileSecurityGroups reconcile the security groups.
 func (s *Service) ReconcileSecurityGroups(openStackCluster *infrav1.OpenStackCluster, clusterName string) error {
-	s.scope.Logger.Info("Reconciling security groups", "cluster", clusterName)
+	s.scope.Logger().Info("Reconciling security groups", "cluster", clusterName)
 	if !openStackCluster.Spec.ManagedSecurityGroups {
-		s.scope.Logger.V(4).Info("No need to reconcile security groups", "cluster", clusterName)
+		s.scope.Logger().V(4).Info("No need to reconcile security groups", "cluster", clusterName)
 		return nil
 	}
 
@@ -179,7 +179,7 @@ func (s *Service) GetSecurityGroups(securityGroupParams []infrav1.SecurityGroupP
 
 		listOpts := groups.ListOpts(sg.Filter)
 		if listOpts.ProjectID == "" {
-			listOpts.ProjectID = s.scope.ProjectID
+			listOpts.ProjectID = s.scope.ProjectID()
 		}
 		listOpts.Name = sg.Name
 		listOpts.ID = sg.UUID
@@ -285,16 +285,16 @@ func (s *Service) reconcileGroupRules(desired, observed infrav1.SecurityGroup) (
 		}
 	}
 
-	s.scope.Logger.V(4).Info("Deleting rules not needed anymore for group", "name", observed.Name, "amount", len(rulesToDelete))
+	s.scope.Logger().V(4).Info("Deleting rules not needed anymore for group", "name", observed.Name, "amount", len(rulesToDelete))
 	for _, rule := range rulesToDelete {
-		s.scope.Logger.V(6).Info("Deleting rule", "ruleID", rule.ID, "groupName", observed.Name)
+		s.scope.Logger().V(6).Info("Deleting rule", "ruleID", rule.ID, "groupName", observed.Name)
 		err := s.client.DeleteSecGroupRule(rule.ID)
 		if err != nil {
 			return infrav1.SecurityGroup{}, err
 		}
 	}
 
-	s.scope.Logger.V(4).Info("Creating new rules needed for group", "name", observed.Name, "amount", len(rulesToCreate))
+	s.scope.Logger().V(4).Info("Creating new rules needed for group", "name", observed.Name, "amount", len(rulesToCreate))
 	for _, rule := range rulesToCreate {
 		r := rule
 		r.SecurityGroupID = observed.ID
@@ -318,13 +318,13 @@ func (s *Service) createSecurityGroupIfNotExists(openStackCluster *infrav1.OpenS
 		return err
 	}
 	if secGroup == nil || secGroup.ID == "" {
-		s.scope.Logger.V(6).Info("Group doesn't exist, creating it.", "name", groupName)
+		s.scope.Logger().V(6).Info("Group doesn't exist, creating it.", "name", groupName)
 
 		createOpts := groups.CreateOpts{
 			Name:        groupName,
 			Description: "Cluster API managed group",
 		}
-		s.scope.Logger.V(6).Info("Creating group", "name", groupName)
+		s.scope.Logger().V(6).Info("Creating group", "name", groupName)
 
 		group, err := s.client.CreateSecGroup(createOpts)
 		if err != nil {
@@ -346,7 +346,7 @@ func (s *Service) createSecurityGroupIfNotExists(openStackCluster *infrav1.OpenS
 	}
 
 	sInfo := fmt.Sprintf("Reuse Existing SecurityGroup %s with %s", groupName, secGroup.ID)
-	s.scope.Logger.V(6).Info(sInfo)
+	s.scope.Logger().V(6).Info(sInfo)
 
 	return nil
 }
@@ -356,7 +356,7 @@ func (s *Service) getSecurityGroupByName(name string) (*infrav1.SecurityGroup, e
 		Name: name,
 	}
 
-	s.scope.Logger.V(6).Info("Attempting to fetch security group with", "name", name)
+	s.scope.Logger().V(6).Info("Attempting to fetch security group with", "name", name)
 	allGroups, err := s.client.ListSecGroup(opts)
 	if err != nil {
 		return &infrav1.SecurityGroup{}, err
@@ -388,7 +388,7 @@ func (s *Service) createRule(r infrav1.SecurityGroupRule) (infrav1.SecurityGroup
 		RemoteIPPrefix: r.RemoteIPPrefix,
 		SecGroupID:     r.SecurityGroupID,
 	}
-	s.scope.Logger.V(6).Info("Creating rule", "Description", r.Description, "Direction", dir, "PortRangeMin", r.PortRangeMin, "PortRangeMax", r.PortRangeMax, "Proto", proto, "etherType", etherType, "RemoteGroupID", r.RemoteGroupID, "RemoteIPPrefix", r.RemoteIPPrefix, "SecurityGroupID", r.SecurityGroupID)
+	s.scope.Logger().V(6).Info("Creating rule", "Description", r.Description, "Direction", dir, "PortRangeMin", r.PortRangeMin, "PortRangeMax", r.PortRangeMax, "Proto", proto, "etherType", etherType, "RemoteGroupID", r.RemoteGroupID, "RemoteIPPrefix", r.RemoteIPPrefix, "SecurityGroupID", r.SecurityGroupID)
 	rule, err := s.client.CreateSecGroupRule(createOpts)
 	if err != nil {
 		return infrav1.SecurityGroupRule{}, err

--- a/pkg/cloud/services/networking/service.go
+++ b/pkg/cloud/services/networking/service.go
@@ -44,7 +44,7 @@ type Service struct {
 
 // NewService returns an instance of the networking service.
 func NewService(scope *scope.Scope) (*Service, error) {
-	networkClient, err := clients.NewNetworkClient(scope)
+	networkClient, err := clients.NewNetworkClient(scope.ProviderClient, scope.ProviderClientOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scope/mock.go
+++ b/pkg/scope/mock.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scope
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"github.com/golang/mock/gomock"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha6"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients/mock"
+)
+
+// MockScopeFactory implements both the ScopeFactory and ClientScope interfaces. It can be used in place of the default ProviderScopeFactory
+// when we want to use mocked service clients which do not attempt to connect to a running OpenStack cloud.
+type MockScopeFactory struct {
+	ComputeClient *mock.MockComputeClient
+	NetworkClient *mock.MockNetworkClient
+	VolumeClient  *mock.MockVolumeClient
+	ImageClient   *mock.MockImageClient
+	LbClient      *mock.MockLbClient
+
+	clientScopeCreateError error
+
+	scope
+}
+
+func NewMockScopeFactory(mockCtrl *gomock.Controller) *MockScopeFactory {
+	computeClient := mock.NewMockComputeClient(mockCtrl)
+	volumeClient := mock.NewMockVolumeClient(mockCtrl)
+	imageClient := mock.NewMockImageClient(mockCtrl)
+	networkClient := mock.NewMockNetworkClient(mockCtrl)
+	lbClient := mock.NewMockLbClient(mockCtrl)
+
+	return &MockScopeFactory{
+		ComputeClient: computeClient,
+		VolumeClient:  volumeClient,
+		ImageClient:   imageClient,
+		NetworkClient: networkClient,
+		LbClient:      lbClient,
+		scope: scope{
+			projectID: "",
+			logger:    logr.Discard(),
+		},
+	}
+}
+
+func (f *MockScopeFactory) SetClientScopeCreateError(err error) {
+	f.clientScopeCreateError = err
+}
+
+func (f *MockScopeFactory) NewClientScopeFromMachine(ctx context.Context, ctrlClient client.Client, openStackMachine *infrav1.OpenStackMachine, logger logr.Logger) (Scope, error) {
+	if f.clientScopeCreateError != nil {
+		return nil, f.clientScopeCreateError
+	}
+	return f, nil
+}
+
+func (f *MockScopeFactory) NewClientScopeFromCluster(ctx context.Context, ctrlClient client.Client, openStackCluster *infrav1.OpenStackCluster, logger logr.Logger) (Scope, error) {
+	if f.clientScopeCreateError != nil {
+		return nil, f.clientScopeCreateError
+	}
+	return f, nil
+}
+
+func (f *MockScopeFactory) NewComputeClient() (clients.ComputeClient, error) {
+	return f.ComputeClient, nil
+}
+
+func (f *MockScopeFactory) NewVolumeClient() (clients.VolumeClient, error) {
+	return f.VolumeClient, nil
+}
+
+func (f *MockScopeFactory) NewImageClient() (clients.ImageClient, error) {
+	return f.ImageClient, nil
+}
+
+func (f *MockScopeFactory) NewNetworkClient() (clients.NetworkClient, error) {
+	return f.NetworkClient, nil
+}
+
+func (f *MockScopeFactory) NewLbClient() (clients.LbClient, error) {
+	return f.LbClient, nil
+}

--- a/pkg/scope/provider.go
+++ b/pkg/scope/provider.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package provider
+package scope
 
 import (
 	"context"
@@ -53,7 +53,7 @@ func NewClientFromMachine(ctx context.Context, ctrlClient client.Client, openSta
 			return nil, nil, "", err
 		}
 	}
-	return NewClient(cloud, caCert)
+	return NewProviderClient(cloud, caCert)
 }
 
 func NewClientFromCluster(ctx context.Context, ctrlClient client.Client, openStackCluster *infrav1.OpenStackCluster) (*gophercloud.ProviderClient, *clientconfig.ClientOpts, string, error) {
@@ -67,10 +67,10 @@ func NewClientFromCluster(ctx context.Context, ctrlClient client.Client, openSta
 			return nil, nil, "", err
 		}
 	}
-	return NewClient(cloud, caCert)
+	return NewProviderClient(cloud, caCert)
 }
 
-func NewClient(cloud clientconfig.Cloud, caCert []byte) (*gophercloud.ProviderClient, *clientconfig.ClientOpts, string, error) {
+func NewProviderClient(cloud clientconfig.Cloud, caCert []byte) (*gophercloud.ProviderClient, *clientconfig.ClientOpts, string, error) {
 	clientOpts := new(clientconfig.ClientOpts)
 	if cloud.AuthInfo != nil {
 		clientOpts.AuthInfo = cloud.AuthInfo

--- a/pkg/scope/provider.go
+++ b/pkg/scope/provider.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/go-logr/logr"
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
@@ -42,7 +43,12 @@ const (
 	caSecretKey     = "cacert"
 )
 
-func NewClientFromMachine(ctx context.Context, ctrlClient client.Client, openStackMachine *infrav1.OpenStackMachine) (*gophercloud.ProviderClient, *clientconfig.ClientOpts, string, error) {
+// ScopeFactory is the default scope factory. It generates service clients which make OpenStack API calls against a running cloud.
+var ScopeFactory Factory = scopeFactory{}
+
+type scopeFactory struct{}
+
+func (scopeFactory) NewClientScopeFromMachine(ctx context.Context, ctrlClient client.Client, openStackMachine *infrav1.OpenStackMachine, logger logr.Logger) (Scope, error) {
 	var cloud clientconfig.Cloud
 	var caCert []byte
 
@@ -50,13 +56,13 @@ func NewClientFromMachine(ctx context.Context, ctrlClient client.Client, openSta
 		var err error
 		cloud, caCert, err = getCloudFromSecret(ctx, ctrlClient, openStackMachine.Namespace, openStackMachine.Spec.IdentityRef.Name, openStackMachine.Spec.CloudName)
 		if err != nil {
-			return nil, nil, "", err
+			return nil, err
 		}
 	}
-	return NewProviderClient(cloud, caCert)
+	return NewScope(cloud, caCert, logger)
 }
 
-func NewClientFromCluster(ctx context.Context, ctrlClient client.Client, openStackCluster *infrav1.OpenStackCluster) (*gophercloud.ProviderClient, *clientconfig.ClientOpts, string, error) {
+func (scopeFactory) NewClientScopeFromCluster(ctx context.Context, ctrlClient client.Client, openStackCluster *infrav1.OpenStackCluster, logger logr.Logger) (Scope, error) {
 	var cloud clientconfig.Cloud
 	var caCert []byte
 
@@ -64,10 +70,10 @@ func NewClientFromCluster(ctx context.Context, ctrlClient client.Client, openSta
 		var err error
 		cloud, caCert, err = getCloudFromSecret(ctx, ctrlClient, openStackCluster.Namespace, openStackCluster.Spec.IdentityRef.Name, openStackCluster.Spec.CloudName)
 		if err != nil {
-			return nil, nil, "", err
+			return nil, err
 		}
 	}
-	return NewProviderClient(cloud, caCert)
+	return NewScope(cloud, caCert, logger)
 }
 
 func NewProviderClient(cloud clientconfig.Cloud, caCert []byte) (*gophercloud.ProviderClient, *clientconfig.ClientOpts, string, error) {

--- a/pkg/scope/scope.go
+++ b/pkg/scope/scope.go
@@ -17,22 +17,92 @@ limitations under the License.
 package scope
 
 import (
+	"context"
+
 	"github.com/go-logr/logr"
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/utils/openstack/clientconfig"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha6"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients"
 )
 
-// Scope is used to initialize Services from Controllers and includes the
-// common objects required for this.
-//
-// The Gophercloud ProviderClient and ClientOpts are required to create new
-// Gophercloud API Clients (e.g. for Networking/Neutron).
-//
-// The Logger includes context values such as the cluster name.
-type Scope struct {
-	ProviderClient     *gophercloud.ProviderClient
-	ProviderClientOpts *clientconfig.ClientOpts
-	ProjectID          string
+// Factory instantiates a new ClientScope using credentials from either a cluster or a machine.
+type Factory interface {
+	NewClientScopeFromMachine(ctx context.Context, ctrlClient client.Client, openStackMachine *infrav1.OpenStackMachine, logger logr.Logger) (Scope, error)
+	NewClientScopeFromCluster(ctx context.Context, ctrlClient client.Client, openStackCluster *infrav1.OpenStackCluster, logger logr.Logger) (Scope, error)
+}
 
-	Logger logr.Logger
+// Scope contains arguments common to most operations.
+type Scope interface {
+	NewComputeClient() (clients.ComputeClient, error)
+	NewVolumeClient() (clients.VolumeClient, error)
+	NewImageClient() (clients.ImageClient, error)
+	NewNetworkClient() (clients.NetworkClient, error)
+	NewLbClient() (clients.LbClient, error)
+	Logger() logr.Logger
+	ProjectID() string
+}
+
+type scope struct {
+	providerClient     *gophercloud.ProviderClient
+	providerClientOpts *clientconfig.ClientOpts
+	projectID          string
+	logger             logr.Logger
+}
+
+// NewTestScope returns a Scope with no initialization. It should only be used by tests.
+func NewTestScope(projectID string, logger logr.Logger) Scope {
+	providerClient := new(gophercloud.ProviderClient)
+	clientOpts := new(clientconfig.ClientOpts)
+
+	return &scope{
+		providerClient:     providerClient,
+		providerClientOpts: clientOpts,
+		projectID:          projectID,
+		logger:             logger,
+	}
+}
+
+func NewScope(cloud clientconfig.Cloud, caCert []byte, logger logr.Logger) (Scope, error) {
+	providerClient, clientOpts, projectID, err := NewProviderClient(cloud, caCert)
+	if err != nil {
+		return nil, err
+	}
+
+	return &scope{
+		providerClient:     providerClient,
+		providerClientOpts: clientOpts,
+		projectID:          projectID,
+		logger:             logger,
+	}, nil
+}
+
+func (s *scope) Logger() logr.Logger {
+	return s.logger
+}
+
+func (s *scope) ProjectID() string {
+	return s.projectID
+}
+
+func (s *scope) NewComputeClient() (clients.ComputeClient, error) {
+	return clients.NewComputeClient(s.providerClient, s.providerClientOpts)
+}
+
+func (s *scope) NewNetworkClient() (clients.NetworkClient, error) {
+	return clients.NewNetworkClient(s.providerClient, s.providerClientOpts)
+}
+
+func (s *scope) NewVolumeClient() (clients.VolumeClient, error) {
+	return clients.NewVolumeClient(s.providerClient, s.providerClientOpts)
+}
+
+func (s *scope) NewImageClient() (clients.ImageClient, error) {
+	return clients.NewImageClient(s.providerClient, s.providerClientOpts)
+}
+
+func (s *scope) NewLbClient() (clients.LbClient, error) {
+	return clients.NewLbClient(s.providerClient, s.providerClientOpts)
 }

--- a/pkg/scope/simulator.go
+++ b/pkg/scope/simulator.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scope
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha6"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients/simulator"
+)
+
+type SimulatorScopeFactory struct {
+	simulator *simulator.OpenStackSimulator
+	projectID string
+	logger    logr.Logger
+}
+
+func NewSimulatorScopeFactory(simulator *simulator.OpenStackSimulator, projectID string, logger logr.Logger) *SimulatorScopeFactory {
+	return &SimulatorScopeFactory{
+		simulator: simulator,
+		projectID: projectID,
+		logger:    logger,
+	}
+}
+
+func (f *SimulatorScopeFactory) ProjectID() string {
+	return f.projectID
+}
+
+func (f *SimulatorScopeFactory) Logger() logr.Logger {
+	return f.logger
+}
+
+func (f *SimulatorScopeFactory) NewClientScopeFromMachine(ctx context.Context, ctrlClient client.Client, openStackMachine *infrav1.OpenStackMachine, logger logr.Logger) (Scope, error) {
+	return f, nil
+}
+
+func (f *SimulatorScopeFactory) NewClientScopeFromCluster(ctx context.Context, ctrlClient client.Client, openStackCluster *infrav1.OpenStackCluster, logger logr.Logger) (Scope, error) {
+	return f, nil
+}
+
+func (f *SimulatorScopeFactory) NewComputeClient() (clients.ComputeClient, error) {
+	return f.simulator.NewComputeClient()
+}
+
+func (f *SimulatorScopeFactory) NewVolumeClient() (clients.VolumeClient, error) {
+	return f.simulator.NewVolumeClient()
+}
+
+func (f *SimulatorScopeFactory) NewImageClient() (clients.ImageClient, error) {
+	return f.simulator.NewImageClient()
+}
+
+func (f *SimulatorScopeFactory) NewNetworkClient() (clients.NetworkClient, error) {
+	return f.simulator.NewNetworkClient()
+}
+
+func (f *SimulatorScopeFactory) NewLbClient() (clients.LbClient, error) {
+	return f.simulator.NewLbClient()
+}

--- a/test/e2e/shared/openstack.go
+++ b/test/e2e/shared/openstack.go
@@ -53,7 +53,7 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha6"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/compute"
-	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/provider"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
 )
 
 type ServerExtWithIP struct {
@@ -494,7 +494,7 @@ func getProviderClient(e2eCtx *E2EContext, openstackCloud string) (*gophercloud.
 	clouds := getParsedOpenStackCloudYAML(openStackCloudYAMLFile)
 	cloud := clouds.Clouds[openstackCloud]
 
-	providerClient, clientOpts, projectID, err := provider.NewClient(cloud, nil)
+	providerClient, clientOpts, projectID, err := scope.NewProviderClient(cloud, nil)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/test/template_reader.go
+++ b/test/template_reader.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"bytes"
+	"embed"
+	"encoding/base64"
+	"fmt"
+	"path"
+	"reflect"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+)
+
+type TemplateVars struct {
+	ClusterName                        string `template:"CLUSTER_NAME"`
+	CNIResources                       string `template:"CNI_RESOURCES"`
+	ControlPlaneMachineCount           string `template:"CONTROL_PLANE_MACHINE_COUNT"`
+	KubernetesVersion                  string `template:"KUBERNETES_VERSION"`
+	OpenStackBastionImageName          string `template:"OPENSTACK_BASTION_IMAGE_NAME"`
+	OpenStackBastionMachineFlavor      string `template:"OPENSTACK_BASTION_MACHINE_FLAVOR"`
+	OpenStackCloud                     string `template:"OPENSTACK_CLOUD"`
+	OpenStackCloudCACert               string `template:"OPENSTACK_CLOUD_CACERT_B64"`
+	OpenStackCloudProviderConf         string `template:"OPENSTACK_CLOUD_PROVIDER_CONF_B64"`
+	OpenStackCloudYAML                 string `template:"OPENSTACK_CLOUD_YAML_B64"`
+	OpenStackControlPlaneMachineFlavor string `template:"OPENSTACK_CONTROL_PLANE_MACHINE_FLAVOR"`
+	OpenStackDNSNameservers            string `template:"OPENSTACK_DNS_NAMESERVERS"`
+	OpenStackExternalNetworkID         string `template:"OPENSTACK_EXTERNAL_NETWORK_ID"`
+	OpenStackFailureDomain             string `template:"OPENSTACK_FAILURE_DOMAIN"`
+	OpenStackImageName                 string `template:"OPENSTACK_IMAGE_NAME"`
+	OpenStackNodeMachineFlavor         string `template:"OPENSTACK_NODE_MACHINE_FLAVOR"`
+	OpenStackSSHKeyName                string `template:"OPENSTACK_SSH_KEY_NAME"`
+	WorkerMachineCount                 string `template:"WORKER_MACHINE_COUNT"`
+}
+
+//go:embed e2e/data/infrastructure-openstack/*.yaml
+var fs embed.FS
+
+func ReadFile(name string) ([]byte, error) {
+	return fs.ReadFile(path.Join("e2e/data/infrastructure-openstack", name))
+}
+
+func Substitute(b []byte, vars TemplateVars) []byte {
+	s := string(b)
+
+	t := reflect.TypeOf(vars)
+	v := reflect.ValueOf(vars)
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		tag := f.Tag.Get("template")
+		value := v.Field(i).String()
+
+		if strings.HasSuffix(tag, "_B64") {
+			b64 := base64.StdEncoding.EncodeToString([]byte(value))
+			value = fmt.Sprintf("%q", b64)
+		}
+
+		s = strings.Replace(s, fmt.Sprintf("${%s}", tag), value, -1)
+	}
+
+	return []byte(s)
+}
+
+func SplitYAML(b []byte) [][]byte {
+	const separator = "\n---"
+
+	ret := [][]byte{}
+	pos := 0
+	for {
+		i := bytes.Index(b[pos:], []byte(separator))
+		if i > 0 {
+			ret = append(ret, b[pos:pos+i])
+			pos += i + len(separator)
+		} else {
+			return append(ret, b[pos:])
+		}
+	}
+}
+
+func ReadObject(b []byte, scheme *runtime.Scheme) (runtime.Object, error) {
+	codecs := serializer.NewCodecFactory(scheme)
+	decoder := codecs.UniversalDeserializer()
+
+	obj, _, err := decoder.Decode(b, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+func ReadTemplatedObjects(name string, vars TemplateVars, scheme *runtime.Scheme) ([]runtime.Object, error) {
+	b, err := ReadFile(name)
+	if err != nil {
+		return nil, err
+	}
+
+	templated := Substitute(b, vars)
+	yamls := SplitYAML(templated)
+
+	objs := []runtime.Object{}
+	for _, yaml := range yamls {
+		o, err := ReadObject(yaml, scheme)
+		if err != nil {
+			return nil, err
+		}
+
+		objs = append(objs, o)
+	}
+
+	return objs, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR builds on the work done in the (unmerged) #1236. That PR added the ability to substitute implementations of the service Scope and introduced a Mock implementation.

This change goes a step further and introduces a simulator. The simulator intends to provide realistic responses to OpenStack API calls. For example, if a controller creates a Router while reconciling, listing routers on a subsequent reconciliation will include the created Router in the response until it is deleted.

Tests are able to inspect the internal state of the simulator to determine what OpenStack changes were made in response to API changes. Additionally, all OpenStack calls have Pre- and Post- hooks.

Pre-hook callbacks receive the arguments to the OpenStack call and return the expected response types with the addition of a 'handled' boolean. If Pre-hook callback sets handled then the simulator implementation will be called. The intended usage is custom behaviour modification, including error injection. 

Post-hook callbacks receive the arguments the method was called with in addition to the values returned by the simulator. Post-hooks will not be called if a pre-hook set handled.

The simulator is not complete, and likely contains a lot of bugs and inaccuracies. Where the simulator is incomplete it will explicitly `panic` with a message indicating the API call which is not yet implemented. However, it seems to be complete enough to to write useful tests today, and we can fix and extend it over time.

**Special notes for your reviewer**:
Commits in this PR up to `Correct typo` by @stephenfin are part of  #1236. If we push this PR it will obsolete the other one. Alternatively we could approve #1236 separately and I'll rebase this on top. My preference would be the latter.

This PR also current contains  #1386, which is now approved. I will rebase when that lands.

To understand what this change is about, I recommend starting with the last commit. This includes some tests that actually use the simulator. The implementation is contained in the prior commit.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] Rebase on top of #1386
- [ ] Rebase on top of #1236 (if we decide to do that)

/hold
