### PR TITLE
✨ Support BYO dual-stack Network

### DIFF
--- a/api/v1alpha5/conversion.go
+++ b/api/v1alpha5/conversion.go
@@ -196,6 +196,14 @@ func Convert_v1alpha8_OpenStackClusterSpec_To_v1alpha5_OpenStackClusterSpec(in *
 		out.ExternalNetworkID = in.ExternalNetwork.ID
 	}
 
+	if in.Subnets != nil {
+		if len(in.Subnets) >= 1 {
+			if err := Convert_v1alpha8_SubnetFilter_To_v1alpha5_SubnetFilter(&in.Subnets[0], &out.Subnet, s); err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -209,6 +217,15 @@ func Convert_v1alpha5_OpenStackClusterSpec_To_v1alpha8_OpenStackClusterSpec(in *
 		out.ExternalNetwork = infrav1.NetworkFilter{
 			ID: in.ExternalNetworkID,
 		}
+	}
+
+	emptySubnet := SubnetFilter{}
+	if in.Subnet != emptySubnet {
+		subnet := infrav1.SubnetFilter{}
+		if err := Convert_v1alpha5_SubnetFilter_To_v1alpha8_SubnetFilter(&in.Subnet, &subnet, s); err != nil {
+			return err
+		}
+		out.Subnets = []infrav1.SubnetFilter{subnet}
 	}
 
 	return nil

--- a/api/v1alpha5/conversion_test.go
+++ b/api/v1alpha5/conversion_test.go
@@ -49,7 +49,7 @@ func TestConvertFrom(t *testing.T) {
 				Spec: OpenStackClusterSpec{},
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"cluster.x-k8s.io/conversion-data": "{\"spec\":{\"allowAllInClusterTraffic\":false,\"apiServerLoadBalancer\":{},\"cloudName\":\"\",\"controlPlaneEndpoint\":{\"host\":\"\",\"port\":0},\"disableAPIServerFloatingIP\":false,\"disableExternalNetwork\":false,\"externalNetwork\":{},\"managedSecurityGroups\":false,\"network\":{},\"subnet\":{}},\"status\":{\"ready\":false}}",
+						"cluster.x-k8s.io/conversion-data": "{\"spec\":{\"allowAllInClusterTraffic\":false,\"apiServerLoadBalancer\":{},\"cloudName\":\"\",\"controlPlaneEndpoint\":{\"host\":\"\",\"port\":0},\"disableAPIServerFloatingIP\":false,\"disableExternalNetwork\":false,\"externalNetwork\":{},\"managedSecurityGroups\":false,\"network\":{}},\"status\":{\"ready\":false}}",
 					},
 				},
 			},
@@ -64,7 +64,7 @@ func TestConvertFrom(t *testing.T) {
 				Spec: OpenStackClusterTemplateSpec{},
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"cluster.x-k8s.io/conversion-data": "{\"spec\":{\"template\":{\"spec\":{\"allowAllInClusterTraffic\":false,\"apiServerLoadBalancer\":{},\"cloudName\":\"\",\"controlPlaneEndpoint\":{\"host\":\"\",\"port\":0},\"disableAPIServerFloatingIP\":false,\"disableExternalNetwork\":false,\"externalNetwork\":{},\"managedSecurityGroups\":false,\"network\":{},\"subnet\":{}}}}}",
+						"cluster.x-k8s.io/conversion-data": "{\"spec\":{\"template\":{\"spec\":{\"allowAllInClusterTraffic\":false,\"apiServerLoadBalancer\":{},\"cloudName\":\"\",\"controlPlaneEndpoint\":{\"host\":\"\",\"port\":0},\"disableAPIServerFloatingIP\":false,\"disableExternalNetwork\":false,\"externalNetwork\":{},\"managedSecurityGroups\":false,\"network\":{}}}}}",
 					},
 				},
 			},

