### PR TITLE
🐛 Only delete all ports when deleting cluster network

### DIFF
--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -155,11 +155,6 @@ func (r *OpenStackClusterReconciler) reconcileDelete(ctx context.Context, scope 
 
 	clusterName := fmt.Sprintf("%s-%s", cluster.Namespace, cluster.Name)
 
-	if err = networkingService.DeletePorts(openStackCluster); err != nil {
-		handleUpdateOSCError(openStackCluster, fmt.Errorf("failed to delete ports: %w", err))
-		return reconcile.Result{}, fmt.Errorf("failed to delete ports: %w", err)
-	}
-
 	if openStackCluster.Spec.APIServerLoadBalancer.Enabled {
 		loadBalancerService, err := loadbalancer.NewService(scope)
 		if err != nil {
@@ -182,6 +177,11 @@ func (r *OpenStackClusterReconciler) reconcileDelete(ctx context.Context, scope 
 		if err = networkingService.DeleteRouter(openStackCluster, clusterName); err != nil {
 			handleUpdateOSCError(openStackCluster, fmt.Errorf("failed to delete router: %w", err))
 			return ctrl.Result{}, fmt.Errorf("failed to delete router: %w", err)
+		}
+
+		if err = networkingService.DeletePorts(openStackCluster); err != nil {
+			handleUpdateOSCError(openStackCluster, fmt.Errorf("failed to delete ports: %w", err))
+			return reconcile.Result{}, fmt.Errorf("failed to delete ports: %w", err)
 		}
 
 		if err = networkingService.DeleteNetwork(openStackCluster, clusterName); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Change https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1260 was added as a stop-gap to clean up after errors in the machine controller which left dangling ports in the cluster network. These dangling ports prevent the deletion of the network. It works by deleting all ports in the cluster network.

This makes sense when the cluster network is about to be deleted, but not when the cluster network is a BYO network with non-CAPO managed resources in it. We should not call this method on a BYO network.

Fixes #1679

/hold
