### PR TITLE
🐛 Fix Tilt by adding CAPO label in tilt-provider.json

### DIFF
--- a/tilt-provider.json
+++ b/tilt-provider.json
@@ -10,6 +10,7 @@
         "config",
         "controllers",
         "pkg"
-      ]
+      ],
+      "label": "CAPO"
     }
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Following https://github.com/kubernetes-sigs/cluster-api/pull/5217, tilt expects a label field in tilt-provider files

The documentation for reference: https://cluster-api.sigs.k8s.io/developer/tilt.html#tilt-provider-configuration

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
