### PR TITLE
🌱 Add fuzzy conversion tests for v1alpha6

### DIFF
--- a/api/v1alpha6/conversion_test.go
+++ b/api/v1alpha6/conversion_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha6
+
+import (
+	"testing"
+
+	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha7"
+)
+
+func TestFuzzyConversion(t *testing.T) {
+	t.Run("for OpenStackCluster", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
+		Hub:   &infrav1.OpenStackCluster{},
+		Spoke: &OpenStackCluster{},
+	}))
+
+	t.Run("for OpenStackClusterTemplate", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
+		Hub:   &infrav1.OpenStackClusterTemplate{},
+		Spoke: &OpenStackClusterTemplate{},
+	}))
+
+	t.Run("for OpenStackMachine", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
+		Hub:   &infrav1.OpenStackMachine{},
+		Spoke: &OpenStackMachine{},
+	}))
+
+	t.Run("for OpenStackMachineTemplate", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
+		Hub:   &infrav1.OpenStackMachineTemplate{},
+		Spoke: &OpenStackMachineTemplate{},
+	}))
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

As there are no API differences yet between v1alpha6 and v1alpha7, no special fuzzers are needed. The tests check hub-spoke-hub and spoke-hub-spoke conversions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #1508 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.
2. I started on this as part of #1291, but decided it makes more sense to add the tests in a separate PR. I'll update the tests in #1291 with the necessary changes when this is merged.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [x] adds unit tests

/hold
