### PR TITLE
Fix "internal ip doesn't exist (yet)" in e2e logs

### DIFF
--- a/test/e2e/shared/common.go
+++ b/test/e2e/shared/common.go
@@ -31,6 +31,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	"sigs.k8s.io/cluster-api/util"
@@ -111,7 +112,12 @@ func dumpMachines(ctx context.Context, e2eCtx *E2EContext, namespace *corev1.Nam
 		_, _ = fmt.Fprintf(GinkgoWriter, "cannot dump machines, could not get machines: %v\n", err)
 		return
 	}
-	srvs, err := GetOpenStackServers(e2eCtx, cluster)
+
+	machineNames := sets.NewString()
+	for _, machine := range machines.Items {
+		machineNames.Insert(machine.Name)
+	}
+	srvs, err := GetOpenStackServers(e2eCtx, cluster, machineNames)
 	if err != nil {
 		_, _ = fmt.Fprintf(GinkgoWriter, "cannot dump machines, could not get servers from OpenStack: %v\n", err)
 		return

--- a/test/e2e/suites/e2e/e2e_test.go
+++ b/test/e2e/suites/e2e/e2e_test.go
@@ -47,6 +47,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apimachinerytypes "k8s.io/apimachinery/pkg/types"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
@@ -532,7 +533,11 @@ var _ = Describe("e2e tests [PR-Blocking]", func() {
 			allMachines = append(allMachines, controlPlaneMachines...)
 			allMachines = append(allMachines, workerMachines...)
 
-			allServers, err := shared.GetOpenStackServers(e2eCtx, cluster)
+			machineNames := sets.NewString()
+			for _, machine := range allMachines {
+				machineNames.Insert(machine.Spec.InfrastructureRef.Name)
+			}
+			allServers, err := shared.GetOpenStackServers(e2eCtx, cluster, machineNames)
 			Expect(err).NotTo(HaveOccurred())
 
 			allServerNames := make([]string, 0, len(allServers))


### PR DESCRIPTION
We see lots of instances of log messages in e2e logs of the form:
```
error getting internal ip for server cluster-e2e-l7xvyz-control-plane-hnj96: internal ip doesn't exist (yet)
```

These are because GetOpenStackServers(), which is called after every test completes, fetches *all* OpenStack servers, not just those for the current cluster. The above log message is displayed when it doesn't find an interface for the server on the current cluster's internal network.

This change cuts down the noise by passing in an explicit list of machine names to return. We still fetch all servers, but we filter them after fetching.

/hold