### PR TITLE
⚠️ Remove ProjectID from PortOpts

### DIFF
--- a/api/v1alpha5/zz_generated.conversion.go
+++ b/api/v1alpha5/zz_generated.conversion.go
@@ -1358,7 +1358,7 @@ func autoConvert_v1alpha5_PortOpts_To_v1alpha7_PortOpts(in *PortOpts, out *v1alp
 	out.MACAddress = in.MACAddress
 	out.FixedIPs = *(*[]v1alpha7.FixedIP)(unsafe.Pointer(&in.FixedIPs))
 	// WARNING: in.TenantID requires manual conversion: does not exist in peer-type
-	out.ProjectID = in.ProjectID
+	// WARNING: in.ProjectID requires manual conversion: does not exist in peer-type
 	// WARNING: in.SecurityGroups requires manual conversion: does not exist in peer-type
 	if in.SecurityGroupFilters != nil {
 		in, out := &in.SecurityGroupFilters, &out.SecurityGroupFilters
@@ -1388,7 +1388,6 @@ func autoConvert_v1alpha7_PortOpts_To_v1alpha5_PortOpts(in *v1alpha7.PortOpts, o
 	out.AdminStateUp = (*bool)(unsafe.Pointer(in.AdminStateUp))
 	out.MACAddress = in.MACAddress
 	out.FixedIPs = *(*[]FixedIP)(unsafe.Pointer(&in.FixedIPs))
-	out.ProjectID = in.ProjectID
 	if in.SecurityGroupFilters != nil {
 		in, out := &in.SecurityGroupFilters, &out.SecurityGroupFilters
 		*out = make([]SecurityGroupParam, len(*in))

--- a/api/v1alpha6/zz_generated.conversion.go
+++ b/api/v1alpha6/zz_generated.conversion.go
@@ -1365,7 +1365,7 @@ func autoConvert_v1alpha6_PortOpts_To_v1alpha7_PortOpts(in *PortOpts, out *v1alp
 	out.MACAddress = in.MACAddress
 	out.FixedIPs = *(*[]v1alpha7.FixedIP)(unsafe.Pointer(&in.FixedIPs))
 	// WARNING: in.TenantID requires manual conversion: does not exist in peer-type
-	out.ProjectID = in.ProjectID
+	// WARNING: in.ProjectID requires manual conversion: does not exist in peer-type
 	// WARNING: in.SecurityGroups requires manual conversion: does not exist in peer-type
 	if in.SecurityGroupFilters != nil {
 		in, out := &in.SecurityGroupFilters, &out.SecurityGroupFilters
@@ -1396,7 +1396,6 @@ func autoConvert_v1alpha7_PortOpts_To_v1alpha6_PortOpts(in *v1alpha7.PortOpts, o
 	out.AdminStateUp = (*bool)(unsafe.Pointer(in.AdminStateUp))
 	out.MACAddress = in.MACAddress
 	out.FixedIPs = *(*[]FixedIP)(unsafe.Pointer(&in.FixedIPs))
-	out.ProjectID = in.ProjectID
 	if in.SecurityGroupFilters != nil {
 		in, out := &in.SecurityGroupFilters, &out.SecurityGroupFilters
 		*out = make([]SecurityGroupParam, len(*in))

--- a/api/v1alpha7/types.go
+++ b/api/v1alpha7/types.go
@@ -88,8 +88,7 @@ type PortOpts struct {
 	AdminStateUp *bool  `json:"adminStateUp,omitempty"`
 	MACAddress   string `json:"macAddress,omitempty"`
 	// Specify pairs of subnet and/or IP address. These should be subnets of the network with the given NetworkID.
-	FixedIPs  []FixedIP `json:"fixedIPs,omitempty"`
-	ProjectID string    `json:"projectId,omitempty"`
+	FixedIPs []FixedIP `json:"fixedIPs,omitempty"`
 	// The names, uuids, filters or any combination these of the security groups to assign to the instance
 	SecurityGroupFilters []SecurityGroupFilter `json:"securityGroupFilters,omitempty"`
 	AllowedAddressPairs  []AddressPair         `json:"allowedAddressPairs,omitempty"`

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -3944,8 +3944,6 @@ spec:
                                     mode” for the VF.
                                   type: boolean
                               type: object
-                            projectId:
-                              type: string
                             propagateUplinkStatus:
                               description: PropageteUplinkStatus enables or disables
                                 the propagate uplink status on the port.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
@@ -1784,8 +1784,6 @@ spec:
                                             the “trusted mode” for the VF.
                                           type: boolean
                                       type: object
-                                    projectId:
-                                      type: string
                                     propagateUplinkStatus:
                                       description: PropageteUplinkStatus enables or
                                         disables the propagate uplink status on the

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
@@ -1320,8 +1320,6 @@ spec:
                             mode” for the VF.
                           type: boolean
                       type: object
-                    projectId:
-                      type: string
                     propagateUplinkStatus:
                       description: PropageteUplinkStatus enables or disables the propagate
                         uplink status on the port.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
@@ -1128,8 +1128,6 @@ spec:
                                     mode” for the VF.
                                   type: boolean
                               type: object
-                            projectId:
-                              type: string
                             propagateUplinkStatus:
                               description: PropageteUplinkStatus enables or disables
                                 the propagate uplink status on the port.

--- a/docs/book/src/topics/crd-changes/v1alpha6-to-v1alpha7.md
+++ b/docs/book/src/topics/crd-changes/v1alpha6-to-v1alpha7.md
@@ -12,7 +12,7 @@
       - [Changes to ports](#changes-to-ports)
         - [Change to securityGroupFilters](#change-to-securitygroupfilters)
         - [Removal of securityGroups](#removal-of-securitygroups)
-        - [Removal of tenantId](#removal-of-tenantid)
+        - [Removal of tenantId and projectId](#removal-of-tenantid-and-projectid)
         - [Change to profile](#change-to-profile)
     - [`OpenStackCluster`](#openstackcluster)
       - [Change to externalRouterIPs.subnet](#change-to-externalrouteripssubnet)
@@ -184,9 +184,9 @@ securityGroupFilters:
 - id: 4a131d3e-9939-4a6b-adea-788a2e89fcd8
 ```
 
-##### Removal of tenantId
+##### Removal of tenantId and projectId
 
-Use projectId instead.
+These are removed without replacement. They required admin permission to set, which CAPO does not have by default, and served no purpose.
 
 ##### Change to profile
 

--- a/pkg/cloud/services/networking/port.go
+++ b/pkg/cloud/services/networking/port.go
@@ -137,7 +137,6 @@ func (s *Service) GetOrCreatePort(eventObject runtime.Object, clusterName string
 		Description:           description,
 		AdminStateUp:          portOpts.AdminStateUp,
 		MACAddress:            portOpts.MACAddress,
-		ProjectID:             portOpts.ProjectID,
 		SecurityGroups:        securityGroupsPtr,
 		AllowedAddressPairs:   addressPairs,
 		FixedIPs:              fixedIPs,

--- a/pkg/cloud/services/networking/port_test.go
+++ b/pkg/cloud/services/networking/port_test.go
@@ -43,7 +43,6 @@ func Test_GetOrCreatePort(t *testing.T) {
 	portID1 := "50214c48-c09e-4a54-914f-97b40fd22802"
 	portID2 := "4c096384-f0a5-466d-9534-06a7ed281a79"
 	hostID := "825c1b11-3dca-4bfe-a2d8-a3cc1964c8d5"
-	projectID := "063171b1-0595-4882-98cd-3ee79676ff87"
 	trunkID := "eb7541fa-5e2a-4cca-b2c3-dfa409b917ce"
 	portSecurityGroupID := "f51d1206-fc5a-4f7a-a5c0-2e03e44e4dc0"
 
@@ -171,7 +170,6 @@ func Test_GetOrCreatePort(t *testing.T) {
 					},
 					IPAddress: "192.168.0.50",
 				}, {IPAddress: "192.168.1.50"}},
-				ProjectID:            projectID,
 				SecurityGroupFilters: portSecurityGroupFilters,
 				AllowedAddressPairs: []infrav1.AddressPair{{
 					IPAddress:  "10.10.10.10",
@@ -203,7 +201,6 @@ func Test_GetOrCreatePort(t *testing.T) {
 							IPAddress: "192.168.1.50",
 						},
 					},
-					ProjectID:      projectID,
 					SecurityGroups: &securityGroupUUIDs,
 					AllowedAddressPairs: []ports.AddressPair{{
 						IPAddress:  "10.10.10.10",


### PR DESCRIPTION
Setting this value requires admin privileges and serves no purpose in CAPO.

/hold
