### PR TITLE
Restore APIServerLoadBalancer.Provider on up-conversion

### DIFF
--- a/api/v1alpha6/conversion.go
+++ b/api/v1alpha6/conversion.go
@@ -88,14 +88,23 @@ func restorev1alpha6MachineSpec(previous *OpenStackMachineSpec, dst *OpenStackMa
 	dst.Subnet = previous.Subnet
 }
 
+func restorev1alpha7ClusterSpec(previous *infrav1.OpenStackClusterSpec, dst *infrav1.OpenStackClusterSpec) {
+	// APIServerLoadBalancer.Provider is new in v1alpha7
+	dst.APIServerLoadBalancer.Provider = previous.APIServerLoadBalancer.Provider
+}
+
 var _ ctrlconversion.Convertible = &OpenStackCluster{}
 
 func (r *OpenStackCluster) ConvertTo(dstRaw ctrlconversion.Hub) error {
 	dst := dstRaw.(*infrav1.OpenStackCluster)
 	var previous infrav1.OpenStackCluster
-	_, err := convertAndRestore(r, dst, &previous, Convert_v1alpha6_OpenStackCluster_To_v1alpha7_OpenStackCluster)
+	restored, err := convertAndRestore(r, dst, &previous, Convert_v1alpha6_OpenStackCluster_To_v1alpha7_OpenStackCluster)
 	if err != nil {
 		return err
+	}
+
+	if restored {
+		restorev1alpha7ClusterSpec(&previous.Spec, &dst.Spec)
 	}
 
 	return nil
@@ -138,8 +147,16 @@ var _ ctrlconversion.Convertible = &OpenStackClusterTemplate{}
 func (r *OpenStackClusterTemplate) ConvertTo(dstRaw ctrlconversion.Hub) error {
 	dst := dstRaw.(*infrav1.OpenStackClusterTemplate)
 	var previous infrav1.OpenStackClusterTemplate
-	_, err := convertAndRestore(r, dst, &previous, Convert_v1alpha6_OpenStackClusterTemplate_To_v1alpha7_OpenStackClusterTemplate)
-	return err
+	restored, err := convertAndRestore(r, dst, &previous, Convert_v1alpha6_OpenStackClusterTemplate_To_v1alpha7_OpenStackClusterTemplate)
+	if err != nil {
+		return err
+	}
+
+	if restored {
+		restorev1alpha7ClusterSpec(&previous.Spec.Template.Spec, &dst.Spec.Template.Spec)
+	}
+
+	return nil
 }
 
 func (r *OpenStackClusterTemplate) ConvertFrom(srcRaw ctrlconversion.Hub) error {

--- a/api/v1alpha6/conversion_test.go
+++ b/api/v1alpha6/conversion_test.go
@@ -19,11 +19,8 @@ package v1alpha6
 import (
 	"testing"
 
-	fuzz "github.com/google/gofuzz"
 	"github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 	ctrlconversion "sigs.k8s.io/controller-runtime/pkg/conversion"
 
@@ -38,33 +35,16 @@ func TestFuzzyConversion(t *testing.T) {
 		delete(obj.GetAnnotations(), utilconversion.DataAnnotation)
 	}
 
-	fuzzerFuncs := func(_ runtimeserializer.CodecFactory) []interface{} {
-		return []interface{}{
-			func(v1alpha7Cluster *infrav1.OpenStackCluster, c fuzz.Continue) {
-				c.FuzzNoCustom(v1alpha7Cluster)
-
-				v1alpha7Cluster.Spec.APIServerLoadBalancer.Provider = ""
-			},
-			func(v1alpha7ClusterTemplate *infrav1.OpenStackClusterTemplate, c fuzz.Continue) {
-				c.FuzzNoCustom(v1alpha7ClusterTemplate)
-
-				v1alpha7ClusterTemplate.Spec.Template.Spec.APIServerLoadBalancer.Provider = ""
-			},
-		}
-	}
-
 	t.Run("for OpenStackCluster", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
 		Hub:              &infrav1.OpenStackCluster{},
 		Spoke:            &OpenStackCluster{},
 		HubAfterMutation: ignoreDataAnnotation,
-		FuzzerFuncs:      []fuzzer.FuzzerFuncs{fuzzerFuncs},
 	}))
 
 	t.Run("for OpenStackClusterTemplate", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
 		Hub:              &infrav1.OpenStackClusterTemplate{},
 		Spoke:            &OpenStackClusterTemplate{},
 		HubAfterMutation: ignoreDataAnnotation,
-		FuzzerFuncs:      []fuzzer.FuzzerFuncs{fuzzerFuncs},
 	}))
 
 	t.Run("for OpenStackMachine", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{


### PR DESCRIPTION
From v1alpha6 onwards we have the facility to losslessly preserve values during conversion which were added or removed in the new version, so we should never require the FuzzerFuncs argument to the fuzzer conversion tests.

/hold
