### PR TITLE
📖 Docs: Update link to NetworkParam codebase.

### DIFF
--- a/docs/book/src/clusteropenstack/configuration.md
+++ b/docs/book/src/clusteropenstack/configuration.md
@@ -279,7 +279,7 @@ openstack loadbalancer listener unset --allowed-cidrs <listener ID>
 
 ## Network Filters
 
-If you have a complex query that you want to use to lookup a network, then you can do this by using a network filter. More details about the filter can be found in [NetworkParam](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/main/api/v1beta1/types.go)
+If you have a complex query that you want to use to lookup a network, then you can do this by using a network filter. More details about the filter can be found in [NetworkParam](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/main/api/v1alpha7/types.go#L57)
 
 By using filters to look up a network, please note that it is possible to get multiple networks as a result. This should not be a problem, however please test your filters with `openstack network list` to be certain that it returns the networks you want. Please refer to the following usage example:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The existing link to NetworkParam struct in Network Filters documentation section is broken, as there is no v1beta1 path in the codebase.

**Special notes for your reviewer**:

We could consider permalink - but likely to get outdated.

**TODOs**:

- [ x] squashed commits
- if necessary:
  - [ x] includes documentation
  - [ ] adds unit tests
