### PR TITLE
🐛 Fix random instance port deletion

### DIFF
--- a/api/v1alpha5/types.go
+++ b/api/v1alpha5/types.go
@@ -273,8 +273,8 @@ func (r SecurityGroupRule) Equal(x SecurityGroupRule) bool {
 type InstanceState string
 
 var (
-	// InstanceStateBuilding is the string representing an instance in a building state.
-	InstanceStateBuilding = InstanceState("BUILDING")
+	// InstanceStateBuild is the string representing an instance in a build state.
+	InstanceStateBuild = InstanceState("BUILD")
 
 	// InstanceStateActive is the string representing an instance in an active state.
 	InstanceStateActive = InstanceState("ACTIVE")
@@ -290,6 +290,9 @@ var (
 
 	// InstanceStateDeleted is the string representing an instance in a deleted state.
 	InstanceStateDeleted = InstanceState("DELETED")
+
+	// InstanceStateUndefined is the string representing an undefined instance state.
+	InstanceStateUndefined = InstanceState("")
 )
 
 // Bastion represents basic information about the bastion node.

--- a/api/v1alpha6/types.go
+++ b/api/v1alpha6/types.go
@@ -285,8 +285,8 @@ func (r SecurityGroupRule) Equal(x SecurityGroupRule) bool {
 type InstanceState string
 
 var (
-	// InstanceStateBuilding is the string representing an instance in a building state.
-	InstanceStateBuilding = InstanceState("BUILDING")
+	// InstanceStateBuild is the string representing an instance in a build state.
+	InstanceStateBuild = InstanceState("BUILD")
 
 	// InstanceStateActive is the string representing an instance in an active state.
 	InstanceStateActive = InstanceState("ACTIVE")
@@ -302,6 +302,9 @@ var (
 
 	// InstanceStateDeleted is the string representing an instance in a deleted state.
 	InstanceStateDeleted = InstanceState("DELETED")
+
+	// InstanceStateUndefined is the string representing an undefined instance state.
+	InstanceStateUndefined = InstanceState("")
 )
 
 // Bastion represents basic information about the bastion node.

--- a/api/v1alpha7/types.go
+++ b/api/v1alpha7/types.go
@@ -315,8 +315,8 @@ func (r SecurityGroupRule) Equal(x SecurityGroupRule) bool {
 type InstanceState string
 
 var (
-	// InstanceStateBuilding is the string representing an instance in a building state.
-	InstanceStateBuilding = InstanceState("BUILDING")
+	// InstanceStateBuild is the string representing an instance in a build state.
+	InstanceStateBuild = InstanceState("BUILD")
 
 	// InstanceStateActive is the string representing an instance in an active state.
 	InstanceStateActive = InstanceState("ACTIVE")
@@ -332,6 +332,9 @@ var (
 
 	// InstanceStateDeleted is the string representing an instance in a deleted state.
 	InstanceStateDeleted = InstanceState("DELETED")
+
+	// InstanceStateUndefined is the string representing an undefined instance state.
+	InstanceStateUndefined = InstanceState("")
 )
 
 // Bastion represents basic information about the bastion node.

--- a/api/v1alpha8/types.go
+++ b/api/v1alpha8/types.go
@@ -321,8 +321,8 @@ func (r SecurityGroupRule) Equal(x SecurityGroupRule) bool {
 type InstanceState string
 
 var (
-	// InstanceStateBuilding is the string representing an instance in a building state.
-	InstanceStateBuilding = InstanceState("BUILDING")
+	// InstanceStateBuild is the string representing an instance in a build state.
+	InstanceStateBuild = InstanceState("BUILD")
 
 	// InstanceStateActive is the string representing an instance in an active state.
 	InstanceStateActive = InstanceState("ACTIVE")
@@ -338,6 +338,9 @@ var (
 
 	// InstanceStateDeleted is the string representing an instance in a deleted state.
 	InstanceStateDeleted = InstanceState("DELETED")
+
+	// InstanceStateUndefined is the string representing an undefined instance state.
+	InstanceStateUndefined = InstanceState("")
 )
 
 // Bastion represents basic information about the bastion node.

--- a/pkg/cloud/services/compute/instance_test.go
+++ b/pkg/cloud/services/compute/instance_test.go
@@ -406,17 +406,6 @@ func TestService_ReconcileInstance(t *testing.T) {
 		})
 	}
 
-	// Expected calls when polling for server creation
-	expectServerPoll := func(computeRecorder *mock.MockComputeClientMockRecorder, states []string) {
-		for _, state := range states {
-			computeRecorder.GetServer(instanceUUID).Return(returnedServer(state), nil)
-		}
-	}
-
-	expectServerPollSuccess := func(computeRecorder *mock.MockComputeClientMockRecorder) {
-		expectServerPoll(computeRecorder, []string{"ACTIVE"})
-	}
-
 	returnedVolume := func(uuid string, status string) *volumes.Volume {
 		return &volumes.Volume{
 			ID:     uuid,
@@ -460,7 +449,6 @@ func TestService_ReconcileInstance(t *testing.T) {
 				expectDefaultImageAndFlavor(r.compute, r.image)
 
 				expectCreateServer(r.compute, getDefaultServerMap(), false)
-				expectServerPollSuccess(r.compute)
 			},
 			wantErr: false,
 		},
@@ -504,32 +492,6 @@ func TestService_ReconcileInstance(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:            "Poll until server is created",
-			getInstanceSpec: getDefaultInstanceSpec,
-			expect: func(r *recorders) {
-				expectUseExistingDefaultPort(r.network)
-				expectDefaultImageAndFlavor(r.compute, r.image)
-
-				expectCreateServer(r.compute, getDefaultServerMap(), false)
-				expectServerPoll(r.compute, []string{"BUILDING", "ACTIVE"})
-			},
-			wantErr: false,
-		},
-		{
-			name:            "Server errors during creation",
-			getInstanceSpec: getDefaultInstanceSpec,
-			expect: func(r *recorders) {
-				expectUseExistingDefaultPort(r.network)
-				expectDefaultImageAndFlavor(r.compute, r.image)
-
-				expectCreateServer(r.compute, getDefaultServerMap(), false)
-				expectServerPoll(r.compute, []string{"BUILDING", "ERROR"})
-
-				// Don't delete ports because the server is created: DeleteInstance will do it
-			},
-			wantErr: true,
-		},
-		{
 			name: "Boot from volume success",
 			getInstanceSpec: func() *InstanceSpec {
 				s := getDefaultInstanceSpec()
@@ -567,7 +529,6 @@ func TestService_ReconcileInstance(t *testing.T) {
 					},
 				}
 				expectCreateServer(r.compute, createMap, false)
-				expectServerPollSuccess(r.compute)
 
 				// Don't delete ports because the server is created: DeleteInstance will do it
 			},
@@ -614,7 +575,6 @@ func TestService_ReconcileInstance(t *testing.T) {
 					},
 				}
 				expectCreateServer(r.compute, createMap, false)
-				expectServerPollSuccess(r.compute)
 
 				// Don't delete ports because the server is created: DeleteInstance will do it
 			},
@@ -734,7 +694,6 @@ func TestService_ReconcileInstance(t *testing.T) {
 					},
 				}
 				expectCreateServer(r.compute, createMap, false)
-				expectServerPollSuccess(r.compute)
 
 				// Don't delete ports because the server is created: DeleteInstance will do it
 			},
@@ -809,7 +768,6 @@ func TestService_ReconcileInstance(t *testing.T) {
 					},
 				}
 				expectCreateServer(r.compute, createMap, false)
-				expectServerPollSuccess(r.compute)
 
 				// Don't delete ports because the server is created: DeleteInstance will do it
 			},
@@ -870,7 +828,6 @@ func TestService_ReconcileInstance(t *testing.T) {
 					},
 				}
 				expectCreateServer(r.compute, createMap, false)
