### PR TITLE
🌱 Add e2e self hosted test

### DIFF
--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -116,6 +116,10 @@ variables:
   # used to ensure we deploy to the correct management cluster
   KUBE_CONTEXT: "kind-capo-e2e"
   KUBERNETES_VERSION: "v1.25.0"
+  KUBERNETES_VERSION_UPGRADE_FROM: "v1.24.9"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.25.0"
+  ETCD_VERSION_UPGRADE_TO: "3.5.4-0"
+  COREDNS_VERSION_UPGRADE_TO: "v1.9.3"
   CNI: "../../data/cni/calico.yaml"
   CCM: "../../data/ccm/cloud-controller-manager.yaml"
   EXP_CLUSTER_RESOURCE_SET: "true"
@@ -148,3 +152,5 @@ intervals:
   default/wait-worker-nodes: ["30m", "10s"]
   default/wait-delete-cluster: ["5m", "10s"]
   default/wait-alt-az: ["20m", "30s"]
+  default/wait-machine-upgrade: ["30m", "10s"]
+  default/wait-nodes-ready: ["15m", "10s"]

--- a/test/e2e/suites/e2e/self_hosted_test.go
+++ b/test/e2e/suites/e2e/self_hosted_test.go
@@ -1,0 +1,52 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	capie2e "sigs.k8s.io/cluster-api/test/e2e"
+
+	"sigs.k8s.io/cluster-api-provider-openstack/test/e2e/shared"
+)
+
+var _ = Describe("When testing Cluster API provider Openstack working on [self-hosted] clusters", func() {
+	ctx := context.TODO()
+	shared.SetEnvVar("USE_CI_ARTIFACTS", "true", false)
+	shared.SetEnvVar("DOWNLOAD_E2E_IMAGE", "true", false)
+	// TODO(lentzi90): Since we currently rely on USE_CI_ARTIFACTS to get kubernetes set up,
+	// we are stuck with one version only and cannot do the k8s upgrade that is part of the
+	// SelfHostedSpec. The reason for this is that the script used to install kubernetes tools comes
+	// with the KubeadmControlPlane and that does not change when upgrading the k8s version
+	// (only the machineTemplate changes).
+	// Until we have a way to work around this, the k8s upgrade test is disabled.
+	capie2e.SelfHostedSpec(ctx, func() capie2e.SelfHostedSpecInput {
+		return capie2e.SelfHostedSpecInput{
+			E2EConfig:             e2eCtx.E2EConfig,
+			ClusterctlConfigPath:  e2eCtx.Environment.ClusterctlConfigPath,
+			BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
+			ArtifactFolder:        e2eCtx.Settings.ArtifactFolder,
+			SkipUpgrade:           true,
+			SkipCleanup:           false,
+			Flavor:                shared.FlavorDefault,
+		}
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds e2e self hosted test. This is a test spec [implemented in CAPI](https://github.com/kubernetes-sigs/cluster-api/blob/main/test/e2e/self_hosted.go) that checks the `clusterctl move` functionality, i.e. that the controllers can be moved from the bootstrap cluster to a workload cluster. It also checks that the controllers are functioning in the new cluster, and can handle node rotations, by doing a k8s upgrade.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #1363

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.
2. This would not be part of the normal e2e tests, only e2e-full.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