--- a/api/v1alpha5/zz_generated.conversion.go
+++ b/api/v1alpha5/zz_generated.conversion.go
@@ -659,9 +659,7 @@ func autoConvert_v1alpha5_OpenStackClusterSpec_To_v1alpha8_OpenStackClusterSpec(
 	if err := Convert_v1alpha5_NetworkFilter_To_v1alpha8_NetworkFilter(&in.Network, &out.Network, s); err != nil {
 		return err
 	}
-	if err := Convert_v1alpha5_SubnetFilter_To_v1alpha8_SubnetFilter(&in.Subnet, &out.Subnet, s); err != nil {
-		return err
-	}
+	// WARNING: in.Subnet requires manual conversion: does not exist in peer-type
 	out.DNSNameservers = *(*[]string)(unsafe.Pointer(&in.DNSNameservers))
 	if in.ExternalRouterIPs != nil {
 		in, out := &in.ExternalRouterIPs, &out.ExternalRouterIPs
@@ -708,9 +706,7 @@ func autoConvert_v1alpha8_OpenStackClusterSpec_To_v1alpha5_OpenStackClusterSpec(
 	if err := Convert_v1alpha8_NetworkFilter_To_v1alpha5_NetworkFilter(&in.Network, &out.Network, s); err != nil {
 		return err
 	}
-	if err := Convert_v1alpha8_SubnetFilter_To_v1alpha5_SubnetFilter(&in.Subnet, &out.Subnet, s); err != nil {
-		return err
-	}
+	// WARNING: in.Subnets requires manual conversion: does not exist in peer-type
 	// WARNING: in.NetworkMTU requires manual conversion: does not exist in peer-type
 	out.DNSNameservers = *(*[]string)(unsafe.Pointer(&in.DNSNameservers))
 	if in.ExternalRouterIPs != nil {

--- a/api/v1alpha6/conversion.go
+++ b/api/v1alpha6/conversion.go
@@ -75,6 +75,12 @@ func restorev1alpha8Bastion(previous **infrav1.Bastion, dst **infrav1.Bastion) {
 	}
 }
 
+func restorev1alpha8Subnets(previous *[]infrav1.SubnetFilter, dst *[]infrav1.SubnetFilter) {
+	if len(*previous) > 1 {
+		*dst = append(*dst, (*previous)[1:]...)
+	}
+}
+
 func restorev1alpha8ClusterStatus(previous *infrav1.OpenStackClusterStatus, dst *infrav1.OpenStackClusterStatus) {
 	// It's (theoretically) possible in v1alpha8 to have Network nil but
 	// Router or APIServerLoadBalancer not nil. In hub-spoke-hub conversion this will
@@ -153,6 +159,12 @@ var v1alpha8OpenStackClusterRestorer = conversion.RestorerFor[*infrav1.OpenStack
 			return &c.Spec.Bastion
 		},
 		restorev1alpha8Bastion,
+	),
+	"subnets": conversion.HashedFieldRestorer(
+		func(c *infrav1.OpenStackCluster) *[]infrav1.SubnetFilter {
+			return &c.Spec.Subnets
+		},
+		restorev1alpha8Subnets,
 	),
 	"status": conversion.HashedFieldRestorer(
 		func(c *infrav1.OpenStackCluster) *infrav1.OpenStackClusterStatus {
@@ -233,6 +245,12 @@ var v1alpha8OpenStackClusterTemplateRestorer = conversion.RestorerFor[*infrav1.O
 			return &c.Spec.Template.Spec.Bastion
 		},
 		restorev1alpha8Bastion,
+	),
+	"subnets": conversion.HashedFieldRestorer(
+		func(c *infrav1.OpenStackClusterTemplate) *[]infrav1.SubnetFilter {
+			return &c.Spec.Template.Spec.Subnets
+		},
+		restorev1alpha8Subnets,
 	),
 }
 

--- a/api/v1alpha6/conversion.go
+++ b/api/v1alpha6/conversion.go
@@ -486,6 +486,12 @@ func Convert_v1alpha8_OpenStackClusterSpec_To_v1alpha6_OpenStackClusterSpec(in *
 		out.ExternalNetworkID = in.ExternalNetwork.ID
 	}
 
+	if len(in.Subnets) >= 1 {
+		if err := Convert_v1alpha8_SubnetFilter_To_v1alpha6_SubnetFilter(&in.Subnets[0], &out.Subnet, s); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -499,6 +505,15 @@ func Convert_v1alpha6_OpenStackClusterSpec_To_v1alpha8_OpenStackClusterSpec(in *
 		out.ExternalNetwork = infrav1.NetworkFilter{
 			ID: in.ExternalNetworkID,
 		}
+	}
+
+	emptySubnet := SubnetFilter{}
+	if in.Subnet != emptySubnet {
+		subnet := infrav1.SubnetFilter{}
+		if err := Convert_v1alpha6_SubnetFilter_To_v1alpha8_SubnetFilter(&in.Subnet, &subnet, s); err != nil {
+			return err
+		}
+		out.Subnets = []infrav1.SubnetFilter{subnet}
 	}
 
 	return nil

--- a/api/v1alpha6/conversion_test.go
+++ b/api/v1alpha6/conversion_test.go
@@ -88,6 +88,19 @@ func TestFuzzyConversion(t *testing.T) {
 					status.ExternalNetwork.APIServerLoadBalancer = nil
 				}
 			},
+
+			func(spec *infrav1.OpenStackClusterSpec, c fuzz.Continue) {
+				c.FuzzNoCustom(spec)
+
+				// The fuzzer only seems to generate Subnets of
+				// length 1, but we need to also test length 2.
+				// Ensure it is occasionally generated.
+				if len(spec.Subnets) == 1 && c.RandBool() {
+					subnet := infrav1.SubnetFilter{}
+					c.FuzzNoCustom(&subnet)
+					spec.Subnets = append(spec.Subnets, subnet)
+				}
+			},
 		}
 	}
 
@@ -119,13 +132,16 @@ func TestFuzzyConversion(t *testing.T) {
 			Hub:              &infrav1.OpenStackClusterTemplate{},
 			Spoke:            &OpenStackClusterTemplate{},
 			HubAfterMutation: ignoreDataAnnotation,
+			FuzzerFuncs:      []fuzzer.FuzzerFuncs{fuzzerFuncs},
 		},
+		MutateFuzzerFuncs: []fuzzer.FuzzerFuncs{fuzzerFuncs},
 	})))
 
 	t.Run("for OpenStackMachine", runParallel(utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
 		Hub:              &infrav1.OpenStackMachine{},
 		Spoke:            &OpenStackMachine{},
 		HubAfterMutation: ignoreDataAnnotation,
+		FuzzerFuncs:      []fuzzer.FuzzerFuncs{fuzzerFuncs},
 	})))
 
 	t.Run("for OpenStackMachine with mutate", runParallel(testhelpers.FuzzMutateTestFunc(testhelpers.FuzzMutateTestFuncInput{
@@ -133,13 +149,16 @@ func TestFuzzyConversion(t *testing.T) {
 			Hub:              &infrav1.OpenStackMachine{},
 			Spoke:            &OpenStackMachine{},
 			HubAfterMutation: ignoreDataAnnotation,
+			FuzzerFuncs:      []fuzzer.FuzzerFuncs{fuzzerFuncs},
 		},
+		MutateFuzzerFuncs: []fuzzer.FuzzerFuncs{fuzzerFuncs},
 	})))
 
 	t.Run("for OpenStackMachineTemplate", runParallel(utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
 		Hub:              &infrav1.OpenStackMachineTemplate{},
 		Spoke:            &OpenStackMachineTemplate{},
 		HubAfterMutation: ignoreDataAnnotation,
+		FuzzerFuncs:      []fuzzer.FuzzerFuncs{fuzzerFuncs},
 	})))
 
 	t.Run("for OpenStackMachineTemplate with mutate", runParallel(testhelpers.FuzzMutateTestFunc(testhelpers.FuzzMutateTestFuncInput{
@@ -147,7 +166,9 @@ func TestFuzzyConversion(t *testing.T) {
 			Hub:              &infrav1.OpenStackMachineTemplate{},
 			Spoke:            &OpenStackMachineTemplate{},
 			HubAfterMutation: ignoreDataAnnotation,
+			FuzzerFuncs:      []fuzzer.FuzzerFuncs{fuzzerFuncs},
 		},
+		MutateFuzzerFuncs: []fuzzer.FuzzerFuncs{fuzzerFuncs},
 	})))
 }
 

