### PR TITLE
🌱 gitignore: ignore vendor/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,6 @@ docs/book/book/
 
 # Development container files (https://containers.dev/)
 .devcontainer
+
+# CAPO doesn't use vendorings
+vendor/


### PR DESCRIPTION
CAPO doesn't use vendoring, so let's ignore that directory from git.
That will prevent someone from committing it.
