### PR TITLE
check flavor and reject CPUs less than 2

### DIFF
--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -343,7 +343,7 @@ func reconcileBastion(scope *scope.Scope, cluster *clusterv1.Cluster, openStackC
 		}
 	}
 
-	instanceStatus, err = computeService.CreateInstance(openStackCluster, openStackCluster, instanceSpec, cluster.Name)
+	instanceStatus, err = computeService.CreateInstance(openStackCluster, openStackCluster, instanceSpec, cluster.Name, true)
 	if err != nil {
 		return errors.Errorf("failed to reconcile bastion: %v", err)
 	}

--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -444,7 +444,7 @@ func (r *OpenStackMachineReconciler) getOrCreate(logger logr.Logger, cluster *cl
 	if instanceStatus == nil {
 		instanceSpec := machineToInstanceSpec(openStackCluster, machine, openStackMachine, userData)
 		logger.Info("Machine not exist, Creating Machine", "Machine", openStackMachine.Name)
-		instanceStatus, err = computeService.CreateInstance(openStackMachine, openStackCluster, instanceSpec, cluster.Name)
+		instanceStatus, err = computeService.CreateInstance(openStackMachine, openStackCluster, instanceSpec, cluster.Name, false)
 		if err != nil {
 			conditions.MarkFalse(openStackMachine, infrav1.InstanceReadyCondition, infrav1.InstanceCreateFailedReason, clusterv1.ConditionSeverityError, err.Error())
 			return nil, fmt.Errorf("create OpenStack instance: %w", err)

--- a/pkg/clients/mock/compute.go
+++ b/pkg/clients/mock/compute.go
@@ -26,6 +26,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	attachinterfaces "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces"
 	availabilityzones "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones"
+	flavors "github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
 	servers "github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 	clients "sigs.k8s.io/cluster-api-provider-openstack/pkg/clients"
 )
@@ -96,19 +97,19 @@ func (mr *MockComputeClientMockRecorder) DeleteServer(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteServer", reflect.TypeOf((*MockComputeClient)(nil).DeleteServer), arg0)
 }
 
-// GetFlavorIDFromName mocks base method.
-func (m *MockComputeClient) GetFlavorIDFromName(arg0 string) (string, error) {
+// GetFlavorFromName mocks base method.
+func (m *MockComputeClient) GetFlavorFromName(arg0 string) (*flavors.Flavor, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetFlavorIDFromName", arg0)
-	ret0, _ := ret[0].(string)
+	ret := m.ctrl.Call(m, "GetFlavorFromName", arg0)
+	ret0, _ := ret[0].(*flavors.Flavor)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetFlavorIDFromName indicates an expected call of GetFlavorIDFromName.
-func (mr *MockComputeClientMockRecorder) GetFlavorIDFromName(arg0 interface{}) *gomock.Call {
+// GetFlavorFromName indicates an expected call of GetFlavorFromName.
+func (mr *MockComputeClientMockRecorder) GetFlavorFromName(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFlavorIDFromName", reflect.TypeOf((*MockComputeClient)(nil).GetFlavorIDFromName), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFlavorFromName", reflect.TypeOf((*MockComputeClient)(nil).GetFlavorFromName), arg0)
 }
 
 // GetServer mocks base method.


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

check flavor and reject flavor with VCPUs < 2 to align with kubeadm checks 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1450 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
