### PR TITLE
✨ Add `--version` flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -70,6 +70,7 @@ var (
 	healthAddr                  string
 	lbProvider                  string
 	caCertsPath                 string
+	showVersion                 bool
 	logOptions                  = logs.NewOptions()
 )
 
@@ -135,6 +136,8 @@ func InitFlags(fs *pflag.FlagSet) {
 		"The name of the load balancer provider (amphora or ovn) to use (defaults to amphora).")
 
 	fs.StringVar(&caCertsPath, "ca-certs", "", "The path to a PEM-encoded CA Certificate file to supply as default for each request.")
+
+	fs.BoolVar(&showVersion, "version", false, "Show current version and exit.")
 }
 
 func main() {
@@ -142,6 +145,11 @@ func main() {
 	pflag.CommandLine.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
+
+	if showVersion {
+		fmt.Println(version.Get().String()) //nolint:forbidigo
+		os.Exit(0)
+	}
 
 	if err := logsv1.ValidateAndApply(logOptions, nil); err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a `--version` flag that, when used, will dump the version set on the binary. This provides a quick and easy way to check the version of the binary from the command line.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

N/A

**Special notes for your reviewer**:

N/A

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
