### PR TITLE
🌱 Remove creation of 2 Events for the same event

### DIFF
--- a/pkg/cloud/services/loadbalancer/loadbalancer.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer.go
@@ -368,8 +368,7 @@ func (s *Service) getOrCreateMonitor(openStackCluster *infrav1.OpenStackCluster,
 	monitor, err = s.loadbalancerClient.CreateMonitor(monitorCreateOpts)
 	// Skip creating monitor if it is not supported by Octavia provider
 	if capoerrors.IsNotImplementedError(err) {
-		record.Warnf(openStackCluster, "SkippedCreateMonitor", "Health monitors are not supported with the current Octavia provider.")
-		record.Eventf(openStackCluster, "SkippedCreateMonitor", "Health Monitor is not created as it's not implemented with the current Octavia provider.")
+		record.Warnf(openStackCluster, "SkippedCreateMonitor", "Health Monitor is not created as it's not implemented with the current Octavia provider.")
 		return nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
`record.Infof()` and `record.Warnf()` both create an event, so there's no need to use both at the same time. This commit removes one such occurrence.

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
- [X] squashed commits

/hold