--- a/api/v1alpha6/zz_generated.conversion.go
+++ b/api/v1alpha6/zz_generated.conversion.go
@@ -681,9 +681,7 @@ func autoConvert_v1alpha6_OpenStackClusterSpec_To_v1alpha8_OpenStackClusterSpec(
 	if err := Convert_v1alpha6_NetworkFilter_To_v1alpha8_NetworkFilter(&in.Network, &out.Network, s); err != nil {
 		return err
 	}
-	if err := Convert_v1alpha6_SubnetFilter_To_v1alpha8_SubnetFilter(&in.Subnet, &out.Subnet, s); err != nil {
-		return err
-	}
+	// WARNING: in.Subnet requires manual conversion: does not exist in peer-type
 	out.DNSNameservers = *(*[]string)(unsafe.Pointer(&in.DNSNameservers))
 	if in.ExternalRouterIPs != nil {
 		in, out := &in.ExternalRouterIPs, &out.ExternalRouterIPs
@@ -731,9 +729,7 @@ func autoConvert_v1alpha8_OpenStackClusterSpec_To_v1alpha6_OpenStackClusterSpec(
 	if err := Convert_v1alpha8_NetworkFilter_To_v1alpha6_NetworkFilter(&in.Network, &out.Network, s); err != nil {
 		return err
 	}
-	if err := Convert_v1alpha8_SubnetFilter_To_v1alpha6_SubnetFilter(&in.Subnet, &out.Subnet, s); err != nil {
-		return err
-	}
+	// WARNING: in.Subnets requires manual conversion: does not exist in peer-type
 	// WARNING: in.NetworkMTU requires manual conversion: does not exist in peer-type
 	out.DNSNameservers = *(*[]string)(unsafe.Pointer(&in.DNSNameservers))
 	if in.ExternalRouterIPs != nil {

--- a/api/v1alpha7/conversion.go
+++ b/api/v1alpha7/conversion.go
@@ -383,6 +383,15 @@ func Convert_v1alpha7_OpenStackClusterSpec_To_v1alpha8_OpenStackClusterSpec(in *
 		}
 	}
 
+	emptySubnet := SubnetFilter{}
+	if in.Subnet != emptySubnet {
+		subnet := infrav1.SubnetFilter{}
+		if err := Convert_v1alpha7_SubnetFilter_To_v1alpha8_SubnetFilter(&in.Subnet, &subnet, s); err != nil {
+			return err
+		}
+		out.Subnets = []infrav1.SubnetFilter{subnet}
+	}
+
 	return nil
 }
 
@@ -394,6 +403,12 @@ func Convert_v1alpha8_OpenStackClusterSpec_To_v1alpha7_OpenStackClusterSpec(in *
 
 	if in.ExternalNetwork.ID != "" {
 		out.ExternalNetworkID = in.ExternalNetwork.ID
+	}
+
+	if len(in.Subnets) >= 1 {
+		if err := Convert_v1alpha8_SubnetFilter_To_v1alpha7_SubnetFilter(&in.Subnets[0], &out.Subnet, s); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/api/v1alpha7/conversion.go
+++ b/api/v1alpha7/conversion.go
@@ -97,6 +97,10 @@ func restorev1alpha8ClusterSpec(previous *infrav1.OpenStackClusterSpec, dst *inf
 	dst.ExternalNetwork.NotTagsAny = previous.ExternalNetwork.NotTagsAny
 
 	dst.DisableExternalNetwork = previous.DisableExternalNetwork
+
+	if len(previous.Subnets) > 1 {
+		dst.Subnets = append(dst.Subnets, previous.Subnets[1:]...)
+	}
 }
 
 func (r *OpenStackCluster) ConvertTo(dstRaw ctrlconversion.Hub) error {

--- a/api/v1alpha7/zz_generated.conversion.go
+++ b/api/v1alpha7/zz_generated.conversion.go
@@ -882,9 +882,7 @@ func autoConvert_v1alpha7_OpenStackClusterSpec_To_v1alpha8_OpenStackClusterSpec(
 	if err := Convert_v1alpha7_NetworkFilter_To_v1alpha8_NetworkFilter(&in.Network, &out.Network, s); err != nil {
 		return err
 	}
-	if err := Convert_v1alpha7_SubnetFilter_To_v1alpha8_SubnetFilter(&in.Subnet, &out.Subnet, s); err != nil {
-		return err
-	}
+	// WARNING: in.Subnet requires manual conversion: does not exist in peer-type
 	out.NetworkMTU = in.NetworkMTU
 	out.DNSNameservers = *(*[]string)(unsafe.Pointer(&in.DNSNameservers))
 	out.ExternalRouterIPs = *(*[]v1alpha8.ExternalRouterIPParam)(unsafe.Pointer(&in.ExternalRouterIPs))
@@ -923,9 +921,7 @@ func autoConvert_v1alpha8_OpenStackClusterSpec_To_v1alpha7_OpenStackClusterSpec(
 	if err := Convert_v1alpha8_NetworkFilter_To_v1alpha7_NetworkFilter(&in.Network, &out.Network, s); err != nil {
 		return err
 	}
-	if err := Convert_v1alpha8_SubnetFilter_To_v1alpha7_SubnetFilter(&in.Subnet, &out.Subnet, s); err != nil {
-		return err
-	}
+	// WARNING: in.Subnets requires manual conversion: does not exist in peer-type
 	out.NetworkMTU = in.NetworkMTU
 	out.DNSNameservers = *(*[]string)(unsafe.Pointer(&in.DNSNameservers))
 	out.ExternalRouterIPs = *(*[]ExternalRouterIPParam)(unsafe.Pointer(&in.ExternalRouterIPs))

--- a/api/v1alpha8/openstackcluster_types.go
+++ b/api/v1alpha8/openstackcluster_types.go
@@ -47,8 +47,9 @@ type OpenStackClusterSpec struct {
 	// If NodeCIDR cannot be set this can be used to detect an existing network.
 	Network NetworkFilter `json:"network,omitempty"`
 
-	// If NodeCIDR cannot be set this can be used to detect an existing subnet.
-	Subnet SubnetFilter `json:"subnet,omitempty"`
+	// If NodeCIDR cannot be set this can be used to detect existing IPv4 and/or IPv6 subnets.
+	// +kubebuilder:validation:MaxItems=2
+	Subnets []SubnetFilter `json:"subnets,omitempty"`
 
 	// NetworkMTU sets the maximum transmission unit (MTU) value to address fragmentation for the private network ID.
 	// This value will be used only if the Cluster actuator creates the network.

--- a/api/v1alpha8/zz_generated.deepcopy.go
+++ b/api/v1alpha8/zz_generated.deepcopy.go
@@ -372,7 +372,11 @@ func (in *OpenStackClusterSpec) DeepCopyInto(out *OpenStackClusterSpec) {
 		**out = **in
 	}
 	out.Network = in.Network
-	out.Subnet = in.Subnet
+	if in.Subnets != nil {
+		in, out := &in.Subnets, &out.Subnets
+		*out = make([]SubnetFilter, len(*in))
+		copy(*out, *in)
+	}
 	if in.DNSNameservers != nil {
 		in, out := &in.DNSNameservers, &out.DNSNameservers
 		*out = make([]string, len(*in))

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -5507,37 +5507,40 @@ spec:
                   tagsAny:
                     type: string
                 type: object
-              subnet:
+              subnets:
                 description: If NodeCIDR cannot be set this can be used to detect
-                  an existing subnet.
-                properties:
-                  cidr:
-                    type: string
-                  description:
-                    type: string
-                  gateway_ip:
-                    type: string
-                  id:
-                    type: string
-                  ipVersion:
-                    type: integer
-                  ipv6AddressMode:
-                    type: string
-                  ipv6RaMode:
-                    type: string
-                  name:
-                    type: string
-                  notTags:
-                    type: string
-                  notTagsAny:
-                    type: string
-                  projectId:
-                    type: string
-                  tags:
-                    type: string
-                  tagsAny:
-                    type: string
-                type: object
+                  existing IPv4 and/or IPv6 subnets.
+                items:
+                  properties:
+                    cidr:
+                      type: string
+                    description:
+                      type: string
+                    gateway_ip:
+                      type: string
+                    id:
+                      type: string
+                    ipVersion:
+                      type: integer
+                    ipv6AddressMode:
+                      type: string
+                    ipv6RaMode:
+                      type: string
+                    name:
+                      type: string
+                    notTags:
+                      type: string
+                    notTagsAny:
+                      type: string
+                    projectId:
+                      type: string
+                    tags:
+                      type: string
+                    tagsAny:
+                      type: string
+                  type: object
+                maxItems: 2
+                type: array
               tags:
                 description: Tags for all resources in cluster
                 items:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
@@ -2942,37 +2942,40 @@ spec:
                           tagsAny:
                             type: string
                         type: object
-                      subnet:
+                      subnets:
                         description: If NodeCIDR cannot be set this can be used to
-                          detect an existing subnet.
-                        properties:
-                          cidr:
-                            type: string
-                          description:
-                            type: string
-                          gateway_ip:
-                            type: string
-                          id:
-                            type: string
-                          ipVersion:
-                            type: integer
-                          ipv6AddressMode:
-                            type: string
-                          ipv6RaMode:
-                            type: string
-                          name:
-                            type: string
-                          notTags:
-                            type: string
-                          notTagsAny:
-                            type: string
-                          projectId:
-                            type: string
-                          tags:
-                            type: string
-                          tagsAny:
-                            type: string
-                        type: object
+                          detect existing IPv4 and/or IPv6 subnets.
+                        items:
+                          properties:
+                            cidr:
+                              type: string
+                            description:
+                              type: string
+                            gateway_ip:
+                              type: string
+                            id:
+                              type: string
+                            ipVersion:
+                              type: integer
+                            ipv6AddressMode:
+                              type: string
+                            ipv6RaMode:
+                              type: string
+                            name:
+                              type: string
+                            notTags:
+                              type: string
+                            notTagsAny:
+                              type: string
+                            projectId:
+                              type: string
+                            tags:
+                              type: string
+                            tagsAny:
+                              type: string
+                          type: object
+                        maxItems: 2
+                        type: array
                       tags:
                         description: Tags for all resources in cluster
                         items:

--- a/docs/book/src/topics/crd-changes/v1alpha7-to-v1alpha8.md
+++ b/docs/book/src/topics/crd-changes/v1alpha7-to-v1alpha8.md
@@ -12,6 +12,7 @@
       - [Changes to image](#change-to-image)
       - [Removal of imageUUID](#removal-of-imageuuid)
       - [Change to floatingIP](#change-to-floatingip)
+      - [Change to subnet](#change-to-subnet)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -156,3 +157,23 @@ spec:
   bastion:
     floatingIP: "1.2.3.4"
 ```
+
+#### ⚠️ Change to subnet
+
+In v1alpha8, `Subnet` of `OpenStackCluster` is modified to `Subnets` to allow specification of two existent subnets for the dual-stack scenario.
+
+```yaml
+  subnet:
+    id: a532beb0-c73a-4b5d-af66-3ad05b73d063
+```
+
+In v1alpha8, this will be automatically converted to:
+
+```yaml
+  subnets:
+    - id: a532beb0-c73a-4b5d-af66-3ad05b73d063
+```
+
+`Subnets` allows specifications of maximum two `SubnetFilter` one being IPv4 and the other IPv6. Both subnets must be on the same network. Any filtered subnets will be added to `OpenStackCluster.Status.Network.Subnets`.
+
+When subnets are not specified on `OpenStackCluster` and only the network is, the network is used to identify the subnets to use. If more than two subnets exist in the network, the user must specify which ones to use by defining the `OpenStackCluster.Spec.Subnets` field.

--- a/pkg/cloud/services/networking/network.go
+++ b/pkg/cloud/services/networking/network.go
@@ -383,3 +383,15 @@ func getSubnetName(clusterName string) string {
 func getNetworkName(clusterName string) string {
 	return fmt.Sprintf("%s-cluster-%s", networkPrefix, clusterName)
 }
+
+// ConvertOpenStackSubnetToCAPOSubnet converts an OpenStack subnet to a capo subnet and adds to a slice.
+// It returns the slice with the converted subnet.
+func (s *Service) ConvertOpenStackSubnetToCAPOSubnet(subnets []infrav1.Subnet, filteredSubnet *subnets.Subnet) []infrav1.Subnet {
+	subnets = append(subnets, infrav1.Subnet{
+		ID:   filteredSubnet.ID,
+		Name: filteredSubnet.Name,
+		CIDR: filteredSubnet.CIDR,
+		Tags: filteredSubnet.Tags,
+	})
+	return subnets
+}

--- a/pkg/utils/controllers/controllers.go
+++ b/pkg/utils/controllers/controllers.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"fmt"
+	"net"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha8"
+)
+
+// ValidateSubnets validates if the amount of IPv4 and IPv6 subnets is allowed by OpenStackCluster.
+func ValidateSubnets(subnets []infrav1.Subnet) error {
+	isIPv6 := []bool{false, false}
+	for i, subnet := range subnets {
+		ip, _, err := net.ParseCIDR(subnet.CIDR)
+		if err != nil {
+			return err
+		}
+
+		if ip.To4() == nil {
+			isIPv6[i] = true
+		}
+	}
+
+	if len(subnets) > 1 && isIPv6[0] == isIPv6[1] {
+		ethertype := 4
+		if isIPv6[0] {
+			ethertype = 6
+		}
+		return fmt.Errorf("multiple IPv%d Subnet not allowed on OpenStackCluster", ethertype)
+	}
+	return nil
+}

--- a/pkg/utils/controllers/controllers_test.go
+++ b/pkg/utils/controllers/controllers_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"testing"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha8"
+)
+
+func Test_validateSubnets(t *testing.T) {
+	tests := []struct {
+		name    string
+		subnets []infrav1.Subnet
+		wantErr bool
+	}{
+		{
+			name: "valid IPv4 and IPv6 subnets",
+			subnets: []infrav1.Subnet{
+				{
+					CIDR: "192.168.0.0/24",
+				},
+				{
+					CIDR: "2001:db8:2222:5555::/64",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid IPv4 and IPv6 subnets",
+			subnets: []infrav1.Subnet{
+				{
+					CIDR: "2001:db8:2222:5555::/64",
+				},
+				{
+					CIDR: "192.168.0.0/24",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "multiple IPv4 subnets",
+			subnets: []infrav1.Subnet{
+				{
+					CIDR: "192.168.0.0/24",
+				},
+				{
+					CIDR: "10.0.0.0/24",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "multiple IPv6 subnets",
+			subnets: []infrav1.Subnet{
+				{
+					CIDR: "2001:db8:2222:5555::/64",
+				},
+				{
+					CIDR: "2001:db8:2222:5555::/64",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid IP address",
+			subnets: []infrav1.Subnet{
+				{
+					CIDR: "192.168.0.0/24",
+				},
+				{
+					CIDR: "invalid",
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateSubnets(tt.subnets)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateSubnets() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit adds support to specify more than one existent subnet on the `OpenStackCluster`.

The existent `OpenStackClusterSpec.Subnet` field that would have the following format:

```yaml
  subnet:
    id: a532beb0-c73a-4b5d-af66-3ad05b73d063
```

is removed in favor of the following `OpenStackClusterSpec.Subnets`: 

```yaml
  subnets:
    - id: a532beb0-c73a-4b5d-af66-3ad05b73d063
```

conversion from v1 alpha8 clusters that use multiple subnets won't be allowed to older releases.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

  - [X] implement conversion
  - [X] includes documentation
  - [X] adds unit tests
