### PR TITLE
:sparkles: Add additional sec group rule for additionalPorts of LB

### DIFF
--- a/pkg/cloud/services/networking/securitygroups.go
+++ b/pkg/cloud/services/networking/securitygroups.go
@@ -121,6 +121,11 @@ func (s *Service) generateDesiredSecGroups(openStackCluster *infrav1.OpenStackCl
 	controlPlaneRules = append(controlPlaneRules, GetSGControlPlaneHTTPS()...)
 	workerRules = append(workerRules, GetSGWorkerNodePort()...)
 
+	// If we set additional ports to LB, we need create secgroup rules those ports, this apply to controlPlaneRules only
+	if openStackCluster.Spec.APIServerLoadBalancer.Enabled {
+		controlPlaneRules = append(controlPlaneRules, GetSGControlPlaneAdditionalPorts(openStackCluster.Spec.APIServerLoadBalancer.AdditionalPorts)...)
+	}
+
 	if openStackCluster.Spec.AllowAllInClusterTraffic {
 		// Permit all ingress from the cluster security groups
 		controlPlaneRules = append(controlPlaneRules, GetSGControlPlaneAllowAll(remoteGroupIDSelf, secWorkerGroupID)...)

--- a/pkg/cloud/services/networking/securitygroups_rules.go
+++ b/pkg/cloud/services/networking/securitygroups_rules.go
@@ -291,6 +291,34 @@ func GetSGWorkerAllowAll(remoteGroupIDSelf, secControlPlaneGroupID string) []inf
 	}
 }
 
+// Permit ports that defined in openStackCluster.Spec.APIServerLoadBalancer.AdditionalPorts.
+func GetSGControlPlaneAdditionalPorts(ports []int) []infrav1.SecurityGroupRule {
+	controlPlaneRules := []infrav1.SecurityGroupRule{}
+
+	r := []infrav1.SecurityGroupRule{
+		{
+			Description: "Additional ports",
+			Direction:   "ingress",
+			EtherType:   "IPv4",
+			Protocol:    "tcp",
+		},
+		{
+			Description: "Additional ports",
+			Direction:   "ingress",
+			EtherType:   "IPv4",
+			Protocol:    "udp",
+		},
+	}
+	for _, p := range ports {
+		r[0].PortRangeMin = p
+		r[0].PortRangeMax = p
+		r[1].PortRangeMin = p
+		r[1].PortRangeMax = p
+		controlPlaneRules = append(controlPlaneRules, r...)
+	}
+	return controlPlaneRules
+}
+
 func GetSGControlPlaneGeneral(remoteGroupIDSelf, secWorkerGroupID string) []infrav1.SecurityGroupRule {
 	controlPlaneRules := []infrav1.SecurityGroupRule{}
 	controlPlaneRules = append(controlPlaneRules, getSGControlPlaneCommon(remoteGroupIDSelf, secWorkerGroupID)...)


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1588 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
