### PR TITLE
✨ Support propagate uplink status

### DIFF
--- a/api/v1alpha4/conversion_test.go
+++ b/api/v1alpha4/conversion_test.go
@@ -313,6 +313,7 @@ func TestFuzzyConversion(t *testing.T) {
 				}
 				v1alpha7PortOpts.SecurityGroupFilters = nil
 				v1alpha7PortOpts.ValueSpecs = nil
+				v1alpha7PortOpts.PropagateUplinkStatus = nil
 			},
 			func(v1alpha7FixedIP *infrav1.FixedIP, c fuzz.Continue) {
 				c.FuzzNoCustom(v1alpha7FixedIP)

--- a/api/v1alpha4/zz_generated.conversion.go
+++ b/api/v1alpha4/zz_generated.conversion.go
@@ -1513,6 +1513,7 @@ func autoConvert_v1alpha7_PortOpts_To_v1alpha4_PortOpts(in *v1alpha7.PortOpts, o
 	out.VNICType = in.VNICType
 	out.Profile = *(*map[string]string)(unsafe.Pointer(&in.Profile))
 	out.DisablePortSecurity = (*bool)(unsafe.Pointer(in.DisablePortSecurity))
+	// WARNING: in.PropagateUplinkStatus requires manual conversion: does not exist in peer-type
 	out.Tags = *(*[]string)(unsafe.Pointer(&in.Tags))
 	// WARNING: in.ValueSpecs requires manual conversion: does not exist in peer-type
 	return nil

--- a/api/v1alpha5/conversion.go
+++ b/api/v1alpha5/conversion.go
@@ -208,7 +208,7 @@ func Convert_v1alpha7_LoadBalancer_To_v1alpha5_LoadBalancer(in *infrav1.LoadBala
 }
 
 func Convert_v1alpha7_PortOpts_To_v1alpha5_PortOpts(in *infrav1.PortOpts, out *PortOpts, s conversion.Scope) error {
-	// value specs have been added in v1alpha7 but have no equivalent in v1alpha5
+	// value specs and propagate uplink status have been added in v1alpha7 but have no equivalent in v1alpha5
 	return autoConvert_v1alpha7_PortOpts_To_v1alpha5_PortOpts(in, out, s)
 }
 

--- a/api/v1alpha5/zz_generated.conversion.go
+++ b/api/v1alpha5/zz_generated.conversion.go
@@ -1480,6 +1480,7 @@ func autoConvert_v1alpha7_PortOpts_To_v1alpha5_PortOpts(in *v1alpha7.PortOpts, o
 	out.VNICType = in.VNICType
 	out.Profile = *(*map[string]string)(unsafe.Pointer(&in.Profile))
 	out.DisablePortSecurity = (*bool)(unsafe.Pointer(in.DisablePortSecurity))
+	// WARNING: in.PropagateUplinkStatus requires manual conversion: does not exist in peer-type
 	out.Tags = *(*[]string)(unsafe.Pointer(&in.Tags))
 	// WARNING: in.ValueSpecs requires manual conversion: does not exist in peer-type
 	return nil

--- a/api/v1alpha6/zz_generated.conversion.go
+++ b/api/v1alpha6/zz_generated.conversion.go
@@ -299,11 +299,6 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*v1alpha7.PortOpts)(nil), (*PortOpts)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1alpha7_PortOpts_To_v1alpha6_PortOpts(a.(*v1alpha7.PortOpts), b.(*PortOpts), scope)
-	}); err != nil {
-		return err
-	}
 	if err := s.AddGeneratedConversionFunc((*RootVolume)(nil), (*v1alpha7.RootVolume)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1alpha6_RootVolume_To_v1alpha7_RootVolume(a.(*RootVolume), b.(*v1alpha7.RootVolume), scope)
 	}); err != nil {
@@ -404,6 +399,16 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
+	if err := s.AddConversionFunc((*[]Network)(nil), (*[]v1alpha7.Network)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_Slice_v1alpha6_Network_To_Slice_v1alpha7_Network(a.(*[]Network), b.(*[]v1alpha7.Network), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*[]v1alpha7.Network)(nil), (*[]Network)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_Slice_v1alpha7_Network_To_Slice_v1alpha6_Network(a.(*[]v1alpha7.Network), b.(*[]Network), scope)
+	}); err != nil {
+		return err
+	}
 	if err := s.AddConversionFunc((*OpenStackMachineSpec)(nil), (*v1alpha7.OpenStackMachineSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1alpha6_OpenStackMachineSpec_To_v1alpha7_OpenStackMachineSpec(a.(*OpenStackMachineSpec), b.(*v1alpha7.OpenStackMachineSpec), scope)
 	}); err != nil {
@@ -416,6 +421,11 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}
 	if err := s.AddConversionFunc((*v1alpha7.OpenStackClusterSpec)(nil), (*OpenStackClusterSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1alpha7_OpenStackClusterSpec_To_v1alpha6_OpenStackClusterSpec(a.(*v1alpha7.OpenStackClusterSpec), b.(*OpenStackClusterSpec), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*v1alpha7.PortOpts)(nil), (*PortOpts)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1alpha7_PortOpts_To_v1alpha6_PortOpts(a.(*v1alpha7.PortOpts), b.(*PortOpts), scope)
 	}); err != nil {
 		return err
 	}
