### PR TITLE
🐛 fix: allow using multiattach volume types

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Each version of Cluster API for OpenStack will attempt to support two Kubernetes
 **NOTE:** As the versioning for this project is tied to the versioning of Cluster API, future modifications to this
 policy may be made to more closely aligned with other providers in the Cluster API ecosystem.
 
-**NOTE:** The minimum microversion of CAPI using nova is `2.53` now due to `server tags` support, see [code](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/c052e7e600f0e5ebddc839c08746bb636e79be87/pkg/cloud/services/compute/service.go#L38) for additional information.
+**NOTE:** The minimum microversion of CAPI using nova is `2.60` now due to `server tags` support as well permitting `multiattach` volume types, see [code](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/c052e7e600f0e5ebddc839c08746bb636e79be87/pkg/cloud/services/compute/service.go#L38) for additional information.
 
 **NOTE:** We require Keystone v3 for authentication.
 

--- a/pkg/clients/compute.go
+++ b/pkg/clients/compute.go
@@ -33,14 +33,15 @@ import (
 
 /*
 NovaMinimumMicroversion is the minimum Nova microversion supported by CAPO
-2.53 corresponds to OpenStack Pike
+2.60 corresponds to OpenStack Queens
 
 For the canonical description of Nova microversions, see
 https://docs.openstack.org/nova/latest/reference/api-microversion-history.html
 
 CAPO uses server tags, which were added in microversion 2.52.
+CAPO supports multiattach volume types, which were added in microversion 2.60.
 */
-const NovaMinimumMicroversion = "2.53"
+const NovaMinimumMicroversion = "2.60"
 
 // ServerExt is the base gophercloud Server with extensions used by InstanceStatus.
 type ServerExt struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
This bumps the minimum supported micro-version to one that would support mulit-attach, but also happens to be the most recent EOL release of OpenStack

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1496

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
