### PR TITLE
 🐛 Verify success of parsing OpenStack cloud cacert

### DIFF
--- a/pkg/scope/provider.go
+++ b/pkg/scope/provider.go
@@ -165,7 +165,11 @@ func NewProviderClient(cloud clientconfig.Cloud, caCert []byte, logger logr.Logg
 	}
 	if caCert != nil {
 		config.RootCAs = x509.NewCertPool()
-		config.RootCAs.AppendCertsFromPEM(caCert)
+		ok := config.RootCAs.AppendCertsFromPEM(caCert)
+		if !ok {
+			// If no certificates were successfully parsed, set RootCAs to nil to use the host's root CA
+			config.RootCAs = nil
+		}
 	}
 
 	provider.HTTPClient.Transport = &http.Transport{Proxy: http.ProxyFromEnvironment, TLSClientConfig: config}


### PR DESCRIPTION
**What this PR does / why we need it**:

If no certificate is set to `OPENSTACK_CLOUD_CACERT_B64` env variable, it defaults to an empty string encoded. This can cause failure to connect to OpenStack API when it uses a certificate bundle that is supplied by the OS, instead of a private certificate. This commit fixes the issue by checking if the certificate was parsed successfully and if not attempts to use the host's root CA.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1771

/hold
