### PR TITLE
🌱  Make it possible to use a pre-created volume type in e2e tests 

### DIFF
--- a/hack/ci/cloud-init/controller.yaml.tpl
+++ b/hack/ci/cloud-init/controller.yaml.tpl
@@ -150,6 +150,14 @@
         openstack aggregate add host "$aggregateid" "$host"
     done
 
+    # Create the volume type
+    VOLUME_TYPE_NAME="test-volume-type"
+    if openstack volume type create --description "Test volume type" --public "${VOLUME_TYPE_NAME}" &> /dev/null; then
+        echo "Volume type '${VOLUME_TYPE_NAME}' created successfully."
+    else
+        echo "Error: Failed to create volume type '${VOLUME_TYPE_NAME}'."
+    fi
+
     # the flavors are created in a way that we can execute at least 2 e2e tests in parallel (overall we have 32 vCPUs)
     openstack flavor delete m1.tiny
     openstack flavor create --ram 512 --disk 1 --ephemeral 1 --vcpus 1 --public --id 1 m1.tiny --property hw_rng:allowed='True'

--- a/test/e2e/suites/e2e/e2e_suite_test.go
+++ b/test/e2e/suites/e2e/e2e_suite_test.go
@@ -52,7 +52,6 @@ func TestE2E(t *testing.T) {
 
 var _ = SynchronizedBeforeSuite(func() []byte {
 	data := shared.Node1BeforeSuite(e2eCtx)
-	createTestVolumeType(e2eCtx)
 	return data
 }, func(data []byte) {
 	shared.AllNodesBeforeSuite(e2eCtx, data)

--- a/test/e2e/suites/e2e/e2e_test.go
+++ b/test/e2e/suites/e2e/e2e_test.go
@@ -28,10 +28,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gophercloud/gophercloud"
-	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
-	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumetypes"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
@@ -57,7 +54,6 @@ import (
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha8"
-	capoerrors "sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/errors"
 	"sigs.k8s.io/cluster-api-provider-openstack/test/e2e/shared"
 )
 
@@ -889,25 +885,4 @@ func isCloudProviderInitialized(taints []corev1.Taint) bool {
 		}
 	}
 	return true
-}
-
-func createTestVolumeType(e2eCtx *shared.E2EContext) {
-	providerClient, clientOpts, _, err := shared.GetAdminProviderClient(e2eCtx)
-	Expect(err).NotTo(HaveOccurred())
-
-	volumeClient, err := openstack.NewBlockStorageV3(providerClient, gophercloud.EndpointOpts{Region: clientOpts.RegionName})
-	Expect(err).NotTo(HaveOccurred())
-
-	shared.Logf("Creating test volume type")
-	_, err = volumetypes.Create(volumeClient, &volumetypes.CreateOpts{
-		Name:        e2eCtx.E2EConfig.GetVariable(shared.OpenStackVolumeTypeAlt),
-		Description: "Test volume type",
-		IsPublic:    pointer.Bool(true),
-		ExtraSpecs:  map[string]string{},
-	}).Extract()
-	if capoerrors.IsConflict(err) {
-		shared.Logf("Volume type already exists. This may happen in development environments, but it is not expected in CI.")
-		return
-	}
-	Expect(err).NotTo(HaveOccurred())
 }


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes #1700 

**TODOs**:
- [ X] squashed commits

/hold
