### PR TITLE
🌱 Un-pointer PortOpts.SecurityGroups

### DIFF
--- a/api/v1alpha4/types.go
+++ b/api/v1alpha4/types.go
@@ -132,7 +132,7 @@ type PortOpts struct {
 	FixedIPs            []FixedIP     `json:"fixedIPs,omitempty"`
 	TenantID            string        `json:"tenantId,omitempty"`
 	ProjectID           string        `json:"projectId,omitempty"`
-	SecurityGroups      *[]string     `json:"securityGroups,omitempty"`
+	SecurityGroups      []string      `json:"securityGroups,omitempty"`
 	AllowedAddressPairs []AddressPair `json:"allowedAddressPairs,omitempty"`
 	// Enables and disables trunk at port level. If not provided, openStackMachine.Spec.Trunk is inherited.
 	Trunk *bool `json:"trunk,omitempty"`

--- a/api/v1alpha4/zz_generated.conversion.go
+++ b/api/v1alpha4/zz_generated.conversion.go
@@ -1474,7 +1474,7 @@ func autoConvert_v1alpha4_PortOpts_To_v1alpha7_PortOpts(in *PortOpts, out *v1alp
 	}
 	out.TenantID = in.TenantID
 	out.ProjectID = in.ProjectID
-	out.SecurityGroups = (*[]string)(unsafe.Pointer(in.SecurityGroups))
+	out.SecurityGroups = *(*[]string)(unsafe.Pointer(&in.SecurityGroups))
 	out.AllowedAddressPairs = *(*[]v1alpha7.AddressPair)(unsafe.Pointer(&in.AllowedAddressPairs))
 	out.Trunk = (*bool)(unsafe.Pointer(in.Trunk))
 	out.HostID = in.HostID
@@ -1504,7 +1504,7 @@ func autoConvert_v1alpha7_PortOpts_To_v1alpha4_PortOpts(in *v1alpha7.PortOpts, o
 	}
 	out.TenantID = in.TenantID
 	out.ProjectID = in.ProjectID
-	out.SecurityGroups = (*[]string)(unsafe.Pointer(in.SecurityGroups))
+	out.SecurityGroups = *(*[]string)(unsafe.Pointer(&in.SecurityGroups))
 	// WARNING: in.SecurityGroupFilters requires manual conversion: does not exist in peer-type
 	out.AllowedAddressPairs = *(*[]AddressPair)(unsafe.Pointer(&in.AllowedAddressPairs))
 	out.Trunk = (*bool)(unsafe.Pointer(in.Trunk))

--- a/api/v1alpha4/zz_generated.deepcopy.go
+++ b/api/v1alpha4/zz_generated.deepcopy.go
@@ -808,12 +808,8 @@ func (in *PortOpts) DeepCopyInto(out *PortOpts) {
 	}
 	if in.SecurityGroups != nil {
 		in, out := &in.SecurityGroups, &out.SecurityGroups
-		*out = new([]string)
-		if **in != nil {
-			in, out := *in, *out
-			*out = make([]string, len(*in))
-			copy(*out, *in)
-		}
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	if in.AllowedAddressPairs != nil {
 		in, out := &in.AllowedAddressPairs, &out.AllowedAddressPairs

--- a/api/v1alpha5/types.go
+++ b/api/v1alpha5/types.go
@@ -118,7 +118,7 @@ type PortOpts struct {
 	TenantID  string    `json:"tenantId,omitempty"`
 	ProjectID string    `json:"projectId,omitempty"`
 	// The uuids of the security groups to assign to the instance
-	SecurityGroups *[]string `json:"securityGroups,omitempty"`
+	SecurityGroups []string `json:"securityGroups,omitempty"`
 	// The names, uuids, filters or any combination these of the security groups to assign to the instance
 	SecurityGroupFilters []SecurityGroupParam `json:"securityGroupFilters,omitempty"`
 	AllowedAddressPairs  []AddressPair        `json:"allowedAddressPairs,omitempty"`

--- a/api/v1alpha5/zz_generated.conversion.go
+++ b/api/v1alpha5/zz_generated.conversion.go
@@ -1449,7 +1449,7 @@ func autoConvert_v1alpha5_PortOpts_To_v1alpha7_PortOpts(in *PortOpts, out *v1alp
 	out.FixedIPs = *(*[]v1alpha7.FixedIP)(unsafe.Pointer(&in.FixedIPs))
 	out.TenantID = in.TenantID
 	out.ProjectID = in.ProjectID
-	out.SecurityGroups = (*[]string)(unsafe.Pointer(in.SecurityGroups))
+	out.SecurityGroups = *(*[]string)(unsafe.Pointer(&in.SecurityGroups))
 	out.SecurityGroupFilters = *(*[]v1alpha7.SecurityGroupParam)(unsafe.Pointer(&in.SecurityGroupFilters))
 	out.AllowedAddressPairs = *(*[]v1alpha7.AddressPair)(unsafe.Pointer(&in.AllowedAddressPairs))
 	out.Trunk = (*bool)(unsafe.Pointer(in.Trunk))
@@ -1475,7 +1475,7 @@ func autoConvert_v1alpha7_PortOpts_To_v1alpha5_PortOpts(in *v1alpha7.PortOpts, o
 	out.FixedIPs = *(*[]FixedIP)(unsafe.Pointer(&in.FixedIPs))
 	out.TenantID = in.TenantID
 	out.ProjectID = in.ProjectID
-	out.SecurityGroups = (*[]string)(unsafe.Pointer(in.SecurityGroups))
+	out.SecurityGroups = *(*[]string)(unsafe.Pointer(&in.SecurityGroups))
 	out.SecurityGroupFilters = *(*[]SecurityGroupParam)(unsafe.Pointer(&in.SecurityGroupFilters))
 	out.AllowedAddressPairs = *(*[]AddressPair)(unsafe.Pointer(&in.AllowedAddressPairs))
 	out.Trunk = (*bool)(unsafe.Pointer(in.Trunk))

--- a/api/v1alpha5/zz_generated.deepcopy.go
+++ b/api/v1alpha5/zz_generated.deepcopy.go
@@ -832,12 +832,8 @@ func (in *PortOpts) DeepCopyInto(out *PortOpts) {
 	}
 	if in.SecurityGroups != nil {
 		in, out := &in.SecurityGroups, &out.SecurityGroups
-		*out = new([]string)
-		if **in != nil {
-			in, out := *in, *out
-			*out = make([]string, len(*in))
-			copy(*out, *in)
-		}
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	if in.SecurityGroupFilters != nil {
 		in, out := &in.SecurityGroupFilters, &out.SecurityGroupFilters

--- a/api/v1alpha6/types.go
+++ b/api/v1alpha6/types.go
@@ -119,7 +119,7 @@ type PortOpts struct {
 	ProjectID string    `json:"projectId,omitempty"`
 	// The uuids of the security groups to assign to the instance
 	// +listType=set
-	SecurityGroups *[]string `json:"securityGroups,omitempty"`
+	SecurityGroups []string `json:"securityGroups,omitempty"`
 	// The names, uuids, filters or any combination these of the security groups to assign to the instance
 	SecurityGroupFilters []SecurityGroupParam `json:"securityGroupFilters,omitempty"`
 	AllowedAddressPairs  []AddressPair        `json:"allowedAddressPairs,omitempty"`

--- a/api/v1alpha6/zz_generated.conversion.go
+++ b/api/v1alpha6/zz_generated.conversion.go
@@ -1345,7 +1345,7 @@ func autoConvert_v1alpha6_PortOpts_To_v1alpha7_PortOpts(in *PortOpts, out *v1alp
 	out.FixedIPs = *(*[]v1alpha7.FixedIP)(unsafe.Pointer(&in.FixedIPs))
 	out.TenantID = in.TenantID
 	out.ProjectID = in.ProjectID
-	out.SecurityGroups = (*[]string)(unsafe.Pointer(in.SecurityGroups))
+	out.SecurityGroups = *(*[]string)(unsafe.Pointer(&in.SecurityGroups))
 	out.SecurityGroupFilters = *(*[]v1alpha7.SecurityGroupParam)(unsafe.Pointer(&in.SecurityGroupFilters))
 	out.AllowedAddressPairs = *(*[]v1alpha7.AddressPair)(unsafe.Pointer(&in.AllowedAddressPairs))
 	out.Trunk = (*bool)(unsafe.Pointer(in.Trunk))
@@ -1372,7 +1372,7 @@ func autoConvert_v1alpha7_PortOpts_To_v1alpha6_PortOpts(in *v1alpha7.PortOpts, o
 	out.FixedIPs = *(*[]FixedIP)(unsafe.Pointer(&in.FixedIPs))
 	out.TenantID = in.TenantID
 	out.ProjectID = in.ProjectID
-	out.SecurityGroups = (*[]string)(unsafe.Pointer(in.SecurityGroups))
+	out.SecurityGroups = *(*[]string)(unsafe.Pointer(&in.SecurityGroups))
 	out.SecurityGroupFilters = *(*[]SecurityGroupParam)(unsafe.Pointer(&in.SecurityGroupFilters))
 	out.AllowedAddressPairs = *(*[]AddressPair)(unsafe.Pointer(&in.AllowedAddressPairs))
 	out.Trunk = (*bool)(unsafe.Pointer(in.Trunk))

--- a/api/v1alpha6/zz_generated.deepcopy.go
+++ b/api/v1alpha6/zz_generated.deepcopy.go
@@ -837,12 +837,8 @@ func (in *PortOpts) DeepCopyInto(out *PortOpts) {
 	}
 	if in.SecurityGroups != nil {
 		in, out := &in.SecurityGroups, &out.SecurityGroups
-		*out = new([]string)
-		if **in != nil {
-			in, out := *in, *out
-			*out = make([]string, len(*in))
-			copy(*out, *in)
-		}
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	if in.SecurityGroupFilters != nil {
 		in, out := &in.SecurityGroupFilters, &out.SecurityGroupFilters

--- a/api/v1alpha7/types.go
+++ b/api/v1alpha7/types.go
@@ -119,7 +119,7 @@ type PortOpts struct {
 	ProjectID string    `json:"projectId,omitempty"`
 	// The uuids of the security groups to assign to the instance
 	// +listType=set
-	SecurityGroups *[]string `json:"securityGroups,omitempty"`
+	SecurityGroups []string `json:"securityGroups,omitempty"`
 	// The names, uuids, filters or any combination these of the security groups to assign to the instance
 	SecurityGroupFilters []SecurityGroupParam `json:"securityGroupFilters,omitempty"`
 	AllowedAddressPairs  []AddressPair        `json:"allowedAddressPairs,omitempty"`

--- a/api/v1alpha7/zz_generated.deepcopy.go
+++ b/api/v1alpha7/zz_generated.deepcopy.go
@@ -837,12 +837,8 @@ func (in *PortOpts) DeepCopyInto(out *PortOpts) {
 	}
 	if in.SecurityGroups != nil {
 		in, out := &in.SecurityGroups, &out.SecurityGroups
-		*out = new([]string)
-		if **in != nil {
-			in, out := *in, *out
-			*out = make([]string, len(*in))
-			copy(*out, *in)
-		}
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	if in.SecurityGroupFilters != nil {
 		in, out := &in.SecurityGroupFilters, &out.SecurityGroupFilters

--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -192,7 +192,7 @@ func (s *Service) createInstanceImpl(eventObject runtime.Object, openStackCluste
 			iTags = instanceSpec.Tags
 		}
 		portName := getPortName(instanceSpec.Name, network.PortOpts, i)
-		port, err := networkingService.GetOrCreatePort(eventObject, clusterName, portName, network, &securityGroups, iTags)
+		port, err := networkingService.GetOrCreatePort(eventObject, clusterName, portName, network, securityGroups, iTags)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cloud/services/networking/port_test.go
+++ b/pkg/cloud/services/networking/port_test.go
@@ -59,7 +59,7 @@ func Test_GetOrCreatePort(t *testing.T) {
 		name                   string
 		portName               string
 		net                    infrav1.Network
-		instanceSecurityGroups *[]string
+		instanceSecurityGroups []string
 		tags                   []string
 		expect                 func(m *mock.MockNetworkClientMockRecorder)
 		// Note the 'wanted' port isn't so important, since it will be whatever we tell ListPort or CreatePort to return.
@@ -127,7 +127,7 @@ func Test_GetOrCreatePort(t *testing.T) {
 				ID:       netID,
 				PortOpts: &infrav1.PortOpts{},
 			},
-			&instanceSecurityGroups,
+			instanceSecurityGroups,
 			[]string{},
 			func(m *mock.MockNetworkClientMockRecorder) {
 				// No ports found
@@ -169,7 +169,7 @@ func Test_GetOrCreatePort(t *testing.T) {
 					}, {IPAddress: "192.168.1.50"}},
 					TenantID:       tenantID,
 					ProjectID:      projectID,
-					SecurityGroups: &portSecurityGroups,
+					SecurityGroups: portSecurityGroups,
 					AllowedAddressPairs: []infrav1.AddressPair{{
 						IPAddress:  "10.10.10.10",
 						MACAddress: "f1:f1:f1:f1:f1:f1",
@@ -297,10 +297,10 @@ func Test_GetOrCreatePort(t *testing.T) {
 			infrav1.Network{
 				ID: netID,
 				PortOpts: &infrav1.PortOpts{
-					SecurityGroups: &portSecurityGroups,
+					SecurityGroups: portSecurityGroups,
 				},
 			},
-			&instanceSecurityGroups,
+			instanceSecurityGroups,
 			[]string{},
 			func(m *mock.MockNetworkClientMockRecorder) {
 				// No ports found


### PR DESCRIPTION
This changes `PortOpts.SecurityGroups` from `*[]string` to `[]string`. Note that this make no changes to the CRDs. As it only affects Go marshalling it's effectively an internal change.

We make the change to all historic API versions to simplify conversion. It isn't a change to those APIs because their CRDs remain unchanged.

/hold
