### PR TITLE
:bug: e2e: refresh packages list before install containerd

### DIFF
--- a/test/e2e/data/kustomize/common-patches/containerd/containerd-kcp.yaml
+++ b/test/e2e/data/kustomize/common-patches/containerd/containerd-kcp.yaml
@@ -17,6 +17,7 @@
         echo "No CI Artifacts installation, exiting"
         exit 0
       fi
+      apt update -qq
       echo "Installing containerd"
       apt-get install -y containerd
       # TODO(lentzi90): This adds cri-tools from the kubernetes repository, since we need to make sure it is a specific version

--- a/test/e2e/data/kustomize/common-patches/containerd/containerd-kct.yaml
+++ b/test/e2e/data/kustomize/common-patches/containerd/containerd-kct.yaml
@@ -17,6 +17,7 @@
         echo "No CI Artifacts installation, exiting"
         exit 0
       fi
+      apt update -qq
       echo "Installing containerd"
       apt-get install -y containerd
       # TODO(lentzi90): This adds cri-tools from the kubernetes repository, since we need to make sure it is a specific version


### PR DESCRIPTION
otherwise 'containerd' will try to pull an old and non-existing 'runc' version

<hr>

I think the Ubuntu focal cloud image comes with an existing packages list but with times it needs to be refreshed. 
```
Mar 14 11:00:24 cluster-e2e-ezbo9h-control-plane-qvgtb cloud-init[1410]: The following additional packages will be installed:
Mar 14 11:00:24 cluster-e2e-ezbo9h-control-plane-qvgtb cloud-init[1410]:   runc
Mar 14 11:00:24 cluster-e2e-ezbo9h-control-plane-qvgtb cloud-init[1410]: The following NEW packages will be installed:
Mar 14 11:00:24 cluster-e2e-ezbo9h-control-plane-qvgtb cloud-init[1410]:   containerd runc
Mar 14 11:00:24 cluster-e2e-ezbo9h-control-plane-qvgtb cloud-init[1410]: 0 upgraded, 2 newly installed, 0 to remove and 0 not upgraded.
Mar 14 11:00:24 cluster-e2e-ezbo9h-control-plane-qvgtb cloud-init[1410]: Need to get 36.9 MB of archives.
Mar 14 11:00:24 cluster-e2e-ezbo9h-control-plane-qvgtb cloud-init[1410]: After this operation, 170 MB of additional disk space will be used.
Mar 14 11:00:24 cluster-e2e-ezbo9h-control-plane-qvgtb cloud-init[1410]: Err:1 http://testaz1.clouds.archive.ubuntu.com/ubuntu focal-updates/main amd64 runc amd64 1.1.0-0ubuntu1~20.04.2
Mar 14 11:00:24 cluster-e2e-ezbo9h-control-plane-qvgtb cloud-init[1410]:   404  Not Found [IP: 185.125.190.38 80]
Mar 14 11:00:24 cluster-e2e-ezbo9h-control-plane-qvgtb cloud-init[1410]: Get:2 http://testaz1.clouds.archive.ubuntu.com/ubuntu focal-updates/main amd64 containerd amd64 1.5.9-0ubuntu1~20.04.6 [33.0 MB]
Mar 14 11:00:26 cluster-e2e-ezbo9h-control-plane-qvgtb cloud-init[1410]: Fetched 33.0 MB in 2s (19.4 MB/s)
Mar 14 11:00:26 cluster-e2e-ezbo9h-control-plane-qvgtb cloud-init[1410]: E: Failed to fetch http://testaz1.clouds.archive.ubuntu.com/ubuntu/pool/main/r/runc/runc_1.1.0-0ubuntu1~20.04.2_amd64.deb  404  Not Found [IP: 185.125.190.38 80]
```

**Special notes for your reviewer**: Locally tested

**TODOs**:


- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
