### PR TITLE
🐛  Fix application credential support in env.rc

### DIFF
--- a/templates/env.rc
+++ b/templates/env.rc
@@ -106,9 +106,17 @@ export OPENSTACK_CLOUD="${CAPO_CLOUD}"
 
 # Build OPENSTACK_CLOUD_YAML_B64
 if [[ ${CAPO_YQ_VERSION} == *"version 1"* || ${CAPO_YQ_VERSION} == *"version 2"* || ${CAPO_YQ_VERSION} == *"version 3"* ]]; then
-    CAPO_OPENSTACK_CLOUD_YAML_SELECTED_CLOUD_B64=$(echo "${CAPO_OPENSTACK_CLOUD_YAML_CONTENT}" | yq r - clouds.${CAPO_CLOUD} | yq w - auth.password ${CAPO_PASSWORD} | yq p - clouds.${CAPO_CLOUD} | b64encode)
+    if [[ "$CAPO_PASSWORD" = "" || "$CAPO_PASSWORD" = "null" ]]; then
+        CAPO_OPENSTACK_CLOUD_YAML_SELECTED_CLOUD_B64=$(echo "${CAPO_OPENSTACK_CLOUD_YAML_CONTENT}" | yq r - clouds.${CAPO_CLOUD} | yq p - clouds.${CAPO_CLOUD} | b64encode)
+    else
+        CAPO_OPENSTACK_CLOUD_YAML_SELECTED_CLOUD_B64=$(echo "${CAPO_OPENSTACK_CLOUD_YAML_CONTENT}" | yq r - clouds.${CAPO_CLOUD} | yq w - auth.password ${CAPO_PASSWORD} | yq p - clouds.${CAPO_CLOUD} | b64encode)
+    fi
 else
-    CAPO_OPENSTACK_CLOUD_YAML_SELECTED_CLOUD_B64=$(echo "${CAPO_OPENSTACK_CLOUD_YAML_CONTENT}" | yq e .clouds.${CAPO_CLOUD} - | PASSWORD=${CAPO_PASSWORD} yq e '.auth.password = env(PASSWORD)' - | yq e '{"clouds": {"'${CAPO_CLOUD}'": . }}' - | b64encode)
+    if [[ "$CAPO_PASSWORD" = "" || "$CAPO_PASSWORD" = "null" ]]; then
+        CAPO_OPENSTACK_CLOUD_YAML_SELECTED_CLOUD_B64=$(echo "${CAPO_OPENSTACK_CLOUD_YAML_CONTENT}" | yq e .clouds.${CAPO_CLOUD} - | yq e '{"clouds": {"'${CAPO_CLOUD}'": . }}' - | b64encode)
+    else
+        CAPO_OPENSTACK_CLOUD_YAML_SELECTED_CLOUD_B64=$(echo "${CAPO_OPENSTACK_CLOUD_YAML_CONTENT}" | yq e .clouds.${CAPO_CLOUD} - | PASSWORD=${CAPO_PASSWORD} yq e '.auth.password = env(PASSWORD)' - | yq e '{"clouds": {"'${CAPO_CLOUD}'": . }}' - | b64encode)
+    fi
 fi
 export OPENSTACK_CLOUD_YAML_B64="${CAPO_OPENSTACK_CLOUD_YAML_SELECTED_CLOUD_B64}"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This allows users to utilise authentication via application credentials again rather than expecting them to use passwords.

Specifically, users that use a cloud.conf with application credentials would run into an error such as:

```
$ source ./templates/env.rc ~/.config/openstack/clouds.yaml example
Error: Value for env variable 'PASSWORD' not provided in env()
```

with the resulting `CAPO_OPENSTACK_CLOUD_YAML_SELECTED_CLOUD_B64` environment variable containing content similar to:

```
clouds:
  example:
```

This commit only includes the password if it does indeed have a value, to ensure that the cloud config file can be rendered correctly.

The erroneous behaviour was introduced in https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1381

/hold
