### PR TITLE
Update external approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,8 +2,6 @@
 
 approvers:
   - sig-cluster-lifecycle-leads
-  - cluster-api-admins
-  - cluster-api-maintainers
   - cluster-api-openstack-maintainers
 
 reviewers:

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -7,23 +7,19 @@
 # - https://github.com/kubernetes/k8s.io/blob/main/groups/sig-cluster-lifecycle/groups.yaml
 
 aliases:
-  # correct as of 2021/03/03
+  # sig-cluster-lifecycle-leads are included as approvers in case it's ever
+  # operationally expedient:
+  # Source:
+  # https://github.com/kubernetes/org/blob/main/config/kubernetes/sig-cluster-lifecycle/teams.yaml
+  # correct as of 2023/05/10
   sig-cluster-lifecycle-leads:
+    members:
+    - CecileRobertMichon
+    - fabriziopandini
     - justinsb
     - neolit123
-    - timothysc
-    - fabriziopandini
-  # correct as of 2021/03/03
-  cluster-api-admins:
-    - justinsb
-    - detiber
     - vincepri
-  # correct as of 2021/03/03
-  cluster-api-maintainers:
-    - justinsb
-    - detiber
-    - vincepri
-    - CecileRobertMichon
+
   cluster-api-openstack-maintainers:
     - jichenjc
     - mdbooth


### PR DESCRIPTION
For a long time, in addition to the CAPO maintainers we have also allowed approvals from:
- sig-cluster-lifecycle-leads
- cluster-api-admins
- cluster-api-maintainers

However, we have to maintain these lists manually and our record of doing this has not been good. In practise there is also significant overlap in these groups.

As far as I am aware this facility has never been used, but it is easy to imagine a circumstance where it might be useful, e.g. a centrally coordinated CVE affecting multiple providers urgently. Allowing commits from CAPI maintainers should cover this use case in practise, and removing the other 2 lists reduces the amount of copy/paste we need to maintain from other projects.

/hold
