### PR TITLE
📖 Add documentation about --ca-cert flag

### DIFF
--- a/docs/book/src/clusteropenstack/configuration.md
+++ b/docs/book/src/clusteropenstack/configuration.md
@@ -8,6 +8,9 @@
   - [SSH key pair](#ssh-key-pair)
   - [OpenStack credential](#openstack-credential)
     - [Generate credentials](#generate-credentials)
+  - [CA certificates](#ca-certificates)
+    - [Per cluster](#per-cluster)
+    - [Global configuration](#global-configuration)
   - [Availability zone](#availability-zone)
   - [DNS server](#dns-server)
   - [Machine flavor](#machine-flavor)
@@ -106,6 +109,29 @@ The following variables are set.
 Note: Only the [external cloud provider](https://cluster-api-openstack.sigs.k8s.io/topics/external-cloud-provider.html) supports [Application Credentials](https://docs.openstack.org/keystone/latest/user/application_credentials.html).
 
 Note: you need to set `clusterctl.cluster.x-k8s.io/move` label for the secret created from `OPENSTACK_CLOUD_YAML_B64` in order to successfully move objects from bootstrap cluster to target cluster. See [bug 626](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/626) for further information.
+
+## CA certificates
+
+When using an `https` openstack endpoint, providing CA certificates is required unless verification is explicitly disabled.
+You can choose to provide your ca certificates per cluster or globally using a specific capo flag.
+
+### Per cluster
+
+To use the per cluster ca certificate, you can use the `OPENSTACK_CLOUD_CACERT_B64` environment variable.
+The generator will set the `cacert` key with the variable's content in the cluster's cloud-config secret.
+
+### Global configuration
+
+To use the same ca certificate for all clusters you can use the `--ca-certs` flag.
+When reconciling a cluster, if no `cacert` is set in the cluster's cloud-config secret, CAPO will use the certicates provided with this flag.
+
+For instance, to use CAPO's docker image ca certificates:
+
+```bash
+kubectl patch deployment capo-controller-manager -n capo-system \
+  --type='json' \
+  -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--ca-certs=/etc/ssl/certs/ca-certificates.crt"}]'
+```
 
 ## Availability zone
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR is a follow up for: https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1440 
It adds the documentation about the `--ca-cert` flag added in this PR. 

**Which issue(s) this PR fixes** *

Fixes: #1439

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
