### PR TITLE
✨ New Controller for Managed Security Groups

### DIFF
--- a/controllers/openstackcluster_controller_test.go
+++ b/controllers/openstackcluster_controller_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 	. "github.com/onsi/ginkgo/v2"
@@ -202,9 +201,6 @@ var _ = Describe("OpenStackCluster controller", func() {
 		computeClientRecorder.ListServers(servers.ListOpts{
 			Name: "^capi-cluster-bastion$",
 		}).Return([]clients.ServerExt{}, nil)
-
-		networkClientRecorder := mockScopeFactory.NetworkClient.EXPECT()
-		networkClientRecorder.ListSecGroup(gomock.Any()).Return([]groups.SecGroup{}, nil)
 
 		err = deleteBastion(scope, capiCluster, testCluster)
 		Expect(err).To(BeNil())

--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -125,6 +125,17 @@ func (r *OpenStackMachineReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, nil
 	}
 
+	if infraCluster.Spec.ManagedSecurityGroups {
+		if infraCluster.Status.ControlPlaneSecurityGroup == nil {
+			log.Info("OpenStackCluster control plane security group is not ready yet")
+			return ctrl.Result{}, nil
+		}
+		if infraCluster.Status.WorkerSecurityGroup == nil {
+			log.Info("OpenStackCluster worker security group is not ready yet")
+			return ctrl.Result{}, nil
+		}
+	}
+
 	log = log.WithValues("openStackCluster", infraCluster.Name)
 
 	// Initialize the patch helper

--- a/controllers/securitygroups_controller.go
+++ b/controllers/securitygroups_controller.go
@@ -1,0 +1,286 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/record"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/annotations"
+	"sigs.k8s.io/cluster-api/util/collections"
+	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/cluster-api/util/predicates"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha7"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/networking"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
+)
+
+// SecurityGroupsReconciler reconciles managed security groups in OpenStackCluster and OpenStackMachine objects.
+type SecurityGroupsReconciler struct {
+	Client           client.Client
+	Recorder         record.EventRecorder
+	WatchFilterValue string
+	ScopeFactory     scope.Factory
+	CaCertificates   []byte // PEM encoded ca certificates.
+}
+
+func (r *SecurityGroupsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	// Fetch the OpenStackCluster instance
+	openStackCluster := &infrav1.OpenStackCluster{}
+	err := r.Client.Get(ctx, req.NamespacedName, openStackCluster)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+
+	// Fetch the Cluster.
+	cluster, err := util.GetOwnerCluster(ctx, r.Client, openStackCluster.ObjectMeta)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if cluster == nil {
+		log.Info("Cluster Controller has not yet set OwnerRef")
+		return reconcile.Result{}, nil
+	}
+
+	log = log.WithValues("cluster", cluster.Name)
+
+	if annotations.IsPaused(cluster, openStackCluster) {
+		log.Info("OpenStackCluster or linked Cluster is marked as paused. Not reconciling")
+		return reconcile.Result{}, nil
+	}
+
+	patchHelper, err := patch.NewHelper(openStackCluster, r.Client)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Always patch the openStackCluster when exiting this function so we can persist any OpenStackCluster changes.
+	defer func() {
+		if err := patchHelper.Patch(ctx, openStackCluster); err != nil {
+			if reterr == nil {
+				reterr = fmt.Errorf("error patching OpenStackCluster %s/%s: %w", openStackCluster.Namespace, openStackCluster.Name, err)
+			}
+		}
+	}()
+
+	scope, err := r.ScopeFactory.NewClientScopeFromCluster(ctx, r.Client, openStackCluster, r.CaCertificates, log)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Handle deleted SecurityGroups
+	if !openStackCluster.DeletionTimestamp.IsZero() {
+		return r.reconcileDeleteSecurityGroups(ctx, scope, cluster, openStackCluster)
+	}
+
+	// Handle non-deleted SecurityGroups
+	return reconcileSecurityGroups(scope, cluster, openStackCluster)
+}
+
+func reconcileSecurityGroups(scope scope.Scope, cluster *clusterv1.Cluster, openStackCluster *infrav1.OpenStackCluster) (ctrl.Result, error) { //nolint:unparam
+	scope.Logger().Info("Reconciling SecurityGroups")
+
+	clusterName := fmt.Sprintf("%s-%s", cluster.Namespace, cluster.Name)
+
+	networkingService, err := networking.NewService(scope)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	err = networkingService.ReconcileSecurityGroups(openStackCluster, clusterName)
+	if err != nil {
+		handleUpdateOSCError(openStackCluster, fmt.Errorf("failed to reconcile security groups: %w", err))
+		return ctrl.Result{}, fmt.Errorf("failed to reconcile security groups: %w", err)
+	}
+
+	scope.Logger().Info("Reconciled SecurityGroups successfully")
+	return ctrl.Result{}, nil
+}
+
+func (r *SecurityGroupsReconciler) reconcileDeleteSecurityGroups(ctx context.Context, scope scope.Scope, cluster *clusterv1.Cluster, openStackCluster *infrav1.OpenStackCluster) (ctrl.Result, error) {
+	scope.Logger().Info("Reconciling SecurityGroups delete")
+
+	// Wait for machines to be deleted before removing the finalizer as they
+	// depend on this resource to deprovision.  Additionally it appears that
+	// allowing the Kubernetes API to vanish too quickly will upset the capi
+	// kubeadm control plane controller.
+	machines, err := collections.GetFilteredMachinesForCluster(ctx, r.Client, cluster)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if len(machines) != 0 {
+		scope.Logger().Info("Waiting for machines to be deleted", "remaining", len(machines))
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+
+	networkingService, err := networking.NewService(scope)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	clusterName := fmt.Sprintf("%s-%s", cluster.Namespace, cluster.Name)
+
+	if err = networkingService.DeleteBastionSecurityGroup(openStackCluster, fmt.Sprintf("%s-%s", cluster.Namespace, cluster.Name)); err != nil {
+		handleUpdateOSCError(openStackCluster, fmt.Errorf("failed to delete bastion security group: %w", err))
+		return reconcile.Result{}, fmt.Errorf("failed to delete bastion security group: %w", err)
+	}
+	openStackCluster.Status.BastionSecurityGroup = nil
+
+	if err = networkingService.DeleteControlPlaneSecurityGroup(openStackCluster, clusterName); err != nil {
+		handleUpdateOSCError(openStackCluster, fmt.Errorf("failed to delete control plane security group: %w", err))
+		return reconcile.Result{}, fmt.Errorf("failed to delete control plane security group: %w", err)
+	}
+	openStackCluster.Status.ControlPlaneSecurityGroup = nil
+
+	if err = networkingService.DeleteWorkerSecurityGroup(openStackCluster, clusterName); err != nil {
+		handleUpdateOSCError(openStackCluster, fmt.Errorf("failed to delete worker security group: %w", err))
+		return reconcile.Result{}, fmt.Errorf("failed to delete worker security group: %w", err)
+	}
+	openStackCluster.Status.WorkerSecurityGroup = nil
+
+	scope.Logger().Info("Reconciled SecurityGroups deleted successfully")
+	return ctrl.Result{}, nil
+}
+
+func (r *SecurityGroupsReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(options).
+		For(
+			&infrav1.OpenStackMachine{},
+			builder.WithPredicates(
+				predicate.Funcs{
+					// Avoid reconciling if the event triggering the reconciliation is related to incremental status updates
+					UpdateFunc: func(e event.UpdateEvent) bool {
+						oldMachine := e.ObjectOld.(*infrav1.OpenStackMachine).DeepCopy()
+						newMachine := e.ObjectNew.(*infrav1.OpenStackMachine).DeepCopy()
+						oldMachine.Status = infrav1.OpenStackMachineStatus{}
+						newMachine.Status = infrav1.OpenStackMachineStatus{}
+						oldMachine.ObjectMeta.ResourceVersion = ""
+						newMachine.ObjectMeta.ResourceVersion = ""
+						return !reflect.DeepEqual(oldMachine, newMachine)
+					},
+				},
+			),
+		).
+		Watches(
+			&clusterv1.Machine{},
+			handler.EnqueueRequestsFromMapFunc(util.MachineToInfrastructureMapFunc(infrav1.GroupVersion.WithKind("OpenStackMachine"))),
+		).
+		Watches(
+			&infrav1.OpenStackCluster{},
+			handler.EnqueueRequestsFromMapFunc(r.OpenStackClusterToOpenStackMachines(ctx)),
+		).
+		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		Watches(
+			&clusterv1.Cluster{},
+			handler.EnqueueRequestsFromMapFunc(r.requeueOpenStackMachinesForUnpausedCluster(ctx)),
+			builder.WithPredicates(predicates.ClusterUnpausedAndInfrastructureReady(ctrl.LoggerFrom(ctx))),
+		).
+		Complete(r)
+}
+
+// OpenStackClusterToOpenStackMachines is a handler.ToRequestsFunc to be used to enqeue requests for reconciliation
+// of OpenStackMachines.
+func (r *SecurityGroupsReconciler) OpenStackClusterToOpenStackMachines(ctx context.Context) handler.MapFunc {
+	log := ctrl.LoggerFrom(ctx)
+	return func(ctx context.Context, o client.Object) []ctrl.Request {
+		c, ok := o.(*infrav1.OpenStackCluster)
+		if !ok {
+			panic(fmt.Sprintf("Expected a OpenStackCluster but got a %T", o))
+		}
+
+		log := log.WithValues("objectMapper", "openStackClusterToOpenStackMachine", "namespace", c.Namespace, "openStackCluster", c.Name)
+
+		// Don't handle deleted OpenStackClusters
+		if !c.ObjectMeta.DeletionTimestamp.IsZero() {
+			log.V(4).Info("OpenStackClusters has a deletion timestamp, skipping mapping.")
+			return nil
+		}
+
+		cluster, err := util.GetOwnerCluster(ctx, r.Client, c.ObjectMeta)
+		switch {
+		case apierrors.IsNotFound(err) || cluster == nil:
+			log.V(4).Info("Cluster for OpenStackCluster not found, skipping mapping.")
+			return nil
+		case err != nil:
+			log.Error(err, "Failed to get owning cluster, skipping mapping.")
+			return nil
+		}
+
+		return r.requestsForCluster(ctx, log, cluster.Namespace, cluster.Name)
+	}
+}
+
+func (r *SecurityGroupsReconciler) requestsForCluster(ctx context.Context, log logr.Logger, namespace, name string) []ctrl.Request {
+	labels := map[string]string{clusterv1.ClusterNameLabel: name}
+	machineList := &clusterv1.MachineList{}
+	if err := r.Client.List(ctx, machineList, client.InNamespace(namespace), client.MatchingLabels(labels)); err != nil {
+		log.Error(err, "Failed to get owned Machines, skipping mapping.")
+		return nil
+	}
+
+	result := make([]ctrl.Request, 0, len(machineList.Items))
+	for _, m := range machineList.Items {
+		if m.Spec.InfrastructureRef.Name != "" {
+			result = append(result, ctrl.Request{NamespacedName: client.ObjectKey{Namespace: m.Namespace, Name: m.Spec.InfrastructureRef.Name}})
+		}
+	}
+	return result
+}
+
+func (r *SecurityGroupsReconciler) requeueOpenStackMachinesForUnpausedCluster(ctx context.Context) handler.MapFunc {
+	log := ctrl.LoggerFrom(ctx)
+	return func(ctx context.Context, o client.Object) []ctrl.Request {
+		c, ok := o.(*clusterv1.Cluster)
+		if !ok {
+			panic(fmt.Sprintf("Expected a Cluster but got a %T", o))
+		}
+
+		log := log.WithValues("objectMapper", "clusterToOpenStackMachine", "namespace", c.Namespace, "cluster", c.Name)
+
+		// Don't handle deleted clusters
+		if !c.ObjectMeta.DeletionTimestamp.IsZero() {
+			log.V(4).Info("Cluster has a deletion timestamp, skipping mapping.")
+			return nil
+		}
+
+		return r.requestsForCluster(ctx, log, c.Namespace, c.Name)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -259,6 +259,16 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager, caCerts []byte, sco
 		setupLog.Error(err, "unable to create controller", "controller", "OpenStackMachine")
 		os.Exit(1)
 	}
+	if err := (&controllers.SecurityGroupsReconciler{
+		Client:           mgr.GetClient(),
+		Recorder:         mgr.GetEventRecorderFor("securitygroup-controller"),
+		WatchFilterValue: watchFilterValue,
+		ScopeFactory:     scopeFactory,
+		CaCertificates:   caCerts,
+	}).SetupWithManager(ctx, mgr, concurrency(openStackMachineConcurrency)); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "SecurityGroup")
+		os.Exit(1)
+	}
 }
 
 func setupWebhooks(mgr ctrl.Manager) {

--- a/pkg/cloud/services/networking/securitygroups.go
+++ b/pkg/cloud/services/networking/securitygroups.go
@@ -205,18 +205,14 @@ func (s *Service) GetSecurityGroups(securityGroupParams []infrav1.SecurityGroupF
 	return sgIDs, nil
 }
 
-func (s *Service) DeleteSecurityGroups(openStackCluster *infrav1.OpenStackCluster, clusterName string) error {
-	secGroupNames := []string{
-		getSecControlPlaneGroupName(clusterName),
-		getSecWorkerGroupName(clusterName),
-	}
-	for _, secGroupName := range secGroupNames {
-		if err := s.deleteSecurityGroup(openStackCluster, secGroupName); err != nil {
-			return err
-		}
-	}
+func (s *Service) DeleteControlPlaneSecurityGroup(openStackCluster *infrav1.OpenStackCluster, clusterName string) error {
+	secControlPlaneGroupName := getSecControlPlaneGroupName(clusterName)
+	return s.deleteSecurityGroup(openStackCluster, secControlPlaneGroupName)
+}
 
-	return nil
+func (s *Service) DeleteWorkerSecurityGroup(openStackCluster *infrav1.OpenStackCluster, clusterName string) error {
+	secWorkerGroupName := getSecWorkerGroupName(clusterName)
+	return s.deleteSecurityGroup(openStackCluster, secWorkerGroupName)
 }
 
 func (s *Service) DeleteBastionSecurityGroup(openStackCluster *infrav1.OpenStackCluster, clusterName string) error {


### PR DESCRIPTION
**What this PR does / why we need it**:

This moves the managed OpenStack Security Groups from the OpenStackCluster controller into a new dedicated controller.

* openstackcluster_controller won't managed the security groups anymore
* securitygroups_controller will now managed the security groups and update OpenStackCluster.Status

This should be feature parity and work as is for the users and be 100% backward compatible.

**TODOs**:

- [ ] Manage the assignment between SecurityGroups and machine. The goal is to remove that [block](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/8a49b9f23c3a8bd2f41c4e071213edc8bc8ede7b/controllers/openstackmachine_controller.go#L500-L511).
- [ ] Update the documentation
- [ ] Add unit tests
- [ ] Squashed commits
