### PR TITLE
🌱 E2e: Use plain ubuntu cloud image

### DIFF
--- a/hack/ci/cloud-init/controller.yaml.tpl
+++ b/hack/ci/cloud-init/controller.yaml.tpl
@@ -135,9 +135,9 @@
 
     # Upload the images so we don't have to upload them from Prow
     # Upload cirros image first in order to avoid reach limit of project
-    # https://docs.openstack.org/glance/latest/admin/quotas.html 
+    # https://docs.openstack.org/glance/latest/admin/quotas.html
     /opt/stack/devstack/tools/upload_image.sh https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/cirros/2022-12-05/cirros-0.6.1-x86_64-disk.img
-    /opt/stack/devstack/tools/upload_image.sh https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/ubuntu/2022-12-05/ubuntu-2004-kube-v1.23.10.qcow2
+    /opt/stack/devstack/tools/upload_image.sh https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/ubuntu/2023-01-14/focal-server-cloudimg-amd64.img
 
     # Add the controller to its own host aggregate and availability zone
     aggregateid=$(openstack aggregate create --zone "${PRIMARY_AZ}" "${PRIMARY_AZ}" -f value -c id)

--- a/kustomize/v1alpha5/external-cloud-provider/patch-ccm.yaml
+++ b/kustomize/v1alpha5/external-cloud-provider/patch-ccm.yaml
@@ -26,7 +26,7 @@ spec:
         kubeletExtraArgs:
           cloud-provider: external
           cloud-config:
-    files:
+    files: []
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
@@ -35,7 +35,7 @@ metadata:
 spec:
   template:
     spec:
-      files:
+      files: []
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:

--- a/kustomize/v1alpha6/external-cloud-provider/patch-ccm.yaml
+++ b/kustomize/v1alpha6/external-cloud-provider/patch-ccm.yaml
@@ -26,7 +26,7 @@ spec:
         kubeletExtraArgs:
           cloud-provider: external
           cloud-config:
-    files:
+    files: []
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
@@ -35,7 +35,7 @@ metadata:
 spec:
   template:
     spec:
-      files:
+      files: []
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:

--- a/templates/cluster-template-external-cloud-provider.yaml
+++ b/templates/cluster-template-external-cloud-provider.yaml
@@ -15,6 +15,7 @@ metadata:
 spec:
   template:
     spec:
+      files: []
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
@@ -77,6 +78,7 @@ spec:
       controllerManager:
         extraArgs:
           cloud-provider: external
+    files: []
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -129,7 +129,7 @@ variables:
   OPENSTACK_DNS_NAMESERVERS: "8.8.8.8"
   OPENSTACK_FAILURE_DOMAIN: "testaz1"
   OPENSTACK_FAILURE_DOMAIN_ALT: "testaz2"
-  OPENSTACK_IMAGE_NAME: "ubuntu-2004-kube-v1.23.10"
+  OPENSTACK_IMAGE_NAME: "focal-server-cloudimg-amd64"
   OPENSTACK_NODE_MACHINE_FLAVOR: "m1.small"
   OPENSTACK_SSH_KEY_NAME: "cluster-api-provider-openstack-sigs-k8s-io"
   OPENSTACK_EXTERNAL_NETWORK_ID: ""

--- a/test/e2e/data/kustomize/common-patches/containerd-kcp.yaml
+++ b/test/e2e/data/kustomize/common-patches/containerd-kcp.yaml
@@ -1,0 +1,40 @@
+---
+# This ensures that containerd is installed and configures the system for kubeadm.
+# https://kubernetes.io/docs/setup/production-environment/container-runtimes/#forwarding-ipv4-and-letting-iptables-see-bridged-traffic
+- op: add
+  path: /spec/kubeadmConfigSpec/preKubeadmCommands
+  value:
+  - /usr/local/bin/ci-pre-kubeadm.sh
+- op: add
+  path: /spec/kubeadmConfigSpec/files/-
+  value:
+    content: |
+      #!/bin/bash
+      sysctl --system
+      systemctl restart systemd-modules-load.service
+      USE_CI_ARTIFACTS=${USE_CI_ARTIFACTS:=false}
+      if [ ! "${USE_CI_ARTIFACTS}" = true ]; then
+        echo "No CI Artifacts installation, exiting"
+        exit 0
+      fi
+      echo "Installing containerd"
+      apt-get install -y containerd
+    owner: root:root
+    path: /usr/local/bin/ci-pre-kubeadm.sh
+    permissions: "0750"
+- op: add
+  path: /spec/kubeadmConfigSpec/files/-
+  value:
+    content: |
+      br_netfilter
+    path: /etc/modules-load.d/k8s.conf
+    permissions: "0644"
+- op: add
+  path: /spec/kubeadmConfigSpec/files/-
+  value:
+    content: |
+      net.bridge.bridge-nf-call-iptables = 1
+      net.ipv4.ip_forward = 1
+      net.bridge.bridge-nf-call-ip6tables = 1
+    path: /etc/sysctl.d/99-kubernetes-cri.conf
+    permissions: "0644"