-				expectServerPollSuccess(r.compute)
 
 				// Don't delete ports because the server is created: DeleteInstance will do it
 			},

--- a/pkg/cloud/services/compute/instance_types.go
+++ b/pkg/cloud/services/compute/instance_types.go
@@ -100,25 +100,25 @@ func (is *InstanceStatus) AvailabilityZone() string {
 	return is.server.AvailabilityZone
 }
 
-// BastionStatus returns an infrav1.BastionStatus for use in the cluster status.
-func (is *InstanceStatus) BastionStatus(openStackCluster *infrav1.OpenStackCluster) (*infrav1.BastionStatus, error) {
-	i := infrav1.BastionStatus{
-		ID:         is.ID(),
-		Name:       is.Name(),
-		SSHKeyName: is.SSHKeyName(),
-		State:      is.State(),
+// BastionStatus updates BastionStatus in openStackCluster.
+func (is *InstanceStatus) UpdateBastionStatus(openStackCluster *infrav1.OpenStackCluster) {
+	if openStackCluster.Status.Bastion == nil {
+		openStackCluster.Status.Bastion = &infrav1.BastionStatus{}
 	}
+
+	openStackCluster.Status.Bastion.ID = is.ID()
+	openStackCluster.Status.Bastion.Name = is.Name()
+	openStackCluster.Status.Bastion.SSHKeyName = is.SSHKeyName()
+	openStackCluster.Status.Bastion.State = is.State()
 
 	ns, err := is.NetworkStatus()
 	if err != nil {
-		return nil, err
+		// Bastion IP won't be saved in status, error is not critical
+		return
 	}
 
 	clusterNetwork := openStackCluster.Status.Network.Name
-	i.IP = ns.IP(clusterNetwork)
-	i.FloatingIP = ns.FloatingIP(clusterNetwork)
-
-	return &i, nil
+	openStackCluster.Status.Bastion.IP = ns.IP(clusterNetwork)
 }
 
 // InstanceIdentifier returns an InstanceIdentifier object for an InstanceStatus.


### PR DESCRIPTION
**What this PR does / why we need it**:

Under certain circumstances, when they are non-responsive cells, nova may return a partial result instead of an error.

(this is controlled by list_records_by_skipping_down_cells parameter that is true by default - no error will be thrown)

When it faces this issue, capo controller will try to create a new server for the machine, resulting in deleting ports of existing one.

In order avoid this issue, use GET instead of LIST to retrieve server using its uuid. For that purpose we must ensure that uuid is stored in machine spec as soon as the server is created, even if server is in error state.

Fixes: #1612 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

Yes

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ X] squashed commits
- if necessary:
  - [ ] includes documentation
  - [x] adds unit tests

/hold
