### PR TITLE
:seedling: Adding logging verbosity levels for pkg/cloud/services/loadbalancer/loadbalancer.go

### DIFF
--- a/pkg/cloud/services/loadbalancer/loadbalancer.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer.go
@@ -48,7 +48,7 @@ const loadBalancerProvisioningStatusActive = "ACTIVE"
 
 func (s *Service) ReconcileLoadBalancer(openStackCluster *infrav1.OpenStackCluster, clusterName string, apiServerPort int) (bool, error) {
 	loadBalancerName := getLoadBalancerName(clusterName)
-	s.scope.Logger().Info("Reconciling load balancer", "name", loadBalancerName)
+	s.scope.Logger().V(3).Info("Reconciling load balancer", "name", loadBalancerName)
 
 	var fixedIPAddress string
 	switch {
@@ -169,7 +169,7 @@ func (s *Service) getOrCreateLoadBalancer(openStackCluster *infrav1.OpenStackClu
 		return lb, nil
 	}
 
-	s.scope.Logger().Info(fmt.Sprintf("Creating load balancer in subnet: %q", subnetID), "name", loadBalancerName)
+	s.scope.Logger().V(2).Info("Creating load balancer in subnet", "subnetID", subnetID, "name", loadBalancerName)
 
 	lbCreateOpts := loadbalancers.CreateOpts{
 		Name:        loadBalancerName,
@@ -199,7 +199,7 @@ func (s *Service) getOrCreateListener(openStackCluster *infrav1.OpenStackCluster
 		return listener, nil
 	}
 
-	s.scope.Logger().Info("Creating load balancer listener", "name", listenerName, "lb-id", lbID)
+	s.scope.Logger().V(2).Info("Creating load balancer listener", "name", listenerName, "loadBalancerID", lbID)
 
 	listenerCreateOpts := listeners.CreateOpts{
 		Name:           listenerName,
@@ -267,7 +267,7 @@ func (s *Service) getOrUpdateAllowedCIDRS(openStackCluster *infrav1.OpenStackClu
 	listener.AllowedCIDRs = capostrings.Unique(listener.AllowedCIDRs)
 
 	if !reflect.DeepEqual(allowedCIDRs, listener.AllowedCIDRs) {
-		s.scope.Logger().Info("CIDRs do not match, start to update listener", "expected CIDRs", allowedCIDRs, "load balancer existing CIDR", listener.AllowedCIDRs)
+		s.scope.Logger().V(3).Info("CIDRs do not match, updating listener", "expectedCIDRs", allowedCIDRs, "currentCIDRs", listener.AllowedCIDRs)
 		listenerUpdateOpts := listeners.UpdateOpts{
 			AllowedCIDRs: &allowedCIDRs,
 		}
@@ -316,7 +316,7 @@ func (s *Service) getOrCreatePool(openStackCluster *infrav1.OpenStackCluster, po
 		return pool, nil
 	}
 
-	s.scope.Logger().Info(fmt.Sprintf("Creating load balancer pool for listener %q", listenerID), "name", poolName, "lb-id", lbID)
+	s.scope.Logger().V(2).Info("Creating load balancer pool for listener", "loadBalancerID", lbID, "listenerID", listenerID, "name", poolName)
 
 	method := pools.LBMethodRoundRobin
 
@@ -356,7 +356,7 @@ func (s *Service) getOrCreateMonitor(openStackCluster *infrav1.OpenStackCluster,
 		return nil
 	}
 
-	s.scope.Logger().Info(fmt.Sprintf("Creating load balancer monitor for pool %q", poolID), "name", monitorName, "lb-id", lbID)
+	s.scope.Logger().V(2).Info("Creating load balancer monitor for pool", "loadBalancerID", lbID, "name", monitorName, "poolID", poolID)
 
 	monitorCreateOpts := monitors.CreateOpts{
 		Name:           monitorName,
@@ -400,7 +400,7 @@ func (s *Service) ReconcileLoadBalancerMember(openStackCluster *infrav1.OpenStac
 	}
 
 	loadBalancerName := getLoadBalancerName(clusterName)
-	s.scope.Logger().Info("Reconciling load balancer member", "name", loadBalancerName)
+	s.scope.Logger().V(3).Info("Reconciling load balancer member", "loadBalancerName", loadBalancerName)
 
 	lbID := openStackCluster.Status.APIServerLoadBalancer.ID
 	portList := []int{int(openStackCluster.Spec.ControlPlaneEndpoint.Port)}
@@ -429,7 +429,7 @@ func (s *Service) ReconcileLoadBalancerMember(openStackCluster *infrav1.OpenStac
 				continue
 			}
 
-			s.scope.Logger().Info("Deleting load balancer member (because the IP of the machine changed)", "name", name)
+			s.scope.Logger().V(2).Info("Deleting load balancer member because the IP of the machine changed", "name", name)
 
 			// lb member changed so let's delete it so we can create it again with the correct IP
 			err = s.waitForLoadBalancerActive(lbID)
@@ -445,7 +445,7 @@ func (s *Service) ReconcileLoadBalancerMember(openStackCluster *infrav1.OpenStac
 			}
 		}
 
-		s.scope.Logger().Info("Creating load balancer member", "name", name)
+		s.scope.Logger().V(2).Info("Creating load balancer member", "name", name)
 
 		// if we got to this point we should either create or re-create the lb member
 		lbMemberOpts := pools.CreateMemberOpts{
@@ -500,7 +500,7 @@ func (s *Service) DeleteLoadBalancer(openStackCluster *infrav1.OpenStackCluster,
 	deleteOpts := loadbalancers.DeleteOpts{
 		Cascade: true,
 	}
-	s.scope.Logger().Info("Deleting load balancer", "name", loadBalancerName, "cascade", deleteOpts.Cascade)
+	s.scope.Logger().V(2).Info("Deleting load balancer", "name", loadBalancerName, "cascade", deleteOpts.Cascade)
 	err = s.loadbalancerClient.DeleteLoadBalancer(lb.ID, deleteOpts)
 	if err != nil && !capoerrors.IsNotFound(err) {
 		record.Warnf(openStackCluster, "FailedDeleteLoadBalancer", "Failed to delete load balancer %s with id %s: %v", lb.Name, lb.ID, err)
@@ -539,7 +539,7 @@ func (s *Service) DeleteLoadBalancerMember(openStackCluster *infrav1.OpenStackCl
 			return err
 		}
 		if pool == nil {
-			s.scope.Logger().Info("Load balancer pool does not exist", "name", lbPortObjectsName)
+			s.scope.Logger().V(4).Info("Load balancer pool does not exist", "name", lbPortObjectsName)
 			continue
 		}
 
@@ -634,7 +634,7 @@ var backoff = wait.Backoff{
 
 // Possible LoadBalancer states are documented here: https://docs.openstack.org/api-ref/load-balancer/v2/index.html#prov-status
 func (s *Service) waitForLoadBalancerActive(id string) error {
-	s.scope.Logger().Info("Waiting for load balancer", "id", id, "targetStatus", "ACTIVE")
+	s.scope.Logger().V(3).Info("Waiting for load balancer", "id", id, "targetStatus", "ACTIVE")
 	return wait.ExponentialBackoff(backoff, func() (bool, error) {
 		lb, err := s.loadbalancerClient.GetLoadBalancer(id)
 		if err != nil {
@@ -645,7 +645,7 @@ func (s *Service) waitForLoadBalancerActive(id string) error {
 }
 
 func (s *Service) waitForListener(id, target string) error {
-	s.scope.Logger().Info("Waiting for load balancer listener", "id", id, "targetStatus", target)
+	s.scope.Logger().V(3).Info("Waiting for load balancer listener", "id", id, "targetStatus", target)
 	return wait.ExponentialBackoff(backoff, func() (bool, error) {
 		_, err := s.loadbalancerClient.GetListener(id)
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is part of the process to improve logging in CAPO (issue #1314). It adds the proper verbosity levels to log messages in loadbalancer.go, as described in these [guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/compare/main...anastaruno:cluster-api-provider-openstack:log_levels).

**Special notes for your reviewer**:
In this file, I used mainly verbosity levels 2, and 3. According to the guidelines, 
- level 2: Useful steady state information about the service and important log messages that may correlate to significant changes in the system
- level 3:  Extended information about changes 

Thus, I used level 2 for the creation/deletion of important objects (load balancer, listener, pool, monitor). 
I used level 3 for 'reconciling' and 'waiting for' messages. I think those are slightly less important for understanding the process flow or debugging, but they do signify changes and deserve the attention of the developers.

/hold
