### PR TITLE
⚠️  Bump Go to 1.20.10

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -130,9 +130,9 @@ linters-settings:
     # https://github.com/golangci/golangci-lint/issues/3228
     allow-unused: true
   staticcheck:
-    go: "1.17"
+    go: "1.20"
   stylecheck:
-    go: "1.17"
+    go: "1.20"
   nestif:
     # minimal complexity of if statements to report, 5 by default
     # TODO(sbuerin) fix remaining findings and set to 5 after:

--- a/Containerfile
+++ b/Containerfile
@@ -24,7 +24,7 @@
 #         media type: "application/vnd.oci.image.layer.v1.tar+gzip"
 
 # Build the manager binary
-FROM golang:1.19.6 as builder
+FROM golang:1.20.10 as builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg goproxy=$(go env GOPROXY) to override the goproxy

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.19.6 as builder
+FROM golang:1.20.10 as builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg goproxy=$(go env GOPROXY) to override the goproxy

--- a/versions.mk
+++ b/versions.mk
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 MDBOOK_VERSION := v0.4.5
-GOLANG_VERSION := 1.19.6
+GOLANG_VERSION := 1.20.10
 PLANTUML_VERSION := 1.2022.6
 GH_VERSION := 1.2.0


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump Golang to 1.20.10, we'll need it for bumping other dependencies like CAPI.
