### PR TITLE
🐛 Fall back to cluster identityRef in absence of machine identityRef

### DIFF
--- a/api/v1alpha7/openstackmachine_types.go
+++ b/api/v1alpha7/openstackmachine_types.go
@@ -89,7 +89,8 @@ type OpenStackMachineSpec struct {
 	// The server group to assign the machine to
 	ServerGroupID string `json:"serverGroupID,omitempty"`
 
-	// IdentityRef is a reference to a identity to be used when reconciling this cluster
+	// IdentityRef is a reference to a identity to be used when reconciling this cluster.
+	// If not specified, the identity ref of the cluster will be used instead.
 	// +optional
 	IdentityRef *OpenStackIdentityReference `json:"identityRef,omitempty"`
 }

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -3849,7 +3849,8 @@ spec:
                         type: string
                       identityRef:
                         description: IdentityRef is a reference to a identity to be
-                          used when reconciling this cluster
+                          used when reconciling this cluster. If not specified, the
+                          identity ref of the cluster will be used instead.
                         properties:
                           kind:
                             description: Kind of the identity. Must be supported by

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
@@ -1695,7 +1695,9 @@ spec:
                                 type: string
                               identityRef:
                                 description: IdentityRef is a reference to a identity
-                                  to be used when reconciling this cluster
+                                  to be used when reconciling this cluster. If not
+                                  specified, the identity ref of the cluster will
+                                  be used instead.
                                 properties:
                                   kind:
                                     description: Kind of the identity. Must be supported

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
@@ -1228,7 +1228,8 @@ spec:
                 type: string
               identityRef:
                 description: IdentityRef is a reference to a identity to be used when
-                  reconciling this cluster
+                  reconciling this cluster. If not specified, the identity ref of
+                  the cluster will be used instead.
                 properties:
                   kind:
                     description: Kind of the identity. Must be supported by the infrastructure

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
@@ -1032,7 +1032,8 @@ spec:
                         type: string
                       identityRef:
                         description: IdentityRef is a reference to a identity to be
-                          used when reconciling this cluster
+                          used when reconciling this cluster. If not specified, the
+                          identity ref of the cluster will be used instead.
                         properties:
                           kind:
                             description: Kind of the identity. Must be supported by

--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -140,7 +140,7 @@ func (r *OpenStackMachineReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 	}()
 
-	scope, err := r.ScopeFactory.NewClientScopeFromMachine(ctx, r.Client, openStackMachine, r.CaCertificates, log)
+	scope, err := r.ScopeFactory.NewClientScopeFromMachine(ctx, r.Client, openStackMachine, infraCluster, r.CaCertificates, log)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/scope/mock.go
+++ b/pkg/scope/mock.go
@@ -66,7 +66,7 @@ func (f *MockScopeFactory) SetClientScopeCreateError(err error) {
 	f.clientScopeCreateError = err
 }
 
-func (f *MockScopeFactory) NewClientScopeFromMachine(_ context.Context, _ client.Client, _ *infrav1.OpenStackMachine, _ []byte, _ logr.Logger) (Scope, error) {
+func (f *MockScopeFactory) NewClientScopeFromMachine(_ context.Context, _ client.Client, _ *infrav1.OpenStackMachine, _ *infrav1.OpenStackCluster, _ []byte, _ logr.Logger) (Scope, error) {
 	if f.clientScopeCreateError != nil {
 		return nil, f.clientScopeCreateError
 	}

--- a/pkg/scope/provider.go
+++ b/pkg/scope/provider.go
@@ -52,13 +52,19 @@ type providerScopeFactory struct {
 	clientCache *cache.LRUExpireCache
 }
 
-func (f *providerScopeFactory) NewClientScopeFromMachine(ctx context.Context, ctrlClient client.Client, openStackMachine *infrav1.OpenStackMachine, defaultCACert []byte, logger logr.Logger) (Scope, error) {
+func (f *providerScopeFactory) NewClientScopeFromMachine(ctx context.Context, ctrlClient client.Client, openStackMachine *infrav1.OpenStackMachine, openStackCluster *infrav1.OpenStackCluster, defaultCACert []byte, logger logr.Logger) (Scope, error) {
 	var cloud clientconfig.Cloud
 	var caCert []byte
 
 	if openStackMachine.Spec.IdentityRef != nil {
 		var err error
 		cloud, caCert, err = getCloudFromSecret(ctx, ctrlClient, openStackMachine.Namespace, openStackMachine.Spec.IdentityRef.Name, openStackMachine.Spec.CloudName)
+		if err != nil {
+			return nil, err
+		}
+	} else if openStackCluster.Spec.IdentityRef != nil {
+		var err error
+		cloud, caCert, err = getCloudFromSecret(ctx, ctrlClient, openStackCluster.Namespace, openStackCluster.Spec.IdentityRef.Name, openStackCluster.Spec.CloudName)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/scope/scope.go
+++ b/pkg/scope/scope.go
@@ -41,7 +41,7 @@ func NewFactory(maxCacheSize int) Factory {
 
 // Factory instantiates a new Scope using credentials from either a cluster or a machine.
 type Factory interface {
-	NewClientScopeFromMachine(ctx context.Context, ctrlClient client.Client, openStackMachine *infrav1.OpenStackMachine, defaultCACert []byte, logger logr.Logger) (Scope, error)
+	NewClientScopeFromMachine(ctx context.Context, ctrlClient client.Client, openStackMachine *infrav1.OpenStackMachine, openStackCluster *infrav1.OpenStackCluster, defaultCACert []byte, logger logr.Logger) (Scope, error)
 	NewClientScopeFromCluster(ctx context.Context, ctrlClient client.Client, openStackCluster *infrav1.OpenStackCluster, defaultCACert []byte, logger logr.Logger) (Scope, error)
 }
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

The `identityRef` attribute is marked as optional but without it we have no ability to talk to the cloud. In a future API version, we may wish to make this a required attribute but for now, provide the ability to retrieve credentials from the cluster in the absence of the machine.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #1759

**Special notes for your reviewer**:

~I'm not sure if we can do this. As things stand, this will cause a change in behavior (you can create a Machine without specifying an `identityRef`) between two different CAPO deployments regardless of API version selected. It might be better to instead explode early (rather than exploding later) and make this field required in API v1alpha8/v1beta1? Open to input here.~

(We discussed the above :point_up_2: on [Slack](https://kubernetes.slack.com/archives/CFKJB65G9/p1701773862641579) and agreed it wasn't an issue)

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [x] includes documentation
  - [ ] adds unit tests

/hold
