### PR TITLE
deleting dangling ports when instance enter error status

### DIFF
--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -280,6 +280,10 @@ func (s *Service) createInstanceImpl(eventObject runtime.Object, openStackCluste
 	})
 	if err != nil {
 		record.Warnf(eventObject, "FailedCreateServer", "Failed to create server %s: %v", createdInstance.Name(), err)
+
+		// we failed to create instance, now with this server = nil, we will let the defer function handle the
+		// defer action to clean up all the ports as it's in infrav1.InstanceStateError status
+		server = nil
 		return nil, err
 	}
 

--- a/pkg/cloud/services/compute/instance_test.go
+++ b/pkg/cloud/services/compute/instance_test.go
@@ -806,7 +806,9 @@ func TestService_ReconcileInstance(t *testing.T) {
 				expectCreateServer(r.compute, getDefaultServerMap(), false)
 				expectServerPoll(r.compute, []string{"BUILDING", "ERROR"})
 
-				// Don't delete ports because the server is created: DeleteInstance will do it
+				// we should delete ports when server ERROR, as we don't know
+				// whether port attached to instance or not
+				expectCleanupDefaultPort(r.network)
 			},
 			wantErr: true,
 		},


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1404 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
