### PR TITLE
✨ WIP - Reconcile Machines & Managed Security Groups

### DIFF
--- a/api/v1alpha5/openstackmachine_types.go
+++ b/api/v1alpha5/openstackmachine_types.go
@@ -110,6 +110,9 @@ type OpenStackMachineStatus struct {
 	// +optional
 	InstanceState *InstanceState `json:"instanceState,omitempty"`
 
+	// SecurityGroups is the list of security groups IDs associated with this machine.
+	SecurityGroups []string `json:"securityGroups,omitempty"`
+
 	FailureReason *errors.MachineStatusError `json:"failureReason,omitempty"`
 
 	// FailureMessage will be set in the event that there is a terminal problem

--- a/api/v1alpha5/zz_generated.conversion.go
+++ b/api/v1alpha5/zz_generated.conversion.go
@@ -1150,6 +1150,7 @@ func autoConvert_v1alpha5_OpenStackMachineStatus_To_v1alpha7_OpenStackMachineSta
 	out.Ready = in.Ready
 	out.Addresses = *(*[]v1.NodeAddress)(unsafe.Pointer(&in.Addresses))
 	out.InstanceState = (*v1alpha7.InstanceState)(unsafe.Pointer(in.InstanceState))
+	out.SecurityGroups = *(*[]string)(unsafe.Pointer(&in.SecurityGroups))
 	out.FailureReason = (*errors.MachineStatusError)(unsafe.Pointer(in.FailureReason))
 	out.FailureMessage = (*string)(unsafe.Pointer(in.FailureMessage))
 	out.Conditions = *(*v1beta1.Conditions)(unsafe.Pointer(&in.Conditions))
@@ -1166,6 +1167,7 @@ func autoConvert_v1alpha7_OpenStackMachineStatus_To_v1alpha5_OpenStackMachineSta
 	out.Addresses = *(*[]v1.NodeAddress)(unsafe.Pointer(&in.Addresses))
 	out.InstanceState = (*InstanceState)(unsafe.Pointer(in.InstanceState))
 	out.FailureReason = (*errors.MachineStatusError)(unsafe.Pointer(in.FailureReason))
+	out.SecurityGroups = *(*[]string)(unsafe.Pointer(&in.SecurityGroups))
 	out.FailureMessage = (*string)(unsafe.Pointer(in.FailureMessage))
 	out.Conditions = *(*v1beta1.Conditions)(unsafe.Pointer(&in.Conditions))
 	return nil

--- a/api/v1alpha5/zz_generated.deepcopy.go
+++ b/api/v1alpha5/zz_generated.deepcopy.go
@@ -682,6 +682,11 @@ func (in *OpenStackMachineStatus) DeepCopyInto(out *OpenStackMachineStatus) {
 		*out = new(InstanceState)
 		**out = **in
 	}
+	if in.SecurityGroups != nil {
+		in, out := &in.SecurityGroups, &out.SecurityGroups
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.FailureReason != nil {
 		in, out := &in.FailureReason, &out.FailureReason
 		*out = new(errors.MachineStatusError)

--- a/api/v1alpha6/openstackmachine_types.go
+++ b/api/v1alpha6/openstackmachine_types.go
@@ -114,6 +114,9 @@ type OpenStackMachineStatus struct {
 
 	FailureReason *errors.MachineStatusError `json:"failureReason,omitempty"`
 
+	// SecurityGroups is the list of security groups IDs associated with this machine.
+	SecurityGroups []string `json:"securityGroups,omitempty"`
+
 	// FailureMessage will be set in the event that there is a terminal problem
 	// reconciling the Machine and will contain a more verbose string suitable
 	// for logging and human consumption.

--- a/api/v1alpha6/zz_generated.conversion.go
+++ b/api/v1alpha6/zz_generated.conversion.go
@@ -1174,6 +1174,7 @@ func autoConvert_v1alpha6_OpenStackMachineStatus_To_v1alpha7_OpenStackMachineSta
 	out.Addresses = *(*[]v1.NodeAddress)(unsafe.Pointer(&in.Addresses))
 	out.InstanceState = (*v1alpha7.InstanceState)(unsafe.Pointer(in.InstanceState))
 	out.FailureReason = (*errors.MachineStatusError)(unsafe.Pointer(in.FailureReason))
+	out.SecurityGroups = *(*[]string)(unsafe.Pointer(&in.SecurityGroups))
 	out.FailureMessage = (*string)(unsafe.Pointer(in.FailureMessage))
 	out.Conditions = *(*v1beta1.Conditions)(unsafe.Pointer(&in.Conditions))
 	return nil
@@ -1189,6 +1190,7 @@ func autoConvert_v1alpha7_OpenStackMachineStatus_To_v1alpha6_OpenStackMachineSta
 	out.Addresses = *(*[]v1.NodeAddress)(unsafe.Pointer(&in.Addresses))
 	out.InstanceState = (*InstanceState)(unsafe.Pointer(in.InstanceState))
 	out.FailureReason = (*errors.MachineStatusError)(unsafe.Pointer(in.FailureReason))
+	out.SecurityGroups = *(*[]string)(unsafe.Pointer(&in.SecurityGroups))
 	out.FailureMessage = (*string)(unsafe.Pointer(in.FailureMessage))
 	out.Conditions = *(*v1beta1.Conditions)(unsafe.Pointer(&in.Conditions))
 	return nil

--- a/api/v1alpha6/zz_generated.deepcopy.go
+++ b/api/v1alpha6/zz_generated.deepcopy.go
@@ -692,6 +692,11 @@ func (in *OpenStackMachineStatus) DeepCopyInto(out *OpenStackMachineStatus) {
 		*out = new(errors.MachineStatusError)
 		**out = **in
 	}
+	if in.SecurityGroups != nil {
+		in, out := &in.SecurityGroups, &out.SecurityGroups
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.FailureMessage != nil {
 		in, out := &in.FailureMessage, &out.FailureMessage
 		*out = new(string)

--- a/api/v1alpha7/openstackmachine_types.go
+++ b/api/v1alpha7/openstackmachine_types.go
@@ -109,6 +109,9 @@ type OpenStackMachineStatus struct {
 
 	FailureReason *errors.MachineStatusError `json:"failureReason,omitempty"`
 
+	// SecurityGroups is the list of security groups IDs associated with this machine.
+	SecurityGroups []string `json:"securityGroups,omitempty"`
+
 	// FailureMessage will be set in the event that there is a terminal problem
 	// reconciling the Machine and will contain a more verbose string suitable
 	// for logging and human consumption.

--- a/api/v1alpha7/zz_generated.deepcopy.go
+++ b/api/v1alpha7/zz_generated.deepcopy.go
@@ -721,6 +721,11 @@ func (in *OpenStackMachineStatus) DeepCopyInto(out *OpenStackMachineStatus) {
 		*out = new(errors.MachineStatusError)
 		**out = **in
 	}
+	if in.SecurityGroups != nil {
+		in, out := &in.SecurityGroups, &out.SecurityGroups
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.FailureMessage != nil {
 		in, out := &in.FailureMessage, &out.FailureMessage
 		*out = new(string)

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
@@ -546,6 +546,12 @@ spec:
               ready:
                 description: Ready is true when the provider resource is ready.
                 type: boolean
+              securityGroups:
+                description: SecurityGroups is the list of security groups IDs associated
+                  with this machine.
+                items:
+                  type: string
+                type: array
             type: object
         type: object
     served: true
@@ -1108,6 +1114,12 @@ spec:
               ready:
                 description: Ready is true when the provider resource is ready.
                 type: boolean
+              securityGroups:
+                description: SecurityGroups is the list of security groups IDs associated
+                  with this machine.
+                items:
+                  type: string
+                type: array
             type: object
         type: object
     served: true
@@ -1601,6 +1613,12 @@ spec:
               ready:
                 description: Ready is true when the provider resource is ready.
                 type: boolean
+              securityGroups:
+                description: SecurityGroups is the list of security groups IDs associated
+                  with this machine.
+                items:
+                  type: string
+                type: array
             type: object
         type: object
     served: true

--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -497,18 +497,6 @@ func machineToInstanceSpec(openStackCluster *infrav1.OpenStackCluster, machine *
 	instanceSpec.Tags = machineTags
 
 	instanceSpec.SecurityGroups = openStackMachine.Spec.SecurityGroups
-	if openStackCluster.Spec.ManagedSecurityGroups {
-		var managedSecurityGroup string
-		if util.IsControlPlaneMachine(machine) && openStackCluster.Status.ControlPlaneSecurityGroup != nil {
-			managedSecurityGroup = openStackCluster.Status.ControlPlaneSecurityGroup.ID
-		} else if openStackCluster.Status.WorkerSecurityGroup != nil {
-			managedSecurityGroup = openStackCluster.Status.WorkerSecurityGroup.ID
-		}
-
-		instanceSpec.SecurityGroups = append(instanceSpec.SecurityGroups, infrav1.SecurityGroupFilter{
-			ID: managedSecurityGroup,
-		})
-	}
 
 	instanceSpec.Ports = openStackMachine.Spec.Ports
 

--- a/pkg/cloud/services/networking/port.go
+++ b/pkg/cloud/services/networking/port.go
@@ -53,6 +53,13 @@ func (s *Service) GetPortFromInstanceIP(instanceID string, ip string) ([]ports.P
 	}
 	return s.client.ListPort(portOpts)
 }
+func (s *Service) GetPort(id string) (*ports.Port, error) {
+	return s.client.GetPort(id)
+}
+
+func (s *Service) UpdatePort(id string, opts ports.UpdateOpts) (*ports.Port, error) {
+	return s.client.UpdatePort(id, opts)
+}
 
 func (s *Service) GetOrCreatePort(eventObject runtime.Object, clusterName string, portName string, portOpts *infrav1.PortOpts, instanceSecurityGroups []string, instanceTags []string) (*ports.Port, error) {
 	networkID := portOpts.Network.ID
@@ -189,6 +196,19 @@ func (s *Service) GetOrCreatePort(eventObject runtime.Object, clusterName string
 	}
 
 	return port, nil
+}
+
+func (s *Service) UpdatePortSecurityGroups(eventObject runtime.Object, portID string, securityGroupIDs []string) error {
+	_, err := s.client.UpdatePort(portID, ports.UpdateOpts{
+		SecurityGroups: &securityGroupIDs,
+	})
+	if err != nil {
+		record.Warnf(eventObject, "FailedUpdatePortSecurityGroups", "Failed to update port %s: %v", portID, err)
+		return err
+	}
+
+	record.Eventf(eventObject, "SuccessfulUpdatePortSecurityGroups", "Updated port %s", portID)
+	return nil
 }
 
 func (s *Service) getSubnetIDForFixedIP(subnet *infrav1.SubnetFilter, networkID string) (string, error) {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Before this patch, if Managed Security Groups would be enabled,
CAPO would create them and the OpenStack Machines would get these
security groups at instance creation time.

Now, we are updating the ports of the machines to ensure they match the
desired security groups that we want assigned.

For now we only have Control Plane & Worker Security groups but in the
future we'll have Bastion, CNI and also an interface to add more
Security Groups.

We'll need to reconcile the machines to ensure they have the security
group assigned.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
