### PR TITLE
🌱 Update verbosity levels in instance.go

### DIFF
--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -73,7 +73,7 @@ func (s *Service) normalizePortTarget(port *infrav1.PortOpts, openStackCluster *
 	// No network, but fixed IPs are defined(we handled the no fixed
 	// IPs case above): try to infer network from a subnet
 	if noNetwork {
-		s.scope.Logger().V(4).Info("No network defined for port %d, attempting to infer from subnet", portIdx)
+		s.scope.Logger().V(4).Info("No network defined for port, attempting to infer from subnet", "port", portIdx)
 
 		// Look for a unique subnet defined in FixedIPs.  If we find one
 		// we can use it to infer the network ID. We don't need to worry
@@ -95,7 +95,7 @@ func (s *Service) normalizePortTarget(port *infrav1.PortOpts, openStackCluster *
 				if err != nil {
 					// Multiple matches might be ok later when we restrict matches to a single network
 					if errors.Is(err, networking.ErrMultipleMatches) {
-						s.scope.Logger().V(4).Info("Can't infer network from subnet %d: %s", i, err)
+						s.scope.Logger().V(4).Info("Couldn't infer network from subnet", "subnetIndex", i, "err", err)
 						continue
 					}
 
@@ -433,7 +433,7 @@ func (s *Service) getOrCreateRootVolume(eventObject runtime.Object, instanceSpec
 			return nil, fmt.Errorf("exected to find volume %s with size %d; found size %d", name, size, volume.Size)
 		}
 
-		s.scope.Logger().Info("using existing root volume %s", name)
+		s.scope.Logger().V(3).Info("Using existing root volume", "name", name)
 		return volume, nil
 	}
 
@@ -580,7 +580,7 @@ func (s *Service) DeleteInstance(eventObject runtime.Object, instanceStatus *Ins
 				return nil
 			}
 
-			s.scope.Logger().Info("deleting dangling root volume %s(%s)", volume.Name, volume.ID)
+			s.scope.Logger().V(2).Info("Deleting dangling root volume", "name", volume.Name, "ID", volume.ID)
 			return s.getVolumeClient().DeleteVolume(volume.ID, volumes.DeleteOpts{})
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Checked and updated verbosity levels in cluster-api-provider-openstack/pkg/cloud/services/compute/instance.go to adhere to the guideline https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md

**Which issue(s) this PR fixes** :
Fixes #<1> add `V(2)` to`s.scope.Logger().Info("using existing root volume %s", name)` 
This message should be important to system administrators or operators as it indicates a specific action taken by the system. However, it may not be critical for every developer or user to see this message, hence the choice of verbosity level 2.

Fixes #<2> add `V(4)` to `s.scope.Logger().Info("deleting dangling root volume %s(%s)", volume.Name, volume.ID)`
Since deleting such resources can impact system stability, administrators closely watching the system receive this detailed level 4 message.

/hold
