### PR TITLE
🌱 Ignore vendor directories in boilerplate check

### DIFF
--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -158,6 +158,7 @@ def file_extension(filename):
 prune_dirs = [
     '_output',
     '.git',
+    'vendor',
 ]
 
 # Paths to be ignored for boilerplate detection


### PR DESCRIPTION
This allows `make verify-boilerplate` to pass when using vendoring.