### PR TITLE
:sparkles: Allow Use of Public CAs

### DIFF
--- a/pkg/scope/provider.go
+++ b/pkg/scope/provider.go
@@ -153,13 +153,13 @@ func NewProviderClient(cloud clientconfig.Cloud, caCert []byte, logger logr.Logg
 	}
 
 	config := &tls.Config{
-		RootCAs:    x509.NewCertPool(),
 		MinVersion: tls.VersionTLS12,
 	}
 	if cloud.Verify != nil {
 		config.InsecureSkipVerify = !*cloud.Verify
 	}
 	if caCert != nil {
+		config.RootCAs = x509.NewCertPool()
 		config.RootCAs.AppendCertsFromPEM(caCert)
 	}
 


### PR DESCRIPTION
As a public cloud operator it strikes me as odd that I have to supply a CA certificate for every cluster that's created.  This leads to a bunch of code that has to Dial the endpoint and extract the root CA (rather than hard coding it - ugh!).  The whole point of the distroless base container image is to distribute TLS root CAs, so allow the option to use what's already present.

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

As stated in the commit message.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
