### PR TITLE
🐛  Update e2e testing image of CAPI version from 1.5.0 to 1.5.1 

### DIFF
--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -12,11 +12,11 @@
 managementClusterName: capo-e2e
 
 images:
-- name: gcr.io/k8s-staging-cluster-api/cluster-api-controller:v1.5.0
+- name: gcr.io/k8s-staging-cluster-api/cluster-api-controller:v1.5.1
   loadBehavior: tryLoad
-- name: gcr.io/k8s-staging-cluster-api/kubeadm-bootstrap-controller:v1.5.0
+- name: gcr.io/k8s-staging-cluster-api/kubeadm-bootstrap-controller:v1.5.1
   loadBehavior: tryLoad
-- name: gcr.io/k8s-staging-cluster-api/kubeadm-control-plane-controller:v1.5.0
+- name: gcr.io/k8s-staging-cluster-api/kubeadm-control-plane-controller:v1.5.1
   loadBehavior: tryLoad
 # Use local dev images built source tree;
 - name: gcr.io/k8s-staging-capi-openstack/capi-openstack-controller:e2e
@@ -32,8 +32,8 @@ providers:
 - name: cluster-api
   type: CoreProvider
   versions:
-  - name: v1.5.0
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.0/core-components.yaml"
+  - name: v1.5.1
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.1/core-components.yaml"
     type: url
     contract: v1beta1
     files:
@@ -58,8 +58,8 @@ providers:
 - name: kubeadm
   type: BootstrapProvider
   versions:
-  - name: v1.5.0
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.0/bootstrap-components.yaml"
+  - name: v1.5.1
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.1/bootstrap-components.yaml"
     type: url
     contract: v1beta1
     files:
@@ -84,8 +84,8 @@ providers:
 - name: kubeadm
   type: ControlPlaneProvider
   versions:
-  - name: v1.5.0
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.0/control-plane-components.yaml"
+  - name: v1.5.1
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.1/control-plane-components.yaml"
     type: url
     contract: v1beta1
     files:

--- a/test/e2e/suites/e2e/e2e_suite_test.go
+++ b/test/e2e/suites/e2e/e2e_suite_test.go
@@ -25,6 +25,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"sigs.k8s.io/cluster-api-provider-openstack/test/e2e/shared"
 )
@@ -44,6 +46,7 @@ func init() {
 
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
+	ctrl.SetLogger(klog.Background())
 	RunSpecs(t, "capo-e2e")
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix misconfigured logger

**Which issue(s) this PR fixes**
Fixes #1698

**TODOs**:
- [X] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
