### PR TITLE
🐛 Don't apply worker SG to control plane machines

### DIFF
--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -499,15 +499,21 @@ func machineToInstanceSpec(openStackCluster *infrav1.OpenStackCluster, machine *
 	instanceSpec.SecurityGroups = openStackMachine.Spec.SecurityGroups
 	if openStackCluster.Spec.ManagedSecurityGroups {
 		var managedSecurityGroup string
-		if util.IsControlPlaneMachine(machine) && openStackCluster.Status.ControlPlaneSecurityGroup != nil {
-			managedSecurityGroup = openStackCluster.Status.ControlPlaneSecurityGroup.ID
-		} else if openStackCluster.Status.WorkerSecurityGroup != nil {
-			managedSecurityGroup = openStackCluster.Status.WorkerSecurityGroup.ID
+		if util.IsControlPlaneMachine(machine) {
+			if openStackCluster.Status.ControlPlaneSecurityGroup != nil {
+				managedSecurityGroup = openStackCluster.Status.ControlPlaneSecurityGroup.ID
+			}
+		} else {
+			if openStackCluster.Status.WorkerSecurityGroup != nil {
+				managedSecurityGroup = openStackCluster.Status.WorkerSecurityGroup.ID
+			}
 		}
 
-		instanceSpec.SecurityGroups = append(instanceSpec.SecurityGroups, infrav1.SecurityGroupFilter{
-			ID: managedSecurityGroup,
-		})
+		if managedSecurityGroup != "" {
+			instanceSpec.SecurityGroups = append(instanceSpec.SecurityGroups, infrav1.SecurityGroupFilter{
+				ID: managedSecurityGroup,
+			})
+		}
 	}
 
 	instanceSpec.Ports = openStackMachine.Spec.Ports


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Currently, if a worker machine security group is specified but a control plane machine security group is not, the worker machine SG will be be applied to both worker *and* control plane machines. Correct this mistake.

Signed-off-by: Stephen Finucane <stephenfin@redhat.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #1784

**Special notes for your reviewer**:

None.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [x] adds unit tests

/hold
