### PR TITLE
✨Infer port network from subnet

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/go-logr/logr v1.2.4
 	github.com/golang/mock v1.6.0
+	github.com/google/go-cmp v0.5.9
 	github.com/google/gofuzz v1.2.0
 	github.com/gophercloud/gophercloud v1.3.0
 	github.com/gophercloud/utils v0.0.0-20221207145018-e8fba78967ca
@@ -68,7 +69,6 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/cel-go v0.14.0 // indirect
 	github.com/google/gnostic v0.6.9 // indirect
-	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/go-github/v48 v48.2.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 // indirect

--- a/pkg/cloud/services/networking/network.go
+++ b/pkg/cloud/services/networking/network.go
@@ -28,8 +28,36 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha7"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/metrics"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/record"
+	capoerrors "sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/errors"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/names"
 )
+
+var (
+	ErrFilterMatch     = fmt.Errorf("filter match error")
+	ErrMultipleMatches = multipleMatchesError{}
+	ErrNoMatches       = noMatchesError{}
+)
+
+type (
+	multipleMatchesError struct{}
+	noMatchesError       struct{}
+)
+
+func (e multipleMatchesError) Error() string {
+	return "filter matched more than one resource"
+}
+
+func (e multipleMatchesError) Is(err error) bool {
+	return err == ErrFilterMatch
+}
+
+func (e noMatchesError) Error() string {
+	return "filter matched no resources"
+}
+
+func (e noMatchesError) Is(err error) bool {
+	return err == ErrFilterMatch
+}
 
 type createOpts struct {
 	AdminStateUp        *bool  `json:"admin_state_up,omitempty"`
@@ -315,9 +343,34 @@ func (s *Service) GetSubnetsByFilter(opts subnets.ListOptsBuilder) ([]subnets.Su
 		return []subnets.Subnet{}, err
 	}
 	if len(subnetList) == 0 {
-		return nil, fmt.Errorf("no subnets could be found with the filters provided")
+		return nil, ErrNoMatches
 	}
 	return subnetList, nil
+}
+
+// GetSubnetByFilter gets a single subnet specified by the given SubnetFilter.
+// It returns an ErrFilterMatch if no or multiple subnets are found.
+func (s *Service) GetSubnetByFilter(filter *infrav1.SubnetFilter) (*subnets.Subnet, error) {
+	// If the ID is set, we can just get the subnet by ID.
+	if filter.ID != "" {
+		subnet, err := s.client.GetSubnet(filter.ID)
+		if capoerrors.IsNotFound(err) {
+			return nil, ErrNoMatches
+		}
+		return subnet, err
+	}
+
+	subnets, err := s.GetSubnetsByFilter(filter.ToListOpt())
+	if err != nil {
+		return nil, err
+	}
+	if len(subnets) == 0 {
+		return nil, ErrNoMatches
+	}
+	if len(subnets) > 1 {
+		return nil, ErrMultipleMatches
+	}
+	return &subnets[0], nil
 }
 
 func getSubnetName(clusterName string) string {

--- a/pkg/cloud/services/networking/router.go
+++ b/pkg/cloud/services/networking/router.go
@@ -166,15 +166,11 @@ func (s *Service) setRouterExternalIPs(openStackCluster *infrav1.OpenStackCluste
 	for _, externalRouterIP := range openStackCluster.Spec.ExternalRouterIPs {
 		subnetID := externalRouterIP.Subnet.UUID
 		if subnetID == "" {
-			listOpts := externalRouterIP.Subnet.Filter.ToListOpt()
-			subnetsByFilter, err := s.GetSubnetsByFilter(&listOpts)
+			subnet, err := s.GetSubnetByFilter(&externalRouterIP.Subnet.Filter)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to get subnet for external router: %w", err)
 			}
-			if len(subnetsByFilter) != 1 {
-				return fmt.Errorf("subnetParam didn't exactly match one subnet")
-			}
-			subnetID = subnetsByFilter[0].ID
+			subnetID = subnet.ID
 		}
 		updateOpts.GatewayInfo.ExternalFixedIPs = append(updateOpts.GatewayInfo.ExternalFixedIPs, routers.ExternalFixedIP{
 			IPAddress: externalRouterIP.FixedIP,


### PR DESCRIPTION
NetworkID is a required field when creating a neutron port. We previously passed on this requirement in the Ports API. However we didn't have this restriction in the Networks API and inferred the network from a subnet if one was defined. This change eases the transition from Networks to Ports by removing this restriction for Ports.

**TODOs**:
- [x] tests

/hold
