### PR TITLE
:seedling: ci: bump flatcar to latest stable

### DIFF
--- a/hack/ci/cloud-init/controller.yaml.tpl
+++ b/hack/ci/cloud-init/controller.yaml.tpl
@@ -138,7 +138,7 @@
     # https://docs.openstack.org/glance/latest/admin/quotas.html
     /opt/stack/devstack/tools/upload_image.sh https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/cirros/2022-12-05/cirros-0.6.1-x86_64-disk.img
     /opt/stack/devstack/tools/upload_image.sh https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/ubuntu/2023-01-14/focal-server-cloudimg-amd64.img
-    /opt/stack/devstack/tools/upload_image.sh https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/flatcar/flatcar-stable-3510.2.3-kube-v1.27.2.img
+    /opt/stack/devstack/tools/upload_image.sh https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/flatcar/flatcar-stable-3510.2.4-kube-v1.27.2.img
 
     # Add the controller to its own host aggregate and availability zone
     aggregateid=$(openstack aggregate create --zone "${PRIMARY_AZ}" "${PRIMARY_AZ}" -f value -c id)

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -158,7 +158,7 @@ variables:
   # The default user for SSH connections from bastion to machines
   SSH_USER_MACHINE: "ubuntu"
   EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION: "true"
-  OPENSTACK_FLATCAR_IMAGE_NAME: "flatcar-stable-3510.2.3-kube-v1.27.2"
+  OPENSTACK_FLATCAR_IMAGE_NAME: "flatcar-stable-3510.2.4-kube-v1.27.2"
 
 intervals:
   conformance/wait-control-plane: ["30m", "10s"]


### PR DESCRIPTION
Hey, there is new Flatcar stable release (https://github.com/flatcar/Flatcar/issues/1106) - it mainly brings Kernel security fixes. Bumped the Kubernetes version to 1.27.3 too. 

NOTE: Here's a small documentation for Flatcar / CAPO maintainers if someone wants to do it next time: https://gist.github.com/tormath1/acbae5c6cd12420bb8ea137e25655c99


**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
