### PR TITLE
🌱 E2e: Bump clusterctl upgrade to start from v0.7.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,12 +192,12 @@ e2e-image: docker-build
 
 # Pull all the images references in test/e2e/data/e2e_conf.yaml
 test-e2e-image-prerequisites:
-	docker pull gcr.io/k8s-staging-cluster-api/cluster-api-controller:v1.3.0
-	docker pull gcr.io/k8s-staging-cluster-api/kubeadm-bootstrap-controller:v1.3.0
-	docker pull gcr.io/k8s-staging-cluster-api/kubeadm-control-plane-controller:v1.3.0
-	docker pull quay.io/jetstack/cert-manager-cainjector:v1.8.2
-	docker pull quay.io/jetstack/cert-manager-webhook:v1.8.2
-	docker pull quay.io/jetstack/cert-manager-controller:v1.8.2
+	docker pull gcr.io/k8s-staging-cluster-api/cluster-api-controller:v1.4.1
+	docker pull gcr.io/k8s-staging-cluster-api/kubeadm-bootstrap-controller:v1.4.1
+	docker pull gcr.io/k8s-staging-cluster-api/kubeadm-control-plane-controller:v1.4.1
+	docker pull quay.io/jetstack/cert-manager-cainjector:v1.12.1
+	docker pull quay.io/jetstack/cert-manager-webhook:v1.12.1
+	docker pull quay.io/jetstack/cert-manager-controller:v1.12.1
 
 CONFORMANCE_E2E_ARGS ?= -kubetest.config-file=$(KUBETEST_CONF_PATH)
 CONFORMANCE_E2E_ARGS += $(E2E_ARGS)

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -21,11 +21,11 @@ images:
 # Use local dev images built source tree;
 - name: gcr.io/k8s-staging-capi-openstack/capi-openstack-controller:e2e
   loadBehavior: mustLoad
-- name: quay.io/jetstack/cert-manager-cainjector:v1.10.0
+- name: quay.io/jetstack/cert-manager-cainjector:v1.12.1
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-webhook:v1.10.0
+- name: quay.io/jetstack/cert-manager-webhook:v1.12.1
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-controller:v1.10.0
+- name: quay.io/jetstack/cert-manager-controller:v1.12.1
   loadBehavior: tryLoad
 
 providers:
@@ -89,8 +89,8 @@ providers:
       new: "--v=4"
     - old: "--leader-elect"
       new: "--leader-elect=false\n        - --sync-period=1m"
-  - name: v0.7.1
-    value: "https://github.com/kubernetes-sigs/cluster-api-provider-openstack/releases/download/v0.7.1/infrastructure-components.yaml"
+  - name: v0.7.2
+    value: "https://github.com/kubernetes-sigs/cluster-api-provider-openstack/releases/download/v0.7.2/infrastructure-components.yaml"
     type: url
     contract: v1beta1
     files:

--- a/test/e2e/suites/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/suites/e2e/clusterctl_upgrade_test.go
@@ -28,11 +28,6 @@ import (
 	"sigs.k8s.io/cluster-api-provider-openstack/test/e2e/shared"
 )
 
-// Note: There isn't really anything fixing this to the v0.6 release. The test will
-// simply pick the latest release with the correct contract from the E2EConfig, as seen here
-// https://github.com/kubernetes-sigs/cluster-api/blob/3abb9089485f51d46054096c17ccb8b59f0f7331/test/e2e/clusterctl_upgrade.go#L265
-// When new minor releases are added (with the same contract) we will need to work on this
-// if we want to continue testing v0.6.
 var _ = Describe("When testing clusterctl upgrades (v0.6=>current) [clusterctl-upgrade]", func() {
 	ctx := context.TODO()
 	shared.SetEnvVar("USE_CI_ARTIFACTS", "true", false)
@@ -68,7 +63,7 @@ var _ = Describe("When testing clusterctl upgrades (v0.7=>current) [clusterctl-u
 			SkipCleanup:                     false,
 			InitWithBinary:                  "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.3.1/clusterctl-{OS}-{ARCH}",
 			InitWithProvidersContract:       "v1beta1",
-			InitWithInfrastructureProviders: []string{"openstack:v0.7.1"},
+			InitWithInfrastructureProviders: []string{"openstack:v0.7.2"},
 			MgmtFlavor:                      shared.FlavorDefault,
 			WorkloadFlavor:                  shared.FlavorV1alpha6,
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

- Bump clusterctl upgrade v0.7 test to start from v0.7.2
- Sync and bump cert-manager version in Makefile and e2e_conf.yaml
- Sync CAPI container tags in Makefile and e2e_conf.yaml

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
