### PR TITLE
Remove the resource and machine tickers from e2e tests

### DIFF
--- a/test/e2e/shared/context.go
+++ b/test/e2e/shared/context.go
@@ -21,7 +21,6 @@ package shared
 
 import (
 	"context"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -86,14 +85,6 @@ type RuntimeEnvironment struct {
 	BootstrapClusterProvider bootstrap.ClusterProvider
 	// BootstrapClusterProxy allows to interact with the bootstrap cluster to be used for the e2e tests.
 	BootstrapClusterProxy framework.ClusterProxy
-	// ResourceTicker for dumping resources
-	ResourceTicker *time.Ticker
-	// ResourceTickerDone to stop ticking
-	ResourceTickerDone chan bool
-	// MachineTicker for dumping resources
-	MachineTicker *time.Ticker
-	// MachineTickerDone to stop ticking
-	MachineTickerDone chan bool
 	// Namespaces holds the namespaces used in the tests
 	Namespaces map[*corev1.Namespace]context.CancelFunc
 	// ClusterctlConfigPath to be used for this test, created by generating a clusterctl local repository

--- a/test/e2e/shared/openstack.go
+++ b/test/e2e/shared/openstack.go
@@ -95,9 +95,10 @@ func ensureSSHKeyPair(e2eCtx *E2EContext) {
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func dumpOpenStack(_ context.Context, e2eCtx *E2EContext, bootstrapClusterProxyName string) {
+func dumpOpenStack(_ context.Context, e2eCtx *E2EContext, bootstrapClusterProxyName string, directory ...string) {
 	Logf("Running dumpOpenStack")
-	logPath := filepath.Join(e2eCtx.Settings.ArtifactFolder, "clusters", bootstrapClusterProxyName, "openstack-resources")
+	paths := append([]string{e2eCtx.Settings.ArtifactFolder, "clusters", bootstrapClusterProxyName, "openstack-resources"}, directory...)
+	logPath := filepath.Join(paths...)
 	if err := os.MkdirAll(logPath, os.ModePerm); err != nil {
 		_, _ = fmt.Fprintf(GinkgoWriter, "error creating directory %s: %s\n", logPath, err)
 		return

--- a/test/e2e/shared/suite.go
+++ b/test/e2e/shared/suite.go
@@ -163,79 +163,12 @@ func AllNodesBeforeSuite(e2eCtx *E2EContext, data []byte) {
 	SetEnvVar("OPENSTACK_CLOUD_YAML_B64", getEncodedOpenStackCloudYAML(openStackCloudYAMLFile), true)
 	SetEnvVar("OPENSTACK_CLOUD_PROVIDER_CONF_B64", getEncodedOpenStackCloudProviderConf(openStackCloudYAMLFile, openStackCloud), true)
 	SetEnvVar("OPENSTACK_SSH_KEY_NAME", DefaultSSHKeyPairName, false)
-
-	e2eCtx.Environment.ResourceTicker = time.NewTicker(time.Second * 10)
-	e2eCtx.Environment.ResourceTickerDone = make(chan bool)
-	// Get OpenStack server logs every 5 minutes
-	e2eCtx.Environment.MachineTicker = time.NewTicker(time.Second * 60)
-	e2eCtx.Environment.MachineTickerDone = make(chan bool)
-	resourceCtx, resourceCancel := context.WithCancel(context.Background())
-	machineCtx, machineCancel := context.WithCancel(context.Background())
-
-	debug := e2eCtx.Settings.Debug
-	// Dump resources every 5 seconds
-	go func() {
-		defer GinkgoRecover()
-		for {
-			select {
-			case <-e2eCtx.Environment.ResourceTickerDone:
-				Debugf(debug, "Running ResourceTickerDone")
-				resourceCancel()
-				Debugf(debug, "Finished ResourceTickerDone")
-				return
-			case <-e2eCtx.Environment.ResourceTicker.C:
-				Debugf(debug, "Running ResourceTicker")
-				for k := range e2eCtx.Environment.Namespaces {
-					// ensure dumpSpecResources cannot get stuck indefinitely
-					timeoutCtx, timeoutCancel := context.WithTimeout(resourceCtx, time.Second*5)
-					dumpSpecResources(timeoutCtx, e2eCtx, k)
-					timeoutCancel()
-				}
-				Debugf(debug, "Finished ResourceTicker")
-			}
-		}
-	}()
-
-	// Dump machine logs every 60 seconds
-	go func() {
-		defer GinkgoRecover()
-		for {
-			select {
-			case <-e2eCtx.Environment.MachineTickerDone:
-				Debugf(debug, "Running MachineTickerDone")
-				machineCancel()
-				Debugf(debug, "Finished MachineTickerDone")
-				return
-			case <-e2eCtx.Environment.MachineTicker.C:
-				Debugf(debug, "Running MachineTicker")
-				for k := range e2eCtx.Environment.Namespaces {
-					// ensure dumpMachines cannot get stuck indefinitely
-					timeoutCtx, timeoutCancel := context.WithTimeout(machineCtx, time.Second*30)
-					dumpMachines(timeoutCtx, e2eCtx, k)
-					timeoutCancel()
-				}
-				Debugf(debug, "Finished MachineTicker")
-			}
-		}
-	}()
 }
 
 // AllNodesAfterSuite is cleanup that runs on all ginkgo parallel nodes after the test suite finishes.
 func AllNodesAfterSuite(e2eCtx *E2EContext) {
 	Logf("Running AllNodesAfterSuite")
 	defer Logf("Finished AllNodesAfterSuite")
-
-	Logf("Stopping ResourceTicker")
-	if e2eCtx.Environment.ResourceTickerDone != nil {
-		e2eCtx.Environment.ResourceTickerDone <- true
-	}
-	Logf("Stopped ResourceTicker")
-
-	Logf("Stopping MachineTicker")
-	if e2eCtx.Environment.MachineTickerDone != nil {
-		e2eCtx.Environment.MachineTickerDone <- true
-	}
-	Logf("Stopped MachineTicker")
 
 	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Minute)
 	defer cancel()


### PR DESCRIPTION
The resource and machine tickers are responsible for fetching logs every 5 and 10 seconds respectively during a test run. Each fetch overwrites the previous one. These are problematic because they cause failure state to be overwritten by logs captured during deletion. That is, if a test ends in failure, we continue to capture these logs regularly during cleanup. This causes the test failure state to be overwritten by the state during cleanup.

We already capture these resources after each test regardless of success or failure, so regular capture during the test is redundant. This change simply removes the tickers. We still get the same logs when we execute DumpSpecResourcesAndCleanup() after each test.

Additionally, if there is an error during cleanup we optionally capture that state too, but to a separate directory.

/hold