@@ -546,7 +556,15 @@ func autoConvert_v1alpha6_Instance_To_v1alpha7_Instance(in *Instance, out *v1alp
 	out.Trunk = in.Trunk
 	out.FailureDomain = in.FailureDomain
 	out.SecurityGroups = (*[]string)(unsafe.Pointer(in.SecurityGroups))
-	out.Networks = (*[]v1alpha7.Network)(unsafe.Pointer(in.Networks))
+	if in.Networks != nil {
+		in, out := &in.Networks, &out.Networks
+		*out = new([]v1alpha7.Network)
+		if err := Convert_Slice_v1alpha6_Network_To_Slice_v1alpha7_Network(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.Networks = nil
+	}
 	out.Subnet = in.Subnet
 	out.Tags = *(*[]string)(unsafe.Pointer(&in.Tags))
 	out.Image = in.Image
@@ -575,7 +593,15 @@ func autoConvert_v1alpha7_Instance_To_v1alpha6_Instance(in *v1alpha7.Instance, o
 	out.Trunk = in.Trunk
 	out.FailureDomain = in.FailureDomain
 	out.SecurityGroups = (*[]string)(unsafe.Pointer(in.SecurityGroups))
-	out.Networks = (*[]Network)(unsafe.Pointer(in.Networks))
+	if in.Networks != nil {
+		in, out := &in.Networks, &out.Networks
+		*out = new([]Network)
+		if err := Convert_Slice_v1alpha7_Network_To_Slice_v1alpha6_Network(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.Networks = nil
+	}
 	out.Subnet = in.Subnet
 	out.Tags = *(*[]string)(unsafe.Pointer(&in.Tags))
 	out.Image = in.Image
@@ -633,7 +659,15 @@ func autoConvert_v1alpha6_Network_To_v1alpha7_Network(in *Network, out *v1alpha7
 	out.ID = in.ID
 	out.Tags = *(*[]string)(unsafe.Pointer(&in.Tags))
 	out.Subnet = (*v1alpha7.Subnet)(unsafe.Pointer(in.Subnet))
-	out.PortOpts = (*v1alpha7.PortOpts)(unsafe.Pointer(in.PortOpts))
+	if in.PortOpts != nil {
+		in, out := &in.PortOpts, &out.PortOpts
+		*out = new(v1alpha7.PortOpts)
+		if err := Convert_v1alpha6_PortOpts_To_v1alpha7_PortOpts(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.PortOpts = nil
+	}
 	out.Router = (*v1alpha7.Router)(unsafe.Pointer(in.Router))
 	out.APIServerLoadBalancer = (*v1alpha7.LoadBalancer)(unsafe.Pointer(in.APIServerLoadBalancer))
 	return nil
@@ -649,7 +683,15 @@ func autoConvert_v1alpha7_Network_To_v1alpha6_Network(in *v1alpha7.Network, out 
 	out.ID = in.ID
 	out.Tags = *(*[]string)(unsafe.Pointer(&in.Tags))
 	out.Subnet = (*Subnet)(unsafe.Pointer(in.Subnet))
-	out.PortOpts = (*PortOpts)(unsafe.Pointer(in.PortOpts))
+	if in.PortOpts != nil {
+		in, out := &in.PortOpts, &out.PortOpts
+		*out = new(PortOpts)
+		if err := Convert_v1alpha7_PortOpts_To_v1alpha6_PortOpts(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.PortOpts = nil
+	}
 	out.Router = (*Router)(unsafe.Pointer(in.Router))
 	out.APIServerLoadBalancer = (*LoadBalancer)(unsafe.Pointer(in.APIServerLoadBalancer))
 	return nil
@@ -884,13 +926,37 @@ func autoConvert_v1alpha7_OpenStackClusterSpec_To_v1alpha6_OpenStackClusterSpec(
 
 func autoConvert_v1alpha6_OpenStackClusterStatus_To_v1alpha7_OpenStackClusterStatus(in *OpenStackClusterStatus, out *v1alpha7.OpenStackClusterStatus, s conversion.Scope) error {
 	out.Ready = in.Ready
-	out.Network = (*v1alpha7.Network)(unsafe.Pointer(in.Network))
-	out.ExternalNetwork = (*v1alpha7.Network)(unsafe.Pointer(in.ExternalNetwork))
+	if in.Network != nil {
+		in, out := &in.Network, &out.Network
+		*out = new(v1alpha7.Network)
+		if err := Convert_v1alpha6_Network_To_v1alpha7_Network(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.Network = nil
+	}
+	if in.ExternalNetwork != nil {
+		in, out := &in.ExternalNetwork, &out.ExternalNetwork
+		*out = new(v1alpha7.Network)
+		if err := Convert_v1alpha6_Network_To_v1alpha7_Network(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.ExternalNetwork = nil
+	}
 	out.FailureDomains = *(*v1beta1.FailureDomains)(unsafe.Pointer(&in.FailureDomains))
 	out.ControlPlaneSecurityGroup = (*v1alpha7.SecurityGroup)(unsafe.Pointer(in.ControlPlaneSecurityGroup))
 	out.WorkerSecurityGroup = (*v1alpha7.SecurityGroup)(unsafe.Pointer(in.WorkerSecurityGroup))
 	out.BastionSecurityGroup = (*v1alpha7.SecurityGroup)(unsafe.Pointer(in.BastionSecurityGroup))
-	out.Bastion = (*v1alpha7.Instance)(unsafe.Pointer(in.Bastion))
+	if in.Bastion != nil {
+		in, out := &in.Bastion, &out.Bastion
+		*out = new(v1alpha7.Instance)
+		if err := Convert_v1alpha6_Instance_To_v1alpha7_Instance(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.Bastion = nil
+	}
 	out.FailureReason = (*errors.ClusterStatusError)(unsafe.Pointer(in.FailureReason))
 	out.FailureMessage = (*string)(unsafe.Pointer(in.FailureMessage))
 	return nil
@@ -903,13 +969,37 @@ func Convert_v1alpha6_OpenStackClusterStatus_To_v1alpha7_OpenStackClusterStatus(
 
 func autoConvert_v1alpha7_OpenStackClusterStatus_To_v1alpha6_OpenStackClusterStatus(in *v1alpha7.OpenStackClusterStatus, out *OpenStackClusterStatus, s conversion.Scope) error {
 	out.Ready = in.Ready
-	out.Network = (*Network)(unsafe.Pointer(in.Network))
-	out.ExternalNetwork = (*Network)(unsafe.Pointer(in.ExternalNetwork))
+	if in.Network != nil {
+		in, out := &in.Network, &out.Network
+		*out = new(Network)
+		if err := Convert_v1alpha7_Network_To_v1alpha6_Network(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.Network = nil
+	}
+	if in.ExternalNetwork != nil {
+		in, out := &in.ExternalNetwork, &out.ExternalNetwork
+		*out = new(Network)
+		if err := Convert_v1alpha7_Network_To_v1alpha6_Network(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.ExternalNetwork = nil
+	}
 	out.FailureDomains = *(*v1beta1.FailureDomains)(unsafe.Pointer(&in.FailureDomains))
 	out.ControlPlaneSecurityGroup = (*SecurityGroup)(unsafe.Pointer(in.ControlPlaneSecurityGroup))
 	out.WorkerSecurityGroup = (*SecurityGroup)(unsafe.Pointer(in.WorkerSecurityGroup))
 	out.BastionSecurityGroup = (*SecurityGroup)(unsafe.Pointer(in.BastionSecurityGroup))
-	out.Bastion = (*Instance)(unsafe.Pointer(in.Bastion))
+	if in.Bastion != nil {
+		in, out := &in.Bastion, &out.Bastion
+		*out = new(Instance)
+		if err := Convert_v1alpha7_Instance_To_v1alpha6_Instance(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.Bastion = nil
+	}
 	out.FailureReason = (*errors.ClusterStatusError)(unsafe.Pointer(in.FailureReason))
 	out.FailureMessage = (*string)(unsafe.Pointer(in.FailureMessage))
 	return nil
@@ -1141,7 +1231,17 @@ func autoConvert_v1alpha6_OpenStackMachineSpec_To_v1alpha7_OpenStackMachineSpec(
 	out.ImageUUID = in.ImageUUID
 	out.SSHKeyName = in.SSHKeyName
 	out.Networks = *(*[]v1alpha7.NetworkParam)(unsafe.Pointer(&in.Networks))
-	out.Ports = *(*[]v1alpha7.PortOpts)(unsafe.Pointer(&in.Ports))
+	if in.Ports != nil {
+		in, out := &in.Ports, &out.Ports
+		*out = make([]v1alpha7.PortOpts, len(*in))
+		for i := range *in {
+			if err := Convert_v1alpha6_PortOpts_To_v1alpha7_PortOpts(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Ports = nil
+	}
 	// WARNING: in.Subnet requires manual conversion: does not exist in peer-type
 	out.FloatingIP = in.FloatingIP
 	out.SecurityGroups = *(*[]v1alpha7.SecurityGroupParam)(unsafe.Pointer(&in.SecurityGroups))
@@ -1164,7 +1264,17 @@ func autoConvert_v1alpha7_OpenStackMachineSpec_To_v1alpha6_OpenStackMachineSpec(
 	out.ImageUUID = in.ImageUUID
 	out.SSHKeyName = in.SSHKeyName
 	out.Networks = *(*[]NetworkParam)(unsafe.Pointer(&in.Networks))
-	out.Ports = *(*[]PortOpts)(unsafe.Pointer(&in.Ports))
+	if in.Ports != nil {
+		in, out := &in.Ports, &out.Ports
+		*out = make([]PortOpts, len(*in))
+		for i := range *in {
+			if err := Convert_v1alpha7_PortOpts_To_v1alpha6_PortOpts(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Ports = nil
+	}
 	out.FloatingIP = in.FloatingIP
 	out.SecurityGroups = *(*[]SecurityGroupParam)(unsafe.Pointer(&in.SecurityGroups))
 	out.Trunk = in.Trunk
@@ -1372,14 +1482,10 @@ func autoConvert_v1alpha7_PortOpts_To_v1alpha6_PortOpts(in *v1alpha7.PortOpts, o
 	out.VNICType = in.VNICType
 	out.Profile = *(*map[string]string)(unsafe.Pointer(&in.Profile))
 	out.DisablePortSecurity = (*bool)(unsafe.Pointer(in.DisablePortSecurity))
+	// WARNING: in.PropagateUplinkStatus requires manual conversion: does not exist in peer-type
 	out.Tags = *(*[]string)(unsafe.Pointer(&in.Tags))
 	out.ValueSpecs = *(*[]ValueSpec)(unsafe.Pointer(&in.ValueSpecs))
 	return nil
-}
-
-// Convert_v1alpha7_PortOpts_To_v1alpha6_PortOpts is an autogenerated conversion function.
-func Convert_v1alpha7_PortOpts_To_v1alpha6_PortOpts(in *v1alpha7.PortOpts, out *PortOpts, s conversion.Scope) error {
-	return autoConvert_v1alpha7_PortOpts_To_v1alpha6_PortOpts(in, out, s)
 }
 
 func autoConvert_v1alpha6_RootVolume_To_v1alpha7_RootVolume(in *RootVolume, out *v1alpha7.RootVolume, s conversion.Scope) error {

--- a/api/v1alpha7/types.go
+++ b/api/v1alpha7/types.go
@@ -152,6 +152,9 @@ type PortOpts struct {
 	// When not set, it takes the value of the corresponding field at the network level.
 	DisablePortSecurity *bool `json:"disablePortSecurity,omitempty"`
 
+	// PropageteUplinkStatus enables or disables the propagate uplink status on the port.
+	PropagateUplinkStatus *bool `json:"propagateUplinkStatus,omitempty"`
+
 	// Tags applied to the port (and corresponding trunk, if a trunk is configured.)
 	// These tags are applied in addition to the instance's tags, which will also be applied to the port.
 	// +listType=set

--- a/api/v1alpha7/zz_generated.deepcopy.go
+++ b/api/v1alpha7/zz_generated.deepcopy.go
@@ -872,6 +872,11 @@ func (in *PortOpts) DeepCopyInto(out *PortOpts) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.PropagateUplinkStatus != nil {
+		in, out := &in.PropagateUplinkStatus, &out.PropagateUplinkStatus
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Tags != nil {
 		in, out := &in.Tags, &out.Tags
 		*out = make([]string, len(*in))

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -6437,6 +6437,10 @@ spec:
                               type: object
                             projectId:
                               type: string
+                            propagateUplinkStatus:
+                              description: PropageteUplinkStatus enables or disables
+                                the propagate uplink status on the port.
+                              type: boolean
                             securityGroupFilters:
                               description: The names, uuids, filters or any combination
                                 these of the security groups to assign to the instance
@@ -7022,6 +7026,10 @@ spec:
                               type: object
                             projectId:
                               type: string
+                            propagateUplinkStatus:
+                              description: PropageteUplinkStatus enables or disables
+                                the propagate uplink status on the port.
+                              type: boolean
                             securityGroupFilters:
                               description: The names, uuids, filters or any combination
                                 these of the security groups to assign to the instance
@@ -7446,6 +7454,10 @@ spec:
                         type: object
                       projectId:
                         type: string
+                      propagateUplinkStatus:
+                        description: PropageteUplinkStatus enables or disables the
+                          propagate uplink status on the port.
+                        type: boolean
                       securityGroupFilters:
                         description: The names, uuids, filters or any combination
                           these of the security groups to assign to the instance
@@ -7783,6 +7795,10 @@ spec:
                         type: object
                       projectId:
                         type: string
+                      propagateUplinkStatus:
+                        description: PropageteUplinkStatus enables or disables the
+                          propagate uplink status on the port.
+                        type: boolean
                       securityGroupFilters:
                         description: The names, uuids, filters or any combination
                           these of the security groups to assign to the instance

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
@@ -2545,6 +2545,11 @@ spec:
                                       type: object
                                     projectId:
                                       type: string
+                                    propagateUplinkStatus:
+                                      description: PropageteUplinkStatus enables or
+                                        disables the propagate uplink status on the
+                                        port.
+                                      type: boolean
                                     securityGroupFilters:
                                       description: The names, uuids, filters or any
                                         combination these of the security groups to

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
@@ -2241,6 +2241,10 @@ spec:
                       type: object
                     projectId:
                       type: string
+                    propagateUplinkStatus:
+                      description: PropageteUplinkStatus enables or disables the propagate
+                        uplink status on the port.
+                      type: boolean
                     securityGroupFilters:
                       description: The names, uuids, filters or any combination these
                         of the security groups to assign to the instance

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
@@ -1859,6 +1859,10 @@ spec:
                               type: object
                             projectId:
                               type: string
+                            propagateUplinkStatus:
+                              description: PropageteUplinkStatus enables or disables
+                                the propagate uplink status on the port.
+                              type: boolean
                             securityGroupFilters:
                               description: The names, uuids, filters or any combination
                                 these of the security groups to assign to the instance

--- a/pkg/cloud/services/networking/port.go
+++ b/pkg/cloud/services/networking/port.go
@@ -137,17 +137,18 @@ func (s *Service) GetOrCreatePort(eventObject runtime.Object, clusterName string
 	}
 
 	createOpts = ports.CreateOpts{
-		Name:                portName,
-		NetworkID:           net.ID,
-		Description:         description,
-		AdminStateUp:        portOpts.AdminStateUp,
-		MACAddress:          portOpts.MACAddress,
-		TenantID:            portOpts.TenantID,
-		ProjectID:           portOpts.ProjectID,
-		SecurityGroups:      securityGroupsPtr,
-		AllowedAddressPairs: addressPairs,
-		FixedIPs:            fixedIPs,
-		ValueSpecs:          valueSpecs,
+		Name:                  portName,
+		NetworkID:             net.ID,
+		Description:           description,
+		AdminStateUp:          portOpts.AdminStateUp,
+		MACAddress:            portOpts.MACAddress,
+		TenantID:              portOpts.TenantID,
+		ProjectID:             portOpts.ProjectID,
+		SecurityGroups:        securityGroupsPtr,
+		AllowedAddressPairs:   addressPairs,
+		FixedIPs:              fixedIPs,
+		ValueSpecs:            valueSpecs,
+		PropagateUplinkStatus: portOpts.PropagateUplinkStatus,
 	}
 
 	if portOpts.DisablePortSecurity != nil {

--- a/pkg/cloud/services/networking/port_test.go
+++ b/pkg/cloud/services/networking/port_test.go
@@ -467,6 +467,39 @@ func Test_GetOrCreatePort(t *testing.T) {
 			&ports.Port{ID: portID1},
 			false,
 		},
+		{
+			"creates port with propagate uplink status",
+			"foo-port-1",
+			infrav1.Network{
+				ID: netID,
+				PortOpts: &infrav1.PortOpts{
+					PropagateUplinkStatus: pointerToTrue,
+				},
+			},
+			instanceSecurityGroups,
+			[]string{},
+			func(m *mock.MockNetworkClientMockRecorder) {
+				// No ports found
+				m.
+					ListPort(ports.ListOpts{
+						Name:      "foo-port-1",
+						NetworkID: netID,
+					}).Return([]ports.Port{}, nil)
+				m.
+					CreatePort(portsbinding.CreateOptsExt{
+						CreateOptsBuilder: ports.CreateOpts{
+							Name:                  "foo-port-1",
+							Description:           "Created by cluster-api-provider-openstack cluster test-cluster",
+							SecurityGroups:        &instanceSecurityGroups,
+							NetworkID:             netID,
+							AllowedAddressPairs:   []ports.AddressPair{},
+							PropagateUplinkStatus: pointerToTrue,
+						},
+					}).Return(&ports.Port{ID: portID1, PropagateUplinkStatus: *pointerToTrue}, nil)
+			},
+			&ports.Port{ID: portID1, PropagateUplinkStatus: *pointerToTrue},
+			false,
+		},
 	}
 
 	eventObject := &infrav1.OpenStackMachine{}


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds support for [propagate_uplink_status](https://docs.openstack.org/heat/zed/template_guide/openstack.html#OS::Neutron::Port-prop-propagate_uplink_status) on ports.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1480 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [x] adds unit tests
- [x] Add support in gophercloud https://github.com/gophercloud/gophercloud/issues/2562
- [x] Bump gophercloud version to release that includes support for this. https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1520

/hold
