### PR TITLE
🐛 Always filter cluster subnets by cluster network ID

### DIFF
--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -456,7 +456,7 @@ func reconcileNetworkComponents(scope *scope.Scope, cluster *clusterv1.Cluster, 
 		openStackCluster.Status.Network.Name = networkList[0].Name
 		openStackCluster.Status.Network.Tags = networkList[0].Tags
 
-		subnet, err := networkingService.GetSubnetByFilter(&openStackCluster.Spec.Subnet)
+		subnet, err := networkingService.GetNetworkSubnetByFilter(openStackCluster.Status.Network.ID, &openStackCluster.Spec.Subnet)
 		if err != nil {
 			err = fmt.Errorf("failed to find subnet: %w", err)
 

--- a/pkg/cloud/services/networking/network.go
+++ b/pkg/cloud/services/networking/network.go
@@ -351,16 +351,31 @@ func (s *Service) GetSubnetsByFilter(opts subnets.ListOptsBuilder) ([]subnets.Su
 // GetSubnetByFilter gets a single subnet specified by the given SubnetFilter.
 // It returns an ErrFilterMatch if no or multiple subnets are found.
 func (s *Service) GetSubnetByFilter(filter *infrav1.SubnetFilter) (*subnets.Subnet, error) {
+	return s.getSubnetByFilter(filter.ToListOpt())
+}
+
+// GetNetworkSubnetByFilter gets a single subnet of the given network, specified by the given SubnetFilter.
+// It returns an ErrFilterMatch if no or multiple subnets are found.
+func (s *Service) GetNetworkSubnetByFilter(networkID string, filter *infrav1.SubnetFilter) (*subnets.Subnet, error) {
+	listOpt := filter.ToListOpt()
+	listOpt.NetworkID = networkID
+
+	return s.getSubnetByFilter(listOpt)
+}
+
+// getSubnetByFilter gets a single subnet specified by the given gophercloud ListOpts.
+// It returns an ErrFilterMatch if no or multiple subnets are found.
+func (s *Service) getSubnetByFilter(listOpts subnets.ListOpts) (*subnets.Subnet, error) {
 	// If the ID is set, we can just get the subnet by ID.
-	if filter.ID != "" {
-		subnet, err := s.client.GetSubnet(filter.ID)
+	if listOpts.ID != "" {
+		subnet, err := s.client.GetSubnet(listOpts.ID)
 		if capoerrors.IsNotFound(err) {
 			return nil, ErrNoMatches
 		}
 		return subnet, err
 	}
 
-	subnets, err := s.GetSubnetsByFilter(filter.ToListOpt())
+	subnets, err := s.GetSubnetsByFilter(listOpts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Conflicts:
  controllers/openstackcluster_controller_test.go

  Unable to backport test as it depends on ScopeFactory.

(cherry picked from commit bbe2472760c2f6d9cfdd0ebf1f7114ddb51d49ed)

Fixes #1570 

**Special notes for your reviewer**:
As noted in the commit message it wasn't possible to backport the envtest as it relies on scope factory, which is not in 0.7.

/hold
