### PR TITLE
🌱 chore: use capo cluster agent for API requests

### DIFF
--- a/pkg/scope/provider.go
+++ b/pkg/scope/provider.go
@@ -37,6 +37,7 @@ import (
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha7"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients"
+	"sigs.k8s.io/cluster-api-provider-openstack/version"
 )
 
 const (
@@ -151,6 +152,10 @@ func NewProviderClient(cloud clientconfig.Cloud, caCert []byte, logger logr.Logg
 	if err != nil {
 		return nil, nil, "", fmt.Errorf("create providerClient err: %v", err)
 	}
+
+	ua := gophercloud.UserAgent{}
+	ua.Prepend(fmt.Sprintf("cluster-api-provider-openstack/%s", version.Get().String()))
+	provider.UserAgent = ua
 
 	config := &tls.Config{
 		MinVersion: tls.VersionTLS12,


### PR DESCRIPTION
**What this PR does / why we need it**:
At the moment, we do not modify the user agent for all API requests we make which make it hard to identify if certain requests were done by CAPO or not.

This change prepends the CAPO version to the Gophercloud user agent which will give plenty of benefits.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1611 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
