### PR TITLE
🌱 Simplify types of Instance.SecurityGroup and Instance.Networks

### DIFF
--- a/api/v1alpha5/types.go
+++ b/api/v1alpha5/types.go
@@ -162,8 +162,8 @@ type Instance struct {
 	Name           string            `json:"name,omitempty"`
 	Trunk          bool              `json:"trunk,omitempty"`
 	FailureDomain  string            `json:"failureDomain,omitempty"`
-	SecurityGroups *[]string         `json:"securigyGroups,omitempty"`
-	Networks       *[]Network        `json:"networks,omitempty"`
+	SecurityGroups []string          `json:"securigyGroups,omitempty"`
+	Networks       []Network         `json:"networks,omitempty"`
 	Subnet         string            `json:"subnet,omitempty"`
 	Tags           []string          `json:"tags,omitempty"`
 	Image          string            `json:"image,omitempty"`

--- a/api/v1alpha5/zz_generated.deepcopy.go
+++ b/api/v1alpha5/zz_generated.deepcopy.go
@@ -125,22 +125,14 @@ func (in *Instance) DeepCopyInto(out *Instance) {
 	*out = *in
 	if in.SecurityGroups != nil {
 		in, out := &in.SecurityGroups, &out.SecurityGroups
-		*out = new([]string)
-		if **in != nil {
-			in, out := *in, *out
-			*out = make([]string, len(*in))
-			copy(*out, *in)
-		}
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	if in.Networks != nil {
 		in, out := &in.Networks, &out.Networks
-		*out = new([]Network)
-		if **in != nil {
-			in, out := *in, *out
-			*out = make([]Network, len(*in))
-			for i := range *in {
-				(*in)[i].DeepCopyInto(&(*out)[i])
-			}
+		*out = make([]Network, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.Tags != nil {

--- a/api/v1alpha6/types.go
+++ b/api/v1alpha6/types.go
@@ -172,8 +172,8 @@ type Instance struct {
 	Name           string            `json:"name,omitempty"`
 	Trunk          bool              `json:"trunk,omitempty"`
 	FailureDomain  string            `json:"failureDomain,omitempty"`
-	SecurityGroups *[]string         `json:"securigyGroups,omitempty"`
-	Networks       *[]Network        `json:"networks,omitempty"`
+	SecurityGroups []string          `json:"securigyGroups,omitempty"`
+	Networks       []Network         `json:"networks,omitempty"`
 	Subnet         string            `json:"subnet,omitempty"`
 	Tags           []string          `json:"tags,omitempty"`
 	Image          string            `json:"image,omitempty"`

--- a/api/v1alpha6/zz_generated.deepcopy.go
+++ b/api/v1alpha6/zz_generated.deepcopy.go
@@ -125,22 +125,14 @@ func (in *Instance) DeepCopyInto(out *Instance) {
 	*out = *in
 	if in.SecurityGroups != nil {
 		in, out := &in.SecurityGroups, &out.SecurityGroups
-		*out = new([]string)
-		if **in != nil {
-			in, out := *in, *out
-			*out = make([]string, len(*in))
-			copy(*out, *in)
-		}
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	if in.Networks != nil {
 		in, out := &in.Networks, &out.Networks
-		*out = new([]Network)
-		if **in != nil {
-			in, out := *in, *out
-			*out = make([]Network, len(*in))
-			for i := range *in {
-				(*in)[i].DeepCopyInto(&(*out)[i])
-			}
+		*out = make([]Network, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.Tags != nil {


### PR DESCRIPTION
These both have a type of pointer to slice, which is:
* Redundant in Go
* Is marshalled identically in the CRD to a slice with no pointer

To verify the latter, note that there are no changes to the CRD despite the type change.

Also note that the values are unused.

The reason for fixing these types is that Semantic.DeepEqual can't compare them correctly so they break the fuzzer tests.

/hold
