### PR TITLE
🌱 Add metadata for release 0.8

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -10,3 +10,6 @@ releaseSeries:
 - major: 0
   minor: 7
   contract: v1beta1
+- major: 0
+  minor: 8
+  contract: v1beta1

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -103,7 +103,7 @@ providers:
       new: "--v=4"
     - old: "--leader-elect"
       new: "--leader-elect=false\n        - --sync-period=1m"
-  - name: v0.7.99
+  - name: v0.8.99
     value: ../../../config/default
     # This is the upcoming version.
     # Specify no contract so that upgrade tests that start from a specific contract won't pick it up.

--- a/test/e2e/data/shared/v1beta1_provider/metadata.yaml
+++ b/test/e2e/data/shared/v1beta1_provider/metadata.yaml
@@ -10,3 +10,6 @@ releaseSeries:
 - major: 0
   minor: 7
   contract: v1beta1
+- major: 0
+  minor: 8
+  contract: v1beta1


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds/updates metadata which needs to exist before branching release-0.8

/hold
