### PR TITLE
🌱Remove APIServerLoadBalancer.Provider Up Conversion

### DIFF
--- a/api/v1alpha6/conversion.go
+++ b/api/v1alpha6/conversion.go
@@ -121,8 +121,6 @@ func restorev1alpha7MachineSpec(previous *infrav1.OpenStackMachineSpec, dst *inf
 }
 
 func restorev1alpha7ClusterSpec(previous *infrav1.OpenStackClusterSpec, dst *infrav1.OpenStackClusterSpec) {
-	// APIServerLoadBalancer.Provider is new in v1alpha7
-	dst.APIServerLoadBalancer.Provider = previous.APIServerLoadBalancer.Provider
 	dst.Router = previous.Router
 	// PropagateUplinkStatus has been added in v1alpha7.
 	// We restore the whole Ports since they are anyway immutable.


### PR DESCRIPTION
**What this PR does / why we need it**:

APIServerLoadBalancer.Provider patch is backported to v1alpha6 in PR
#1529. We don't need up conversion for it anymore.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
