### PR TITLE
🌱 scripts: replace apt with apt-get 

### DIFF
--- a/scripts/ci-conformance.sh
+++ b/scripts/ci-conformance.sh
@@ -46,8 +46,8 @@ cleanup() {
 trap cleanup EXIT
 
 # Ensure that python3-pip is installed.
-apt update
-apt install -y python3-pip
+apt-get update -y
+apt-get install -y python3-pip
 rm -rf /var/lib/apt/lists/*
 
 # Install/upgrade pip and requests module explicitly for HTTP calls.

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -47,8 +47,8 @@ cleanup() {
 trap cleanup EXIT
 
 # Ensure that python3-pip is installed.
-apt update
-apt install -y python3-pip
+apt-get update -y
+apt-get install -y python3-pip
 rm -rf /var/lib/apt/lists/*
 
 # Install/upgrade pip and requests module explicitly for HTTP calls.


### PR DESCRIPTION
apt does not have stable CLI, and should not be used in scripts directly. Apt prints out warnings about it on each invocation. Replace apt with apt-get.