### PR TITLE
✨ add explicit securitycontext to controller

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -17,28 +17,40 @@ spec:
         control-plane: capo-controller-manager
     spec:
       containers:
-      - command:
-        - /manager
-        args:
-        - "--leader-elect"
-        - "--v=2"
-        - "--metrics-bind-addr=127.0.0.1:8080"
-        image: controller:latest
-        imagePullPolicy: Always
-        name: manager
-        ports:
-        - containerPort: 9440
-          name: healthz
-          protocol: TCP
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: healthz
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: healthz
+        - command:
+            - /manager
+          args:
+            - "--leader-elect"
+            - "--v=2"
+            - "--metrics-bind-addr=127.0.0.1:8080"
+          image: controller:latest
+          imagePullPolicy: Always
+          name: manager
+          ports:
+            - containerPort: 9440
+              name: healthz
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: healthz
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            runAsUser: 65532
+            runAsGroup: 65532
       terminationGracePeriodSeconds: 10
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: manager
       tolerations:
         - effect: NoSchedule


### PR DESCRIPTION
Adding explicit securitycontext ensures the CAPO controller will run as non-root, without special capabilities. Those are often also the defaults but being explicit avoids reliance on fallback values, and enables further hardening by making it possible to apply strict Pod Security Standards for CAPO namespace etc.

In addition, adding seccompProfile of RuntimeDefault adds runtime specific syscall filtering (mostly off-limit by not having capability in the first place) but also couple other, non-namespaced syscalls. In general, very safe set to be filtered.

There is good discussion and reference links in similar CAPI PR at: https://github.com/kubernetes-sigs/cluster-api/pull/7831

Also, reindent the command block properly.