### PR TITLE
:bug: Fix Provisioning to Unavailable AZs

### DIFF
--- a/api/v1alpha6/openstackcluster_webhook.go
+++ b/api/v1alpha6/openstackcluster_webhook.go
@@ -115,6 +115,10 @@ func (r *OpenStackCluster) ValidateUpdate(oldRaw runtime.Object) error {
 		r.Spec.APIServerLoadBalancer.AllowedCIDRs = []string{}
 	}
 
+	// Allow changes to the availability zones.
+	old.Spec.ControlPlaneAvailabilityZones = []string{}
+	r.Spec.ControlPlaneAvailabilityZones = []string{}
+
 	if !reflect.DeepEqual(old.Spec, r.Spec) {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec"), "cannot be modified"))
 	}

--- a/api/v1alpha6/openstackcluster_webhook_test.go
+++ b/api/v1alpha6/openstackcluster_webhook_test.go
@@ -175,6 +175,65 @@ func TestOpenStackCluster_ValidateUpdate(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "Adding OpenStackCluster.Spec.ControlPlaneAvailabilityZones is allowed",
+			oldTemplate: &OpenStackCluster{
+				Spec: OpenStackClusterSpec{
+					CloudName: "foobar",
+				},
+			},
+			newTemplate: &OpenStackCluster{
+				Spec: OpenStackClusterSpec{
+					CloudName: "foobar",
+					ControlPlaneAvailabilityZones: []string{
+						"alice",
+						"bob",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Modifying OpenStackCluster.Spec.ControlPlaneAvailabilityZones is allowed",
+			oldTemplate: &OpenStackCluster{
+				Spec: OpenStackClusterSpec{
+					CloudName: "foobar",
+					ControlPlaneAvailabilityZones: []string{
+						"alice",
+						"bob",
+					},
+				},
+			},
+			newTemplate: &OpenStackCluster{
+				Spec: OpenStackClusterSpec{
+					CloudName: "foobar",
+					ControlPlaneAvailabilityZones: []string{
+						"alice",
+						"bob",
+						"eve",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Removing OpenStackCluster.Spec.ControlPlaneAvailabilityZones is allowed",
+			oldTemplate: &OpenStackCluster{
+				Spec: OpenStackClusterSpec{
+					CloudName: "foobar",
+					ControlPlaneAvailabilityZones: []string{
+						"alice",
+						"bob",
+					},
+				},
+			},
+			newTemplate: &OpenStackCluster{
+				Spec: OpenStackClusterSpec{
+					CloudName: "foobar",
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cloud/services/compute/availabilityzone.go
+++ b/pkg/cloud/services/compute/availabilityzone.go
@@ -28,5 +28,13 @@ func (s *Service) GetAvailabilityZones() ([]availabilityzones.AvailabilityZone, 
 		return nil, fmt.Errorf("error extracting availability zone list: %v", err)
 	}
 
-	return availabilityZoneList, nil
+	available := make([]availabilityzones.AvailabilityZone, 0, len(availabilityZoneList))
+
+	for _, az := range availabilityZoneList {
+		if az.ZoneState.Available {
+			available = append(available, az)
+		}
+	}
+
+	return available, nil
 }


### PR DESCRIPTION
CAPO uses any ZA it finds, rather than checking whether the ZA is actually available, meaning you can get into a state where it's impossible to provision a cluster.  This allows clients to filter based on AZ availability before scheduling.

Fixes #1477

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Discussion in #1477 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
