### PR TITLE
🐛 Allow UDP traffic over nodeports

### DIFF
--- a/pkg/cloud/services/networking/securitygroups_rules.go
+++ b/pkg/cloud/services/networking/securitygroups_rules.go
@@ -232,6 +232,14 @@ func GetSGWorkerNodePort() []infrav1.SecurityGroupRule {
 			PortRangeMax: 32767,
 			Protocol:     "tcp",
 		},
+		{
+			Description:  "Node Port Services",
+			Direction:    "ingress",
+			EtherType:    "IPv4",
+			PortRangeMin: 30000,
+			PortRangeMax: 32767,
+			Protocol:     "udp",
+		},
 	}
 }
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR adds a security group rule to allow UDP over nodeports.

Currently CAPO only allows TCP traffic to pass.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1395

**Special notes for your reviewer**:
N/A

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
