### PR TITLE
📖 Fix APIVersion to use existing router with OpenStackCluster

### DIFF
--- a/docs/book/src/clusteropenstack/configuration.md
+++ b/docs/book/src/clusteropenstack/configuration.md
@@ -176,7 +176,7 @@ Note: If your openstack cluster does not already have a public network, you shou
 You can use a pre-existing router instead of creating a new one. When deleting a cluster a pre-existing router will not be deleted.
 
  ```yaml
- apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
+ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
  kind: OpenStackCluster
  metadata:
    name: <cluster-name>


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fix the documentation about "Use an existing Router". the book  say that the apiversion v1alpha6 support an existing router but that's not true : 

```bash
k explain --api-version=infrastructure.cluster.x-k8s.io/v1alpha6 openstackcluster.spec.router
GROUP:      infrastructure.cluster.x-k8s.io
KIND:       OpenStackCluster
VERSION:    v1alpha6

error: field "router" does not exist
```

The spec.router exists since the apiversion v1alpha7 : [Router in OpenStackCluster struct](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/main/api/v1alpha7/openstackcluster_types.go#L45l)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

This PR only change the book.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
