### PR TITLE
🌱 Updated log levels for pkg/cloud/services/networking/network.go and router.go

### DIFF
--- a/pkg/cloud/services/networking/network.go
+++ b/pkg/cloud/services/networking/network.go
@@ -110,7 +110,7 @@ func (s *Service) ReconcileExternalNetwork(openStackCluster *infrav1.OpenStackCl
 			Name: networkList[0].Name,
 			Tags: networkList[0].Tags,
 		}
-		s.scope.Logger().Info("External network found", "network id", networkList[0].ID)
+		s.scope.Logger().Info("External network found", "id", networkList[0].ID)
 		return nil
 	}
 	return fmt.Errorf("found %d external networks, which should not happen", len(networkList))
@@ -131,8 +131,7 @@ func (s *Service) ReconcileNetwork(openStackCluster *infrav1.OpenStackCluster, c
 		openStackCluster.Status.Network.ID = res.ID
 		openStackCluster.Status.Network.Name = res.Name
 		openStackCluster.Status.Network.Tags = res.Tags
-		sInfo := fmt.Sprintf("Reuse Existing Network %s with id %s", res.Name, res.ID)
-		s.scope.Logger().V(6).Info(sInfo)
+		s.scope.Logger().V(6).Info("Reusing existing network", "name", res.Name, "id", res.ID)
 		return nil
 	}
 
