### PR TITLE
🌱 E2e: Bump the tested Kubernetes versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ This provider's versions are compatible with the following versions of Cluster A
 
 This provider's versions are able to install and manage the following versions of Kubernetes:
 
-|                                    | v1.21 | v1.22 | v1.23 | v1.24 | v1.25 | v1.26 |
+|                                    | v1.22 | v1.23 | v1.24 | v1.25 | v1.26 | v1.27 |
 |------------------------------------| ----- | ----- | ----- | ----- | ----- | ----- |
-| OpenStack Provider v1alpha5 (v0.6) | ✓     | +     | ✓     | ✓     | ✓     | +     |
-| OpenStack Provider v1alpha6 (v0.7) | ✓     | +     | ✓     | ✓     | ✓     | ✓     |
-| OpenStack Provider v1alpha7        | +     | +     | +     | +     | +     | ✓     |
+| OpenStack Provider v1alpha5 (v0.6) | +     | ✓     | ✓     | ✓     | +     | +     |
+| OpenStack Provider v1alpha6 (v0.7) | +     | ✓     | ✓     | ✓     | ✓     | ✓     |
+| OpenStack Provider v1alpha7        | +     | +     | +     | +     | ✓     | ✓     |
 
 This provider's versions are able to install Kubernetes to the following versions of OpenStack:
 

--- a/hack/ci/cloud-init/controller.yaml.tpl
+++ b/hack/ci/cloud-init/controller.yaml.tpl
@@ -138,7 +138,7 @@
     # https://docs.openstack.org/glance/latest/admin/quotas.html
     /opt/stack/devstack/tools/upload_image.sh https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/cirros/2022-12-05/cirros-0.6.1-x86_64-disk.img
     /opt/stack/devstack/tools/upload_image.sh https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/ubuntu/2023-01-14/focal-server-cloudimg-amd64.img
-    /opt/stack/devstack/tools/upload_image.sh https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/flatcar/flatcar-stable-3510.2.1-kube-v1.26.5.img
+    /opt/stack/devstack/tools/upload_image.sh https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/flatcar/flatcar-stable-3510.2.3-kube-v1.27.2.img
 
     # Add the controller to its own host aggregate and availability zone
     aggregateid=$(openstack aggregate create --zone "${PRIMARY_AZ}" "${PRIMARY_AZ}" -f value -c id)

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -128,9 +128,9 @@ providers:
 variables:
   # used to ensure we deploy to the correct management cluster
   KUBE_CONTEXT: "kind-capo-e2e"
-  KUBERNETES_VERSION: "v1.26.5"
-  KUBERNETES_VERSION_UPGRADE_FROM: "v1.25.10"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.26.5"
+  KUBERNETES_VERSION: "v1.27.2"
+  KUBERNETES_VERSION_UPGRADE_FROM: "v1.26.5"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.27.2"
   ETCD_VERSION_UPGRADE_TO: "3.5.6-0"
   COREDNS_VERSION_UPGRADE_TO: "v1.9.3"
   CNI: "../../data/cni/calico.yaml"
@@ -153,12 +153,12 @@ variables:
   OPENSTACK_VOLUME_TYPE_ALT: "test-volume-type"
   CONFORMANCE_WORKER_MACHINE_COUNT: "5"
   CONFORMANCE_CONTROL_PLANE_MACHINE_COUNT: "1"
-  INIT_WITH_KUBERNETES_VERSION: "v1.26.5"
+  INIT_WITH_KUBERNETES_VERSION: "v1.27.2"
   E2E_IMAGE_URL: "http://10.0.3.15/capo-e2e-image.tar"
   # The default user for SSH connections from bastion to machines
   SSH_USER_MACHINE: "ubuntu"
   EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION: "true"
-  OPENSTACK_FLATCAR_IMAGE_NAME: "flatcar-stable-3510.2.1-kube-v1.26.5"
+  OPENSTACK_FLATCAR_IMAGE_NAME: "flatcar-stable-3510.2.3-kube-v1.27.2"
 
 intervals:
   conformance/wait-control-plane: ["30m", "10s"]


### PR DESCRIPTION
**What this PR does / why we need it**:

This bumps the tested Kubernetes version to v1.27.2. It also adds v1.27 to the list of compatible versions and removes v1.21. This is just to keep the table from growing too much. The v1.21 is anyway out of support.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests
- [x] Update flatcar image @tormath1 :pray: 

/hold
