### PR TITLE
fix: skip port deletion when instances have no port

### DIFF
--- a/pkg/cloud/services/networking/port.go
+++ b/pkg/cloud/services/networking/port.go
@@ -315,6 +315,10 @@ func (s *Service) GarbageCollectErrorInstancesPort(eventObject runtime.Object, i
 			return fmt.Errorf("garbage collection of port %s failed, found %d ports with the same name", portName, len(portList))
 		}
 
+		if len(portList) == 0 {
+			continue
+		}
+
 		if err := s.DeletePort(eventObject, portList[0].ID); err != nil {
 			return err
 		}


### PR DESCRIPTION
fix https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/1805
**What this PR does / why we need it**:
This adds a condition in `GarbageCollectErrorInstancesPort` to avoid `index outOfRange` error when an instance has no port because of some reason (maybe the instance provisioning failed because of infra issue).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
