### PR TITLE
🌱 Bump golangci-lint to 1.54.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,7 @@ linters:
   - bidichk
   - bodyclose
   - cyclop
-  - depguard
+#  - depguard
   - dogsled
   - dupword
   - durationcheck

--- a/api/v1alpha6/conversion.go
+++ b/api/v1alpha6/conversion.go
@@ -341,7 +341,9 @@ func Convert_v1alpha6_OpenStackMachineSpec_To_v1alpha7_OpenStackMachineSpec(in *
 func convertNetworksToPorts(networks []NetworkParam) []infrav1.PortOpts {
 	var ports []infrav1.PortOpts
 
-	for _, network := range networks {
+	for i := range networks {
+		network := networks[i]
+
 		// This will remain null if the network is not specified in NetworkParam
 		var networkFilter *infrav1.NetworkFilter
 
@@ -378,7 +380,8 @@ func convertNetworksToPorts(networks []NetworkParam) []infrav1.PortOpts {
 			ports = append(ports, infrav1.PortOpts{Network: networkFilter})
 		} else {
 			// If the network has explicit subnets then we create a separate port for each subnet.
-			for _, subnet := range network.Subnets {
+			for i := range network.Subnets {
+				subnet := network.Subnets[i]
 				if subnet.UUID != "" {
 					ports = append(ports, infrav1.PortOpts{
 						Network: networkFilter,

--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -258,7 +258,7 @@ func deleteBastion(scope scope.Scope, cluster *clusterv1.Cluster, openStackClust
 	return nil
 }
 
-func reconcileNormal(scope scope.Scope, cluster *clusterv1.Cluster, openStackCluster *infrav1.OpenStackCluster) (ctrl.Result, error) {
+func reconcileNormal(scope scope.Scope, cluster *clusterv1.Cluster, openStackCluster *infrav1.OpenStackCluster) (ctrl.Result, error) { //nolint:unparam
 	scope.Logger().Info("Reconciling Cluster")
 
 	// If the OpenStackCluster doesn't have our finalizer, add it.

--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -218,7 +218,7 @@ func (r *OpenStackMachineReconciler) SetupWithManager(ctx context.Context, mgr c
 		Complete(r)
 }
 
-func (r *OpenStackMachineReconciler) reconcileDelete(scope scope.Scope, cluster *clusterv1.Cluster, openStackCluster *infrav1.OpenStackCluster, machine *clusterv1.Machine, openStackMachine *infrav1.OpenStackMachine) (ctrl.Result, error) {
+func (r *OpenStackMachineReconciler) reconcileDelete(scope scope.Scope, cluster *clusterv1.Cluster, openStackCluster *infrav1.OpenStackCluster, machine *clusterv1.Machine, openStackMachine *infrav1.OpenStackMachine) (ctrl.Result, error) { //nolint:unparam
 	scope.Logger().Info("Reconciling Machine delete")
 
 	clusterName := fmt.Sprintf("%s-%s", cluster.ObjectMeta.Namespace, cluster.Name)

--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -15,7 +15,7 @@
 ROOT_DIR_RELATIVE := ../..
 include $(ROOT_DIR_RELATIVE)/common.mk
 
-GOLANGCI_LINT_VERSION := v1.52.2
+GOLANGCI_LINT_VERSION := v1.54.2
 
 UNAME := $(shell uname -s)
 

--- a/pkg/cloud/services/networking/port_test.go
+++ b/pkg/cloud/services/networking/port_test.go
@@ -509,7 +509,8 @@ func Test_GetOrCreatePort(t *testing.T) {
 	}
 
 	eventObject := &infrav1.OpenStackMachine{}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 			mockClient := mock.NewMockNetworkClient(mockCtrl)

--- a/pkg/cloud/services/networking/router.go
+++ b/pkg/cloud/services/networking/router.go
@@ -165,7 +165,8 @@ func (s *Service) setRouterExternalIPs(openStackCluster *infrav1.OpenStackCluste
 		},
 	}
 
-	for _, externalRouterIP := range openStackCluster.Spec.ExternalRouterIPs {
+	for i := range openStackCluster.Spec.ExternalRouterIPs {
+		externalRouterIP := openStackCluster.Spec.ExternalRouterIPs[i]
 		subnetID := externalRouterIP.Subnet.ID
 		if subnetID == "" {
 			subnet, err := s.GetSubnetByFilter(&externalRouterIP.Subnet)

--- a/test/e2e/shared/defaults.go
+++ b/test/e2e/shared/defaults.go
@@ -38,7 +38,7 @@ const (
 	OpenStackCloudYAMLFile     = "OPENSTACK_CLOUD_YAML_FILE"
 	OpenStackCloud             = "OPENSTACK_CLOUD"
 	OpenStackCloudAdmin        = "OPENSTACK_CLOUD_ADMIN"
-	OpenStackFailureDomain     = "OPENSTACK_FAILURE_DOMAIN"
+	OpenStackFailureDomain     = "OPENSTACK_FAILURE_DOMAIN" //nolint:gosec
 	OpenStackFailureDomainAlt  = "OPENSTACK_FAILURE_DOMAIN_ALT"
 	OpenStackVolumeTypeAlt     = "OPENSTACK_VOLUME_TYPE_ALT"
 	OpenStackImageName         = "OPENSTACK_IMAGE_NAME"

--- a/test/e2e/shared/defaults.go
+++ b/test/e2e/shared/defaults.go
@@ -38,7 +38,7 @@ const (
 	OpenStackCloudYAMLFile     = "OPENSTACK_CLOUD_YAML_FILE"
 	OpenStackCloud             = "OPENSTACK_CLOUD"
 	OpenStackCloudAdmin        = "OPENSTACK_CLOUD_ADMIN"
-	OpenStackFailureDomain     = "OPENSTACK_FAILURE_DOMAIN" //nolint:gosec
+	OpenStackFailureDomain     = "OPENSTACK_FAILURE_DOMAIN" //nolint:gosec // Linter thinks this could be credentials...
 	OpenStackFailureDomainAlt  = "OPENSTACK_FAILURE_DOMAIN_ALT"
 	OpenStackVolumeTypeAlt     = "OPENSTACK_VOLUME_TYPE_ALT"
 	OpenStackImageName         = "OPENSTACK_IMAGE_NAME"


### PR DESCRIPTION
Note that this disables depguard which we had previously explicitly enabled but we don't seem to have a config for. With this upgrade and with no config it complains about all imports. It looks potentially useful to avoid accidental problematic imports like Hashicorp, but we can look into that separately.

/hold
