### PR TITLE
🌱 Replace github.com/pkg/errors

### DIFF
--- a/api/v1alpha7/openstackmachine_webhook.go
+++ b/api/v1alpha7/openstackmachine_webhook.go
@@ -17,9 +17,9 @@ limitations under the License.
 package v1alpha7
 
 import (
+	"fmt"
 	"reflect"
 
-	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -69,13 +69,13 @@ func (r *OpenStackMachine) ValidateUpdate(old runtime.Object) error {
 	newOpenStackMachine, err := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	if err != nil {
 		return apierrors.NewInvalid(GroupVersion.WithKind("OpenStackMachine").GroupKind(), r.Name, field.ErrorList{
-			field.InternalError(nil, errors.Wrap(err, "failed to convert new OpenStackMachine to unstructured object")),
+			field.InternalError(nil, fmt.Errorf("failed to convert new OpenStackMachine to unstructured object: %w", err)),
 		})
 	}
 	oldOpenStackMachine, err := runtime.DefaultUnstructuredConverter.ToUnstructured(old)
 	if err != nil {
 		return apierrors.NewInvalid(GroupVersion.WithKind("OpenStackMachine").GroupKind(), r.Name, field.ErrorList{
-			field.InternalError(nil, errors.Wrap(err, "failed to convert old OpenStackMachine to unstructured object")),
+			field.InternalError(nil, fmt.Errorf("failed to convert old OpenStackMachine to unstructured object: %w", err)),
 		})
 	}
 

--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -447,12 +447,12 @@ func reconcileNetworkComponents(scope scope.Scope, cluster *clusterv1.Cluster, o
 			return fmt.Errorf("failed to find network: %w", err)
 		}
 		if len(networkList) == 0 {
-			handleUpdateOSCError(openStackCluster, fmt.Errorf("failed to find any network: %w", err))
-			return fmt.Errorf("failed to find any network: %w", err)
+			handleUpdateOSCError(openStackCluster, fmt.Errorf("failed to find any network"))
+			return fmt.Errorf("failed to find any network")
 		}
 		if len(networkList) > 1 {
-			handleUpdateOSCError(openStackCluster, fmt.Errorf("failed to find only one network (result: %v): %w", networkList, err))
-			return fmt.Errorf("failed to find only one network (result: %v): %w", networkList, err)
+			handleUpdateOSCError(openStackCluster, fmt.Errorf("found multiple networks (result: %v)", networkList))
+			return fmt.Errorf("found multiple networks (result: %v)", networkList)
 		}
 		if openStackCluster.Status.Network == nil {
 			openStackCluster.Status.Network = &infrav1.Network{}

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/hashicorp/go-version v1.4.0
 	github.com/onsi/ginkgo/v2 v2.9.2
 	github.com/onsi/gomega v1.27.6
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/crypto v0.7.0
@@ -96,6 +95,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect


### PR DESCRIPTION
**What this PR does / why we need it**:

The package [pkg/errors](https://github.com/pkg/errors) has served its purpose and its proposed changes have been incorporated into Go's standard library in Go v1.13.

This change removes it as a direct dependency, replacing its functionality with the corresponding features of `fmt` and `errors`.

**Special notes for your reviewer**:

The old `pkg/errors` defined the method `Cause() error`, whereas the stdlib incorporated its functionality with the method `Unwrap() error`. As such, if a consumer of CAPO directly called `errors.Cause(err)` to match the causing error, then their code would silently break because the underlying sentinel error wouldn't be identified.

This problem is susceptible to affect any code that uses CAPO as a library, that uses  a version of `pkg/errors` below [`v0.9.0`](https://github.com/pkg/errors/releases/tag/v0.9.0).

The last versions of `pkg/errors` (v0.9.0+) [incorporated](https://github.com/pkg/errors/blob/614d223910a179a466c1767a985424175c39b465/errors.go#L248) a compatibility layer with the new `Unwrap()` syntax.

**TODOs**:

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold

_EDIT: Added a note pointing out that there is a risk of compatibility issues_