### PR TITLE
🐛 Don't enable router-ovn service in CI deployments

### DIFF
--- a/hack/ci/cloud-init/controller.yaml.tpl
+++ b/hack/ci/cloud-init/controller.yaml.tpl
@@ -82,7 +82,7 @@
 
     [[post-config|$NEUTRON_CONF]]
     [DEFAULT]
-    service_plugins = ovn-router,trunk, router
+    service_plugins = trunk,router
 - path: /tmp/register-worker.sh
   permissions: 0755
   content: |


### PR DESCRIPTION
**What this PR does / why we need it**:

We are currently using the ML2-OVS neutron, not ML2-OVN. It doesn't make sense to enable the router-ovn service and should actually result in an error [1]. Don't do it.

[1] https://bugs.launchpad.net/neutron/+bug/1997970

**Which issue(s) this PR fixes**

Fixes #1397

**Special notes for your reviewer**:

None.

**TODOs**:

N/A.