@@ -195,7 +194,7 @@ func (s *Service) DeleteNetwork(openStackCluster *infrav1.OpenStackCluster, clus
 
 func (s *Service) ReconcileSubnet(openStackCluster *infrav1.OpenStackCluster, clusterName string) error {
 	if openStackCluster.Status.Network == nil || openStackCluster.Status.Network.ID == "" {
-		s.scope.Logger().V(4).Info("No need to reconcile network components since no network exists.")
+		s.scope.Logger().V(4).Info("No need to reconcile network components since no network exists")
 		return nil
 	}
 
@@ -223,7 +222,7 @@ func (s *Service) ReconcileSubnet(openStackCluster *infrav1.OpenStackCluster, cl
 		}
 	} else if len(subnetList) == 1 {
 		subnet = &subnetList[0]
-		s.scope.Logger().V(6).Info(fmt.Sprintf("Reuse existing subnet %s with id %s", subnetName, subnet.ID))
+		s.scope.Logger().V(6).Info("Reusing existing subnet", "name", subnet.Name, "id", subnet.ID)
 	}
 
 	openStackCluster.Status.Network.Subnets = []infrav1.Subnet{

--- a/pkg/cloud/services/networking/network.go
+++ b/pkg/cloud/services/networking/network.go
@@ -102,7 +102,7 @@ func (s *Service) ReconcileExternalNetwork(openStackCluster *infrav1.OpenStackCl
 	case 0:
 		// Not finding an external network is fine
 		openStackCluster.Status.ExternalNetwork = &infrav1.NetworkStatus{}
-		s.scope.Logger().Info("No external network found - proceeding with internal network only")
+		s.scope.Logger().V(2).Info("No external network found - proceeding with internal network only")
 		return nil
 	case 1:
 		openStackCluster.Status.ExternalNetwork = &infrav1.NetworkStatus{
@@ -110,7 +110,7 @@ func (s *Service) ReconcileExternalNetwork(openStackCluster *infrav1.OpenStackCl
 			Name: networkList[0].Name,
 			Tags: networkList[0].Tags,
 		}
-		s.scope.Logger().Info("External network found", "id", networkList[0].ID)
+		s.scope.Logger().V(2).Info("External network found", "id", networkList[0].ID)
 		return nil
 	}
 	return fmt.Errorf("found %d external networks, which should not happen", len(networkList))
@@ -118,7 +118,7 @@ func (s *Service) ReconcileExternalNetwork(openStackCluster *infrav1.OpenStackCl
 
 func (s *Service) ReconcileNetwork(openStackCluster *infrav1.OpenStackCluster, clusterName string) error {
 	networkName := getNetworkName(clusterName)
-	s.scope.Logger().Info("Reconciling network", "name", networkName)
+	s.scope.Logger().V(2).Info("Reconciling network", "name", networkName)
 
 	res, err := s.getNetworkByName(networkName)
 	if err != nil {
@@ -131,7 +131,7 @@ func (s *Service) ReconcileNetwork(openStackCluster *infrav1.OpenStackCluster, c
 		openStackCluster.Status.Network.ID = res.ID
 		openStackCluster.Status.Network.Name = res.Name
 		openStackCluster.Status.Network.Tags = res.Tags
-		s.scope.Logger().V(6).Info("Reusing existing network", "name", res.Name, "id", res.ID)
+		s.scope.Logger().V(2).Info("Reusing existing network", "name", res.Name, "id", res.ID)
 		return nil
 	}
 
@@ -194,12 +194,12 @@ func (s *Service) DeleteNetwork(openStackCluster *infrav1.OpenStackCluster, clus
 
 func (s *Service) ReconcileSubnet(openStackCluster *infrav1.OpenStackCluster, clusterName string) error {
 	if openStackCluster.Status.Network == nil || openStackCluster.Status.Network.ID == "" {
-		s.scope.Logger().V(4).Info("No need to reconcile network components since no network exists")
+		s.scope.Logger().V(2).Info("No need to reconcile network components since no network exists")
 		return nil
 	}
 
 	subnetName := getSubnetName(clusterName)
-	s.scope.Logger().Info("Reconciling subnet", "name", subnetName)
+	s.scope.Logger().V(2).Info("Reconciling subnet", "name", subnetName)
 
 	subnetList, err := s.client.ListSubnet(subnets.ListOpts{
 		NetworkID: openStackCluster.Status.Network.ID,
@@ -222,7 +222,7 @@ func (s *Service) ReconcileSubnet(openStackCluster *infrav1.OpenStackCluster, cl
 		}
 	} else if len(subnetList) == 1 {
 		subnet = &subnetList[0]
-		s.scope.Logger().V(6).Info("Reusing existing subnet", "name", subnet.Name, "id", subnet.ID)
+		s.scope.Logger().V(2).Info("Reusing existing subnet", "name", subnet.Name, "id", subnet.ID)
 	}
 
 	openStackCluster.Status.Network.Subnets = []infrav1.Subnet{

--- a/pkg/cloud/services/networking/router.go
+++ b/pkg/cloud/services/networking/router.go
@@ -32,15 +32,15 @@ import (
 
 func (s *Service) ReconcileRouter(openStackCluster *infrav1.OpenStackCluster, clusterName string) error {
 	if openStackCluster.Status.Network == nil || openStackCluster.Status.Network.ID == "" {
-		s.scope.Logger().V(3).Info("No need to reconcile router since no network exists.")
+		s.scope.Logger().V(3).Info("No need to reconcile router since no network exists")
 		return nil
 	}
 	if len(openStackCluster.Status.Network.Subnets) == 0 {
-		s.scope.Logger().V(4).Info("No need to reconcile router since no subnet exists.")
+		s.scope.Logger().V(4).Info("No need to reconcile router since no subnet exists")
 		return nil
 	}
 	if openStackCluster.Status.ExternalNetwork == nil || openStackCluster.Status.ExternalNetwork.ID == "" {
-		s.scope.Logger().V(3).Info("No need to create router, due to missing ExternalNetworkID.")
+		s.scope.Logger().V(3).Info("No need to create router, due to missing ExternalNetworkID")
 		return nil
 	}
 
@@ -70,7 +70,7 @@ func (s *Service) ReconcileRouter(openStackCluster *infrav1.OpenStackCluster, cl
 		}
 		router = *createdRouter
 	} else {
-		s.scope.Logger().V(6).Info(fmt.Sprintf("Reuse existing Router %s with id %s", router.Name, router.ID))
+		s.scope.Logger().V(6).Info("Reusing existing router", "name", router.Name, "id", router.ID)
 	}
 
 	routerIPs := []string{}
@@ -222,9 +222,9 @@ func (s *Service) DeleteRouter(openStackCluster *infrav1.OpenStackCluster, clust
 			if !capoerrors.IsNotFound(err) {
 				return fmt.Errorf("unable to remove router interface: %v", err)
 			}
-			s.scope.Logger().V(4).Info("Router Interface already removed, nothing to do", "id", router.ID)
+			s.scope.Logger().V(4).Info("Router interface already removed, nothing to do", "id", router.ID)
 		} else {
-			s.scope.Logger().V(4).Info("Removed RouterInterface of Router", "id", router.ID)
+			s.scope.Logger().V(4).Info("Removed RouterInterface of router", "id", router.ID)
 		}
 	}
 

--- a/pkg/cloud/services/networking/router.go
+++ b/pkg/cloud/services/networking/router.go
@@ -32,19 +32,19 @@ import (
 
 func (s *Service) ReconcileRouter(openStackCluster *infrav1.OpenStackCluster, clusterName string) error {
 	if openStackCluster.Status.Network == nil || openStackCluster.Status.Network.ID == "" {
-		s.scope.Logger().V(3).Info("No need to reconcile router since no network exists")
+		s.scope.Logger().V(2).Info("No need to reconcile router since no network exists")
 		return nil
 	}
 	if len(openStackCluster.Status.Network.Subnets) == 0 {
-		s.scope.Logger().V(4).Info("No need to reconcile router since no subnet exists")
+		s.scope.Logger().V(2).Info("No need to reconcile router since no subnet exists")
 		return nil
 	}
 	if openStackCluster.Status.ExternalNetwork == nil || openStackCluster.Status.ExternalNetwork.ID == "" {
-		s.scope.Logger().V(3).Info("No need to create router, due to missing ExternalNetworkID")
+		s.scope.Logger().V(2).Info("No need to create router, due to missing ExternalNetworkID")
 		return nil
 	}
 
-	s.scope.Logger().Info("Reconciling router", "cluster", clusterName)
+	s.scope.Logger().V(2).Info("Reconciling router", "cluster", clusterName)
 	routerName := getRouterName(clusterName)
 	routerListOpts := routers.ListOpts{Name: routerName}
 	existingRouter := false
@@ -70,7 +70,7 @@ func (s *Service) ReconcileRouter(openStackCluster *infrav1.OpenStackCluster, cl
 		}
 		router = *createdRouter
 	} else {
-		s.scope.Logger().V(6).Info("Reusing existing router", "name", router.Name, "id", router.ID)
+		s.scope.Logger().V(2).Info("Reusing existing router", "name", router.Name, "id", router.ID)
 	}
 
 	routerIPs := []string{}
@@ -111,14 +111,14 @@ func (s *Service) ReconcileRouter(openStackCluster *infrav1.OpenStackCluster, cl
 
 		// ... and create a router interface for our subnet.
 		if createInterface {
-			s.scope.Logger().V(4).Info("Creating RouterInterface", "routerID", router.ID, "subnetID", subnet.ID)
+			s.scope.Logger().V(2).Info("Creating RouterInterface", "routerID", router.ID, "subnetID", subnet.ID)
 			routerInterface, err := s.client.AddRouterInterface(router.ID, routers.AddInterfaceOpts{
 				SubnetID: subnet.ID,
 			})
 			if err != nil {
 				return fmt.Errorf("unable to create router interface: %v", err)
 			}
-			s.scope.Logger().V(4).Info("Created RouterInterface", "id", routerInterface.ID)
+			s.scope.Logger().V(2).Info("Created RouterInterface", "id", routerInterface.ID)
 		}
 	}
 	return nil
@@ -222,14 +222,14 @@ func (s *Service) DeleteRouter(openStackCluster *infrav1.OpenStackCluster, clust
 			if !capoerrors.IsNotFound(err) {
 				return fmt.Errorf("unable to remove router interface: %v", err)
 			}
-			s.scope.Logger().V(4).Info("Router interface already removed, nothing to do", "id", router.ID)
+			s.scope.Logger().V(2).Info("Router interface already removed, nothing to do", "id", router.ID)
 		} else {
-			s.scope.Logger().V(4).Info("Removed RouterInterface of router", "id", router.ID)
+			s.scope.Logger().V(2).Info("Removed RouterInterface of router", "id", router.ID)
 		}
 	}
 
 	if existingRouter {
-		s.scope.Logger().V(4).Info("No need to delete pre-existing router", "name", router.Name)
+		s.scope.Logger().V(2).Info("No need to delete pre-existing router", "name", router.Name)
 		return nil
 	}
 


### PR DESCRIPTION


**What this PR does / why we need it**:

**Which issue(s) this PR fixes** 

updated the log verbosity levels to adhere to the guidelines here: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md#what-method-to-use

**Special notes for your reviewer**:

It seems like most of the levels in these files were set to 6 but the guidelines say to not go above 5 so I thought of just bumping everything down to 5 but it looked like most of the logs in these files are more fit in the "Useful steady state information" category provided in the documentation linked above, so I changed everything to the default verbosity level --2. 

/hold
