### PR TITLE
🌱 Use newer containerd in e2e tests

### DIFF
--- a/test/e2e/data/kustomize/common-patches/containerd-kcp.yaml
+++ b/test/e2e/data/kustomize/common-patches/containerd-kcp.yaml
@@ -19,6 +19,18 @@
       fi
       echo "Installing containerd"
       apt-get install -y containerd
+      # TODO(lentzi90): This adds cri-tools from the kubernetes repository, since we need to make sure it is a specific version
+      # When pulled in as a dependency of kubeadm, we just get the latest version.
+      # After upgrading to v1.26 we should be able to drop this.
+      mkdir -p /etc/apt/keyrings
+      curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /etc/apt/keyrings/kubernetes.gpg
+      echo 'deb [signed-by=/etc/apt/keyrings/kubernetes.gpg] https://apt.kubernetes.io/ kubernetes-xenial main' > /etc/apt/sources.list.d/kubernetes.list
+      apt-get update
+      VERSION_WITHOUT_PREFIX="${KUBERNETES_VERSION#v}"
+      # replace . with \.
+      VERSION_REGEX="$${VERSION_WITHOUT_PREFIX//./\\.}"
+      PACKAGE_VERSION="$(apt-cache madison kubelet | grep "$${VERSION_REGEX}-" | head -n1 | cut -d '|' -f 2 | tr -d '[:space:]')"
+      apt-get install -y cri-tools="$${PACKAGE_VERSION}"
     owner: root:root
     path: /usr/local/bin/ci-pre-kubeadm.sh
     permissions: "0750"

--- a/test/e2e/data/kustomize/common-patches/containerd-kct.yaml
+++ b/test/e2e/data/kustomize/common-patches/containerd-kct.yaml
@@ -19,6 +19,18 @@
       fi
       echo "Installing containerd"
       apt-get install -y containerd
+      # TODO(lentzi90): This adds cri-tools from the kubernetes repository, since we need to make sure it is a specific version
+      # When pulled in as a dependency of kubeadm, we just get the latest version.
+      # After upgrading to v1.26 we should be able to drop this.
+      mkdir -p /etc/apt/keyrings
+      curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /etc/apt/keyrings/kubernetes.gpg
+      echo 'deb [signed-by=/etc/apt/keyrings/kubernetes.gpg] https://apt.kubernetes.io/ kubernetes-xenial main' > /etc/apt/sources.list.d/kubernetes.list
+      apt-get update
+      VERSION_WITHOUT_PREFIX="${KUBERNETES_VERSION#v}"
+      # replace . with \.
+      VERSION_REGEX="$${VERSION_WITHOUT_PREFIX//./\\.}"
+      PACKAGE_VERSION="$(apt-cache madison kubelet | grep "$${VERSION_REGEX}-" | head -n1 | cut -d '|' -f 2 | tr -d '[:space:]')"
+      apt-get install -y cri-tools="$${PACKAGE_VERSION}"
     owner: root:root
     path: /usr/local/bin/ci-pre-kubeadm.sh
     permissions: "0750"


### PR DESCRIPTION
For some reason the kubeadm v1.25 package pulls in cri-tools v1.26. This is not compatible with containerd <v1.6. To work around this I use containerd from the docker repositories where v1.6 is available.

**What this PR does / why we need it**:

~~This should fix the e2e tests by installing a newer version of containerd.
I went with newer containerd instead of older cri-tools for two reasons.~~

1. ~~cri-tools are "not installed by us", i.e. they are installed by the script we get from CAPI~~
2. ~~we would anyway need the newer version as soon as we go to k8s v1.26.~~

The above did not work. Instead I went with installing the specific version of cri-tools that matches kubeadm.

Here is the documented change in v1.26: https://kubernetes.io/blog/2022/11/18/upcoming-changes-in-kubernetes-1-26/#cri-api-removal

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1458

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
