### PR TITLE
🌱 E2e: Implement LogCollector interface

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -86,7 +86,7 @@ fi
 
 # Upload image for e2e clusterctl upgrade tests
 source "${REPO_ROOT}/hack/ci/${RESOURCE_TYPE}.sh"
-CONTAINER_ARCHIVE="${ARTIFACTS}/capo-e2e-image.tar"
+CONTAINER_ARCHIVE="/tmp/capo-e2e-image.tar"
 SSH_KEY="$(get_ssh_private_key_file)"
 SSH_ARGS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o PasswordAuthentication=no"
 CONTROLLER_IP=${CONTROLLER_IP:-"10.0.3.15"}

--- a/test/e2e/shared/suite.go
+++ b/test/e2e/shared/suite.go
@@ -182,7 +182,8 @@ func AllNodesBeforeSuite(e2eCtx *E2EContext, data []byte) {
 	e2eCtx.Settings.ArtifactFolder = conf.ArtifactFolder
 	e2eCtx.Settings.ConfigPath = conf.ConfigPath
 	e2eCtx.Environment.ClusterctlConfigPath = conf.ClusterctlConfigPath
-	e2eCtx.Environment.BootstrapClusterProxy = framework.NewClusterProxy("bootstrap", conf.KubeconfigPath, e2eCtx.Environment.Scheme)
+	withLogCollector := framework.WithMachineLogCollector(OpenStackLogCollector{E2EContext: *e2eCtx})
+	e2eCtx.Environment.BootstrapClusterProxy = framework.NewClusterProxy("bootstrap", conf.KubeconfigPath, e2eCtx.Environment.Scheme, withLogCollector)
 	e2eCtx.E2EConfig = &conf.E2EConfig
 	e2eCtx.Settings.KubetestConfigFilePath = conf.KubetestConfigFilePath
 	e2eCtx.Settings.UseCIArtifacts = conf.UseCIArtifacts


### PR DESCRIPTION
**What this PR does / why we need it**:

CAPI provides an interface LogCollector that the providers can implement to get provider specific logs from the CAPI test specs. This gives us logs from the clusterctl upgrade, self-hosted and remediation tests.

Moves the `capo-e2e-image.tar` out of the `_artifacts` since we do not need to save this with the logs. It just takes up space for no reason.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
