### PR TITLE
🐛 fix nil-pointer in initial reconciliation loop with empty status field

### DIFF
--- a/pkg/cloud/services/loadbalancer/loadbalancer.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer.go
@@ -227,16 +227,26 @@ func (s *Service) getOrUpdateAllowedCIDRS(openStackCluster *infrav1.OpenStackClu
 	if len(openStackCluster.Spec.APIServerLoadBalancer.AllowedCIDRs) > 0 {
 		allowedCIDRs = append(allowedCIDRs, openStackCluster.Spec.APIServerLoadBalancer.AllowedCIDRs...)
 
-		if openStackCluster.Spec.Bastion.Enabled {
-			allowedCIDRs = append(allowedCIDRs, openStackCluster.Status.Bastion.FloatingIP, openStackCluster.Status.Bastion.IP)
+		// In the first reconciliation loop, only the Ready field is set in openStackCluster.Status
+		// All other fields are empty/nil
+		if openStackCluster.Status.Bastion != nil {
+			if openStackCluster.Status.Bastion.FloatingIP != "" {
+				allowedCIDRs = append(allowedCIDRs, openStackCluster.Status.Bastion.FloatingIP)
+			}
+
+			if openStackCluster.Status.Bastion.IP != "" {
+				allowedCIDRs = append(allowedCIDRs, openStackCluster.Status.Bastion.IP)
+			}
 		}
 
-		if openStackCluster.Status.Network.Subnet.CIDR != "" {
-			allowedCIDRs = append(allowedCIDRs, openStackCluster.Status.Network.Subnet.CIDR)
-		}
+		if openStackCluster.Status.Network != nil {
+			if openStackCluster.Status.Network.Subnet.CIDR != "" {
+				allowedCIDRs = append(allowedCIDRs, openStackCluster.Status.Network.Subnet.CIDR)
+			}
 
-		if len(openStackCluster.Status.Network.Router.IPs) > 0 {
-			allowedCIDRs = append(allowedCIDRs, openStackCluster.Status.Network.Router.IPs...)
+			if len(openStackCluster.Status.Network.Router.IPs) > 0 {
+				allowedCIDRs = append(allowedCIDRs, openStackCluster.Status.Network.Router.IPs...)
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

in the initial reconciliation loop, a nil-pointer occurs if the cluster is configured with a bastion host. In this initial run the status field is still empty.

Signed-off-by: Mario Constanti <mario@constanti.de>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1438

**Special notes for your reviewer**:

As i don't have any access to an Openstack installation ATM i can't verify the PR on a running system.

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
