### PR TITLE
🌱Be more robust when checking gophercloud errors in IsNotFound

### DIFF
--- a/pkg/utils/errors/errors.go
+++ b/pkg/utils/errors/errors.go
@@ -33,13 +33,15 @@ func IsRetryable(err error) bool {
 }
 
 func IsNotFound(err error) bool {
+	// Gophercloud is not consistent in how it returns 404 errors. Sometimes
+	// it returns a pointer to the error, sometimes it returns the error
+	// directly.
+	// Some discussion here: https://github.com/gophercloud/gophercloud/issues/2279
 	var errDefault404 gophercloud.ErrDefault404
-	if errors.As(err, &errDefault404) {
-		return true
-	}
-
-	var errResourceNotFound gophercloud.ErrResourceNotFound
-	if errors.As(err, &errResourceNotFound) {
+	var pErrDefault404 *gophercloud.ErrDefault404
+	var errNotFound gophercloud.ErrResourceNotFound
+	var pErrNotFound *gophercloud.ErrResourceNotFound
+	if errors.As(err, &errDefault404) || errors.As(err, &pErrDefault404) || errors.As(err, &errNotFound) || errors.As(err, &pErrNotFound) {
 		return true
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

As [discussed here](https://github.com/gophercloud/gophercloud/issues/2279) gophercloud is not consistent in whether it returns `error` or `*error`. [IsNotFound](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/ba962696a8affa2fde65232ed4d28bf241b5ddab/pkg/utils/errors/errors.go#L35-L36) currently assumes that the error it has been given is not a pointer, and will incorrectly return false if it is a pointer.

Rather than audit CAPO to determine all the possible sources of errors we pass to IsNotFound and checking gophercloud to ensure they are not pointers, this change simply checks both.

/hold
/cc @pierreprinetti 