### PR TITLE
🐛Fix missing endpoint type in OpenStack endpoint clients configuration

### DIFF
--- a/pkg/clients/compute.go
+++ b/pkg/clients/compute.go
@@ -67,7 +67,8 @@ type computeClient struct{ client *gophercloud.ServiceClient }
 // NewComputeClient returns a new compute client.
 func NewComputeClient(providerClient *gophercloud.ProviderClient, providerClientOpts *clientconfig.ClientOpts) (ComputeClient, error) {
 	compute, err := openstack.NewComputeV2(providerClient, gophercloud.EndpointOpts{
-		Region: providerClientOpts.RegionName,
+		Region:       providerClientOpts.RegionName,
+		Availability: clientconfig.GetEndpointType(providerClientOpts.EndpointType),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create compute service client: %v", err)

--- a/pkg/clients/image.go
+++ b/pkg/clients/image.go
@@ -36,7 +36,8 @@ type imageClient struct{ client *gophercloud.ServiceClient }
 // NewImageClient returns a new glance client.
 func NewImageClient(providerClient *gophercloud.ProviderClient, providerClientOpts *clientconfig.ClientOpts) (ImageClient, error) {
 	images, err := openstack.NewImageServiceV2(providerClient, gophercloud.EndpointOpts{
-		Region: providerClientOpts.RegionName,
+		Region:       providerClientOpts.RegionName,
+		Availability: clientconfig.GetEndpointType(providerClientOpts.EndpointType),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create image service client: %v", err)

--- a/pkg/clients/loadbalancer.go
+++ b/pkg/clients/loadbalancer.go
@@ -64,7 +64,8 @@ type lbClient struct {
 // NewLbClient returns a new loadbalancer client.
 func NewLbClient(providerClient *gophercloud.ProviderClient, providerClientOpts *clientconfig.ClientOpts) (LbClient, error) {
 	loadbalancerClient, err := openstack.NewLoadBalancerV2(providerClient, gophercloud.EndpointOpts{
-		Region: providerClientOpts.RegionName,
+		Region:       providerClientOpts.RegionName,
+		Availability: clientconfig.GetEndpointType(providerClientOpts.EndpointType),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create load balancer service client: %v", err)

--- a/pkg/clients/networking.go
+++ b/pkg/clients/networking.go
@@ -96,7 +96,8 @@ type networkClient struct {
 // NewNetworkClient returns an instance of the networking service.
 func NewNetworkClient(providerClient *gophercloud.ProviderClient, providerClientOpts *clientconfig.ClientOpts) (NetworkClient, error) {
 	serviceClient, err := openstack.NewNetworkV2(providerClient, gophercloud.EndpointOpts{
-		Region: providerClientOpts.RegionName,
+		Region:       providerClientOpts.RegionName,
+		Availability: clientconfig.GetEndpointType(providerClientOpts.EndpointType),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create networking service providerClient: %v", err)

--- a/pkg/clients/volume.go
+++ b/pkg/clients/volume.go
@@ -39,7 +39,8 @@ type volumeClient struct{ client *gophercloud.ServiceClient }
 // NewVolumeClient returns a new cinder client.
 func NewVolumeClient(providerClient *gophercloud.ProviderClient, providerClientOpts *clientconfig.ClientOpts) (VolumeClient, error) {
 	volume, err := openstack.NewBlockStorageV3(providerClient, gophercloud.EndpointOpts{
-		Region: providerClientOpts.RegionName,
+		Region:       providerClientOpts.RegionName,
+		Availability: clientconfig.GetEndpointType(providerClientOpts.EndpointType),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create volume service client: %v", err)

--- a/pkg/scope/provider.go
+++ b/pkg/scope/provider.go
@@ -198,6 +198,7 @@ func NewProviderClient(cloud clientconfig.Cloud, caCert []byte, logger logr.Logg
 		clientOpts.AuthInfo = cloud.AuthInfo
 		clientOpts.AuthType = cloud.AuthType
 		clientOpts.RegionName = cloud.RegionName
+		clientOpts.EndpointType = cloud.EndpointType
 	}
 
 	opts, err := clientconfig.AuthOptions(clientOpts)


### PR DESCRIPTION
**What this PR does / why we need it**:

Cloud configuration allows to set endpoint type option, however it leaves are out luck to be used in service configuration, this PR is going to fix this behaviour and pass endpoint type to all the clients.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fix: #1747

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

Yes

About tests: I would probably like to add them, but there's no clean way for that because client constructors are impacted and there's no DI in use in that place.

**TODOs**:

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
