### PR TITLE
:seedling: Deprecate v1alpha5

### DIFF
--- a/api/v1alpha5/openstackcluster_types.go
+++ b/api/v1alpha5/openstackcluster_types.go
@@ -206,6 +206,7 @@ type OpenStackClusterStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion:warning="The v1alpha5 version of OpenStackCluster has been deprecated and will be removed in a future release of the API. Please upgrade."
 // +kubebuilder:resource:path=openstackclusters,scope=Namespaced,categories=cluster-api,shortName=osc
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this OpenStackCluster belongs"
@@ -217,6 +218,8 @@ type OpenStackClusterStatus struct {
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of OpenStackCluster"
 
 // OpenStackCluster is the Schema for the openstackclusters API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type OpenStackCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -228,6 +231,8 @@ type OpenStackCluster struct {
 // +kubebuilder:object:root=true
 
 // OpenStackClusterList contains a list of OpenStackCluster.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type OpenStackClusterList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/v1alpha5/openstackclustertemplate_types.go
+++ b/api/v1alpha5/openstackclustertemplate_types.go
@@ -30,10 +30,13 @@ type OpenStackClusterTemplateSpec struct {
 	Template OpenStackClusterTemplateResource `json:"template"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:resource:path=openstackclustertemplates,scope=Namespaced,categories=cluster-api,shortName=osct
+// +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion:warning="The v1alpha5 version of OpenStackClusterTemplate has been deprecated and will be removed in a future release of the API. Please upgrade."
+// +kubebuilder:resource:path=openstackclustertemplates,scope=Namespaced,categories=cluster-api,shortName=osct
 
 // OpenStackClusterTemplate is the Schema for the openstackclustertemplates API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type OpenStackClusterTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -41,9 +44,11 @@ type OpenStackClusterTemplate struct {
 	Spec OpenStackClusterTemplateSpec `json:"spec,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // OpenStackClusterTemplateList contains a list of OpenStackClusterTemplate.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type OpenStackClusterTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/v1alpha5/openstackmachine_types.go
+++ b/api/v1alpha5/openstackmachine_types.go
@@ -135,6 +135,7 @@ type OpenStackMachineStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion:warning="The v1alpha5 version of OpenStackMachine has been deprecated and will be removed in a future release of the API. Please upgrade."
 // +kubebuilder:resource:path=openstackmachines,scope=Namespaced,categories=cluster-api,shortName=osm
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this OpenStackMachine belongs"
@@ -145,6 +146,8 @@ type OpenStackMachineStatus struct {
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of OpenStackMachine"
 
 // OpenStackMachine is the Schema for the openstackmachines API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type OpenStackMachine struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -156,6 +159,8 @@ type OpenStackMachine struct {
 // +kubebuilder:object:root=true
 
 // OpenStackMachineList contains a list of OpenStackMachine.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type OpenStackMachineList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/v1alpha5/openstackmachinetemplate_types.go
+++ b/api/v1alpha5/openstackmachinetemplate_types.go
@@ -26,9 +26,12 @@ type OpenStackMachineTemplateSpec struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion:warning="The v1alpha5 version of OpenStackMachineTemplate has been deprecated and will be removed in a future release of the API. Please upgrade."
 // +kubebuilder:resource:path=openstackmachinetemplates,scope=Namespaced,categories=cluster-api,shortName=osmt
 
 // OpenStackMachineTemplate is the Schema for the openstackmachinetemplates API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type OpenStackMachineTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -39,6 +42,8 @@ type OpenStackMachineTemplate struct {
 // +kubebuilder:object:root=true
 
 // OpenStackMachineTemplateList contains a list of OpenStackMachineTemplate.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type OpenStackMachineTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -49,10 +49,14 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: The v1alpha5 version of OpenStackCluster has been deprecated
+      and will be removed in a future release of the API. Please upgrade.
     name: v1alpha5
     schema:
       openAPIV3Schema:
-        description: OpenStackCluster is the Schema for the openstackclusters API.
+        description: "OpenStackCluster is the Schema for the openstackclusters API.
+          \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
@@ -19,11 +19,14 @@ spec:
     singular: openstackclustertemplate
   scope: Namespaced
   versions:
-  - name: v1alpha5
+  - deprecated: true
+    deprecationWarning: The v1alpha5 version of OpenStackClusterTemplate has been
+      deprecated and will be removed in a future release of the API. Please upgrade.
+    name: v1alpha5
     schema:
       openAPIV3Schema:
-        description: OpenStackClusterTemplate is the Schema for the openstackclustertemplates
-          API.
+        description: "OpenStackClusterTemplate is the Schema for the openstackclustertemplates
+          API. \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
@@ -44,10 +44,14 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: The v1alpha5 version of OpenStackMachine has been deprecated
+      and will be removed in a future release of the API. Please upgrade.
     name: v1alpha5
     schema:
       openAPIV3Schema:
-        description: OpenStackMachine is the Schema for the openstackmachines API.
+        description: "OpenStackMachine is the Schema for the openstackmachines API.
+          \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
@@ -19,11 +19,14 @@ spec:
     singular: openstackmachinetemplate
   scope: Namespaced
   versions:
-  - name: v1alpha5
+  - deprecated: true
+    deprecationWarning: The v1alpha5 version of OpenStackMachineTemplate has been
+      deprecated and will be removed in a future release of the API. Please upgrade.
+    name: v1alpha5
     schema:
       openAPIV3Schema:
-        description: OpenStackMachineTemplate is the Schema for the openstackmachinetemplates
-          API.
+        description: "OpenStackMachineTemplate is the Schema for the openstackmachinetemplates
+          API. \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Mark v1alpha5 version deprecated in our Kubernetes CRDs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1556 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
<sub>Sean Schneeweiss <sean.schneeweiss@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)</sub>