### PR TITLE
🐛 Switch to "4" instead of "ipip" for rules

### DIFF
--- a/pkg/cloud/services/networking/securitygroups_rules.go
+++ b/pkg/cloud/services/networking/securitygroups_rules.go
@@ -101,14 +101,14 @@ func getSGControlPlaneCalico(remoteGroupIDSelf, secWorkerGroupID string) []infra
 			Description:   "IP-in-IP (calico)",
 			Direction:     "ingress",
 			EtherType:     "IPv4",
-			Protocol:      "ipip",
+			Protocol:      "4",
 			RemoteGroupID: remoteGroupIDSelf,
 		},
 		{
 			Description:   "IP-in-IP (calico)",
 			Direction:     "ingress",
 			EtherType:     "IPv4",
-			Protocol:      "ipip",
+			Protocol:      "4",
 			RemoteGroupID: secWorkerGroupID,
 		},
 	}
@@ -164,14 +164,14 @@ func getSGWorkerCalico(remoteGroupIDSelf, secControlPlaneGroupID string) []infra
 			Description:   "IP-in-IP (calico)",
 			Direction:     "ingress",
 			EtherType:     "IPv4",
-			Protocol:      "ipip",
+			Protocol:      "4",
 			RemoteGroupID: remoteGroupIDSelf,
 		},
 		{
 			Description:   "IP-in-IP (calico)",
 			Direction:     "ingress",
 			EtherType:     "IPv4",
-			Protocol:      "ipip",
+			Protocol:      "4",
 			RemoteGroupID: secControlPlaneGroupID,
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a regression where we started using `ipip` instead of `4` for the security groups.  Inside Linux, the protocol `ipip` maps to protocol number `94` which is what Neutron uses when you use that, which meant that all Calico IPIP connectivity stopped working with this change

```
root@abb2f5652d8f:/# egrep '^(ipencap|ipip)' /etc/protocols
ipencap	4	IP-ENCAP	# IP encapsulated in IP (officially ``IP'')
ipip	94	IPIP		# IP-within-IP Encapsulation Protocol
```

Unfortunately, the Neutron API does not accept `ipencap` therefore we should go back to putting the digit to make things work again.

Related: https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1290

**Which issue(s) this PR fixes**:
Fixes #1484 

**Special notes for your reviewer**:

The generated `iptables` rules look like this:

```
    0     0 RETURN     94    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set NIPv4c7df0104-3ffe-47fd-972b- src
    0     0 RETURN     94    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set NIPv4c845a9c7-aafa-46b2-95ed- src
```

Those don't end up sending any traffic through.

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
