### PR TITLE
:bug: Fix potential panic during instance create

### DIFF
--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -348,7 +348,7 @@ func (s *Service) createInstanceImpl(eventObject runtime.Object, openStackCluste
 		return createdInstance.State() == infrav1.InstanceStateActive, nil
 	})
 	if err != nil {
-		record.Warnf(eventObject, "FailedCreateServer", "Failed to create server %s: %v", createdInstance.Name(), err)
+		record.Warnf(eventObject, "FailedCreateServer", "Failed to create server %s: %v", instanceSpec.Name, err)
 		return nil, err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The `FailedCreateServer` event was mistakenly calling the `Name()` method on the createdInstance instance, that could very well be unitialized since creation failed. Instead, log the event using the named passed in the instance spec.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1802

**Special notes for your reviewer**:


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests
