### PR TITLE
🌱 ci: Several CI fixes

### DIFF
--- a/hack/ensure-kubectl.sh
+++ b/hack/ensure-kubectl.sh
@@ -40,7 +40,7 @@ verify_kubectl_version() {
   fi
 
   local kubectl_version
-  IFS=" " read -ra kubectl_version <<< "$(kubectl version --client --short)"
+  IFS=" " read -ra kubectl_version <<< "$(kubectl version --client)"
   if [[ "${MINIMUM_KUBECTL_VERSION}" != $(echo -e "${MINIMUM_KUBECTL_VERSION}\n${kubectl_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) ]]; then
     cat <<EOF
 Detected kubectl version: ${kubectl_version[2]}.

--- a/scripts/ci-conformance.sh
+++ b/scripts/ci-conformance.sh
@@ -47,7 +47,8 @@ trap cleanup EXIT
 
 apt-get update -y
 # Install requests module explicitly for HTTP calls.
-apt-get install -y python3-requests
+# libffi required for pip install cffi (yoga dependency)
+apt-get install -y python3-requests libffi-dev
 rm -rf /var/lib/apt/lists/*
 
 # If BOSKOS_HOST is set then acquire a resource of type ${RESOURCE_TYPE} from Boskos.

--- a/scripts/ci-conformance.sh
+++ b/scripts/ci-conformance.sh
@@ -45,13 +45,10 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Ensure that python3-pip is installed.
 apt-get update -y
-apt-get install -y python3-pip
+# Install requests module explicitly for HTTP calls.
+apt-get install -y python3-requests
 rm -rf /var/lib/apt/lists/*
-
-# Install/upgrade pip and requests module explicitly for HTTP calls.
-python3 -m pip install --upgrade pip requests
 
 # If BOSKOS_HOST is set then acquire a resource of type ${RESOURCE_TYPE} from Boskos.
 if [ -n "${BOSKOS_HOST:-}" ]; then

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -48,7 +48,8 @@ trap cleanup EXIT
 
 apt-get update -y
 # Install requests module explicitly for HTTP calls.
-apt-get install -y python3-requests
+# libffi required for pip install cffi (yoga dependency)
+apt-get install -y python3-requests libffi-dev
 rm -rf /var/lib/apt/lists/*
 
 # If BOSKOS_HOST is set then acquire a resource of type ${RESOURCE_TYPE} from Boskos.

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -46,13 +46,10 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Ensure that python3-pip is installed.
 apt-get update -y
-apt-get install -y python3-pip
+# Install requests module explicitly for HTTP calls.
+apt-get install -y python3-requests
 rm -rf /var/lib/apt/lists/*
-
-# Install/upgrade pip and requests module explicitly for HTTP calls.
-python3 -m pip install --upgrade pip requests
 
 # If BOSKOS_HOST is set then acquire a resource of type ${RESOURCE_TYPE} from Boskos.
 if [ -n "${BOSKOS_HOST:-}" ]; then


### PR DESCRIPTION
This PR contains several critical fixes, all of which are required for passing CI.

Firstly, fixes several issues which seem to stem from a bump in the base prow image.

Secondly, reverts the effect of #1716 by putting the devstack image back to Ubuntu 20.04. Devstack for OpenStack Yoga does not support Ubuntu 22.04.

Lastly, fixes a GCE provisioning issue which prevented #1716 from being tested properly. It looks like we could non-deterministically reuse an old disk image depending on which zone we landed in, meaning we were not necessarily testing the change in the PR under test.

Fixes: #1717 

/hold