### PR TITLE
:seedling: ci: bump flatcar to latest major stable

### DIFF
--- a/hack/ci/cloud-init/controller.yaml.tpl
+++ b/hack/ci/cloud-init/controller.yaml.tpl
@@ -138,7 +138,7 @@
     # https://docs.openstack.org/glance/latest/admin/quotas.html
     /opt/stack/devstack/tools/upload_image.sh https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/cirros/2022-12-05/cirros-0.6.1-x86_64-disk.img
     /opt/stack/devstack/tools/upload_image.sh https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/ubuntu/2023-01-14/focal-server-cloudimg-amd64.img
-    /opt/stack/devstack/tools/upload_image.sh https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/flatcar/flatcar-stable-3374.2.5-kube-v1.25.6.img
+    /opt/stack/devstack/tools/upload_image.sh https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/flatcar/flatcar-stable-3510.2.0-kube-v1.25.8.img
 
     # Add the controller to its own host aggregate and availability zone
     aggregateid=$(openstack aggregate create --zone "${PRIMARY_AZ}" "${PRIMARY_AZ}" -f value -c id)

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -158,7 +158,7 @@ variables:
   # The default user for SSH connections from bastion to machines
   SSH_USER_MACHINE: "ubuntu"
   EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION: "true"
-  OPENSTACK_FLATCAR_IMAGE_NAME: "flatcar-stable-3374.2.5-kube-v1.25.6"
+  OPENSTACK_FLATCAR_IMAGE_NAME: "flatcar-stable-3510.2.0-kube-v1.25.8"
 
 intervals:
   conformance/wait-control-plane: ["30m", "10s"]


### PR DESCRIPTION
**What this PR does / why we need it**: This PR brings the [new Flatcar stable](https://www.flatcar.org/releases#stable-release) version in the CI - for now it runs from a non-official bucket, just for running the tests.

**Special notes for your reviewer**: Hello @tobiasgiese, any chance to upload the image on the dedicated bucket please?

**TODOs**:

- [x] squashed commits
- [x] use the image from the capo bucket
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
