### PR TITLE
✨ Add support to IPv6 in Machine's status

### DIFF
--- a/pkg/cloud/services/compute/instance_types_test.go
+++ b/pkg/cloud/services/compute/instance_types_test.go
@@ -107,7 +107,7 @@ func TestNetworkStatus_Addresses(t *testing.T) {
 			},
 		},
 		{
-			name: "Ignore IPv6",
+			name: "Multiple Fixed IP and Floating IP",
 			addresses: map[string][]networkAddress{
 				"primary": {
 					{
@@ -132,6 +132,14 @@ func TestNetworkStatus_Addresses(t *testing.T) {
 				{
 					Type:    corev1.NodeInternalIP,
 					Address: "192.168.0.1",
+				},
+				{
+					Type:    corev1.NodeInternalIP,
+					Address: "fe80::f816:3eff:fe56:3174",
+				},
+				{
+					Type:    corev1.NodeExternalIP,
+					Address: "fe80::f816:3eff:fe56:3175",
 				},
 			},
 		},
@@ -248,7 +256,7 @@ func TestInstanceNetworkStatus(t *testing.T) {
 			wantFloatingIP: "10.0.0.1",
 		},
 		{
-			name: "Ignore IPv6",
+			name: "Multiple Fixed IP and Floating IP",
 			addresses: map[string][]networkAddress{
 				"primary": {
 					{


### PR DESCRIPTION
Dual-stack clusters require that the Machine's status contains the
IPv6 address. This commit removed the check that would skip the addition
of IPv6 to the Machines. Also, it ensures the IPv4 addresses of each
Network remains being the first ones listed in the Machines given there are
operations that rely on the first address of each network.