--- a/test/e2e/data/kustomize/common-patches/containerd-kct.yaml
+++ b/test/e2e/data/kustomize/common-patches/containerd-kct.yaml
@@ -1,0 +1,40 @@
+---
+# This ensures that containerd is installed and configures the system for kubeadm.
+# https://kubernetes.io/docs/setup/production-environment/container-runtimes/#forwarding-ipv4-and-letting-iptables-see-bridged-traffic
+- op: add
+  path: /spec/template/spec/preKubeadmCommands
+  value:
+  - /usr/local/bin/ci-pre-kubeadm.sh
+- op: add
+  path: /spec/template/spec/files/-
+  value:
+    content: |
+      #!/bin/bash
+      sysctl --system
+      systemctl restart systemd-modules-load.service
+      USE_CI_ARTIFACTS=${USE_CI_ARTIFACTS:=false}
+      if [ ! "${USE_CI_ARTIFACTS}" = true ]; then
+        echo "No CI Artifacts installation, exiting"
+        exit 0
+      fi
+      echo "Installing containerd"
+      apt-get install -y containerd
+    owner: root:root
+    path: /usr/local/bin/ci-pre-kubeadm.sh
+    permissions: "0750"
+- op: add
+  path: /spec/template/spec/files/-
+  value:
+    content: |
+      br_netfilter
+    path: /etc/modules-load.d/k8s.conf
+    permissions: "0644"
+- op: add
+  path: /spec/template/spec/files/-
+  value:
+    content: |
+      net.bridge.bridge-nf-call-iptables = 1
+      net.ipv4.ip_forward = 1
+      net.bridge.bridge-nf-call-ip6tables = 1
+    path: /etc/sysctl.d/99-kubernetes-cri.conf
+    permissions: "0644"

--- a/test/e2e/data/kustomize/common-patches/kustomization.yaml
+++ b/test/e2e/data/kustomize/common-patches/kustomization.yaml
@@ -14,3 +14,11 @@ patches:
     kind: OpenStackCluster
     name: \${CLUSTER_NAME}
   path: patch-cluster.yaml
+- target:
+    kind: KubeadmControlPlane
+    name: \${CLUSTER_NAME}-control-plane
+  path: containerd-kcp.yaml
+- target:
+    kind: KubeadmConfigTemplate
+    name: \${CLUSTER_NAME}-md-0
+  path: containerd-kct.yaml

--- a/test/e2e/data/kustomize/external-cloud-provider/kustomization.yaml
+++ b/test/e2e/data/kustomize/external-cloud-provider/kustomization.yaml
@@ -14,3 +14,7 @@ patches:
     kind: OpenStackCluster
     name: \${CLUSTER_NAME}
   path: patch-allow-all-in-cluster-traffic.yaml
+- target:
+    kind: KubeadmControlPlane
+    name: \${CLUSTER_NAME}-control-plane
+  path: patch-ccm-cloud-config.yaml

--- a/test/e2e/data/kustomize/external-cloud-provider/patch-ccm-cloud-config.yaml
+++ b/test/e2e/data/kustomize/external-cloud-provider/patch-ccm-cloud-config.yaml
@@ -1,0 +1,16 @@
+- op: add
+  path: /spec/kubeadmConfigSpec/files/-
+  value:
+    content: ${OPENSTACK_CLOUD_PROVIDER_CONF_B64}
+    encoding: base64
+    owner: root
+    path: /etc/kubernetes/cloud.conf
+    permissions: "0600"
+- op: add
+  path: /spec/kubeadmConfigSpec/files/-
+  value:
+    content: ${OPENSTACK_CLOUD_CACERT_B64}
+    encoding: base64
+    owner: root
+    path: /etc/certs/cacert
+    permissions: "0600"

--- a/test/e2e/data/kustomize/external-cloud-provider/patch-ccm.yaml
+++ b/test/e2e/data/kustomize/external-cloud-provider/patch-ccm.yaml
@@ -5,22 +5,3 @@ metadata:
   name: ${CLUSTER_NAME}
   labels:
     ccm: ${CLUSTER_NAME}-crs-1
----
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
-kind: KubeadmControlPlane
-metadata:
-  name: ${CLUSTER_NAME}-control-plane
-spec:
-  kubeadmConfigSpec:
-    file:
-    files:
-    - content: ${OPENSTACK_CLOUD_PROVIDER_CONF_B64}
-      encoding: base64
-      owner: root
-      path: /etc/kubernetes/cloud.conf
-      permissions: "0600"
-    - content: ${OPENSTACK_CLOUD_CACERT_B64}
-      encoding: base64
-      owner: root
-      path: /etc/certs/cacert
-      permissions: "0600"


### PR DESCRIPTION
**What this PR does / why we need it**:

This changes the image we use for e2e tests to a plain ubuntu cloud image. That way the cloud-init script that installs/upgrades kubeadm will not have any issues with pre-existing versions. The drawback is that we must always set `USE_CI_ARTIFACTS=true` for all tests sine there is no "default" kubernetes tools installed in the image to fall back on. However, we already do this in practice so there is no real change.
Ref: https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/6af7e0193c89a5617fd34e5761b24719a304d697/test/e2e/suites/e2e/e2e_test.go#L81

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1429 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.
2. Should we use a fixed image or the daily build? Should we upload it to some other place?

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
