### PR TITLE
✨ Allow AZs to be Omitted at Runtime

### DIFF
--- a/api/v1alpha8/openstackcluster_webhook.go
+++ b/api/v1alpha8/openstackcluster_webhook.go
@@ -130,6 +130,11 @@ func (r *OpenStackCluster) ValidateUpdate(oldRaw runtime.Object) (admission.Warn
 	old.Spec.ControlPlaneAvailabilityZones = []string{}
 	r.Spec.ControlPlaneAvailabilityZones = []string{}
 
+	// Allow the scheduling to be changed from CAPI managed to Nova and
+	// vice versa.
+	old.Spec.ControlPlaneOmitAvailabilityZone = false
+	r.Spec.ControlPlaneOmitAvailabilityZone = false
+
 	// Allow change to the allowAllInClusterTraffic.
 	old.Spec.AllowAllInClusterTraffic = false
 	r.Spec.AllowAllInClusterTraffic = false

--- a/api/v1alpha8/openstackcluster_webhook_test.go
+++ b/api/v1alpha8/openstackcluster_webhook_test.go
@@ -235,6 +235,21 @@ func TestOpenStackCluster_ValidateUpdate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "Modifying OpenstackCluster.Spec.ControlPlaneOmitAvailabilityZone is allowed",
+			oldTemplate: &OpenStackCluster{
+				Spec: OpenStackClusterSpec{
+					CloudName: "foobar",
+				},
+			},
+			newTemplate: &OpenStackCluster{
+				Spec: OpenStackClusterSpec{
+					CloudName:                        "foobar",
+					ControlPlaneOmitAvailabilityZone: true,
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "Changing OpenStackCluster.Spec.APIServerFixedIP is allowed when API Server Floating IP is disabled",
 			oldTemplate: &OpenStackCluster{
 				Spec: OpenStackClusterSpec{


### PR DESCRIPTION
CAPI appears to make implicit CP scheduling decisions based on what it's told is available by CAPO on an "LRU" basis. It also assumes an infinite sized AZ, so problems begin when the "next" AZ cannot accommodate the VM. We could manually specify an AZ that aggregates all machines explcitly, however this is another mechanism that disables scheduling by CAPI altogether and allows Nova to do what it does, along with a soft-AA rule. However, switching from CAPI scheduling to Nova scheduling is impossible as the field is immutable, so allow this.  Testing shows existing scheduled clusters undergo no topology changes, which will be due to the KCPM not taking action, but you can force the changes with a rolling upgrade of some variety. Crucially, if a cluster with CAPI scheduling gets stuck, we can modify to Nova scheduling and it should pick up the new specification and get past the hurdle.

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

As above

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [x] adds unit tests

/hold
