### PR TITLE
✨ Update CI to use OpenStack Bobcat

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,12 @@ This provider's versions are able to install and manage the following versions o
 
 This provider's versions are able to install Kubernetes to the following versions of OpenStack:
 
-|                                    | Queens | Rocky | Stein | Train | Ussuri | Victoria | Wallaby | Xena | Yoga |
-|------------------------------------| ------ | ----- | ----- | ----- | ------ | -------- | ------- | ---- | ---- |
-| OpenStack Provider v1alpha5 (v0.6) | +      | +     | +     | +     | +      | ✓        | ✓       | ✓    | ★    |
-| OpenStack Provider v1alpha6 (v0.7) | +      | +     | +     | +     | +      | ✓        | ✓       | ✓    | ★    |
-| OpenStack Provider v1alpha7 (v0.9) |        | +     | +     | +     | +      | ✓        | ✓       | ✓    | ★    |
-| OpenStack Provider v1alpha8        |        | +     | +     | +     | +      | ✓        | ✓       | ✓    | ★    |
+|                                    | Queens | Rocky | Stein | Train | Ussuri | Victoria | Wallaby | Xena | Yoga | Bobcat |
+|------------------------------------| ------ | ----- | ----- | ----- | ------ | -------- | ------- | ---- | ---- | ------ |
+| OpenStack Provider v1alpha5 (v0.6) | +      | +     | +     | +     | +      | ✓        | ✓       | ✓    | ✓    | ★      |
+| OpenStack Provider v1alpha6 (v0.7) | +      | +     | +     | +     | +      | ✓        | ✓       | ✓    | ✓    | ★      |
+| OpenStack Provider v1alpha7 (v0.9) |        | +     | +     | +     | +      | ✓        | ✓       | ✓    | ✓    | ★      |
+| OpenStack Provider v1alpha8        |        | +     | +     | +     | +      | ✓        | ✓       | ✓    | ✓    | ★      |
 
 Test status:
 

--- a/hack/ci/aws-project.sh
+++ b/hack/ci/aws-project.sh
@@ -23,8 +23,8 @@ function cloud_init {
   AWS_ZONE=${AWS_ZONE:-"eu-central-1a"}
   # AMIs:
   # * capa-ami-ubuntu-20.04-1.20.4-00-1613898574 id: ami-0120656d38c206057
-  # * ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210223 id: ami-0767046d1677be5a0
-  AWS_AMI=${AWS_AMI:-"ami-0767046d1677be5a0"}
+  # * ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20231207 id: ami-05d47d29a4c2d19e1
+  AWS_AMI=${AWS_AMI:-"ami-05d47d29a4c2d19e1"}
   # Choose via: https://eu-central-1.console.aws.amazon.com/ec2/v2/home?region=eu-central-1#InstanceTypes:
   AWS_MACHINE_TYPE=${AWS_MACHINE_TYPE:-"c5.metal"}
   AWS_NETWORK_NAME=${AWS_NETWORK_NAME:-"${CLUSTER_NAME}-mynetwork"}

--- a/hack/ci/cloud-init/controller.yaml.tpl
+++ b/hack/ci/cloud-init/controller.yaml.tpl
@@ -12,9 +12,6 @@
     VERBOSE=True
     LOG_COLOR=True
 
-    # Neutron
-    enable_plugin neutron https://github.com/openstack/neutron stable/${OPENSTACK_RELEASE}
-
     # Octavia
     enable_plugin octavia https://github.com/openstack/octavia stable/${OPENSTACK_RELEASE}
     enable_plugin octavia-dashboard https://github.com/openstack/octavia-dashboard stable/${OPENSTACK_RELEASE}
@@ -35,9 +32,17 @@
     ENABLED_SERVICES+=,g-api
 
     # Neutron
-    ENABLED_SERVICES+=,neutron-api,neutron-agent,neutron-dhcp,neutron-l3,neutron-trunk
+    enable_plugin neutron https://github.com/openstack/neutron stable/${OPENSTACK_RELEASE}
+    ENABLED_SERVICES+=,q-svc,neutron-trunk,ovn-controller,ovs-vswitchd,ovn-northd,ovsdb-server,q-ovn-metadata-agent
+    
+    DISABLED_SERVICES=q-agt,q-dhcp,q-l3,q-meta,q-metering
+    PUBLIC_BRIDGE_MTU=${MTU}
+    ENABLE_CHASSIS_AS_GW="True"
+    OVN_DBS_LOG_LEVEL="dbg"
+    Q_ML2_PLUGIN_MECHANISM_DRIVERS="ovn,logger"
+    OVN_L3_CREATE_PUBLIC_NETWORK="True"
+    Q_AGENT="ovn"
 
-    ENABLED_SERVICES+=,neutron-metadata-agent,neutron-qos
     # Octavia
     ENABLED_SERVICES+=,octavia,o-api,o-cw,o-hm,o-hk,o-da
 
@@ -50,6 +55,7 @@
 
     # Additional services
     ENABLED_SERVICES+=${OPENSTACK_ADDITIONAL_SERVICES}
+    DISABLED_SERVICES+=${OPENSTACK_DISABLED_SERVICES}
 
     # Don't download default images, just our test images
     DOWNLOAD_DEFAULT_IMAGES=False
@@ -87,13 +93,18 @@
     [DEFAULT]
     storage_availability_zone = ${PRIMARY_AZ}
 
-    [[post-config|/$NEUTRON_CORE_PLUGIN_CONF]]
-    [ml2]
-    path_mtu = ${MTU}
-
     [[post-config|$NEUTRON_CONF]]
     [DEFAULT]
+    global_physnet_mtu = ${MTU}
     service_plugins = trunk,router
+
+    # The following are required for OVN to set default DNS when a subnet is
+    # created without specifying DNS servers.
+    # Not specifying these will result in the default DNS servers being set to
+    # 127.0.0.53 which might be problematic in some environments.
+    [[post-config|/$Q_PLUGIN_CONF_FILE]]
+    [ovn]
+    dns_servers = ${OPENSTACK_DNS_NAMESERVERS}
 - path: /tmp/register-worker.sh
   permissions: "0755"
   content: |

--- a/hack/ci/cloud-init/controller.yaml.tpl
+++ b/hack/ci/cloud-init/controller.yaml.tpl
@@ -176,7 +176,7 @@
     openstack flavor delete m1.small
     openstack flavor create --ram 4192 --disk 20 --ephemeral 5 --vcpus 2 --public --id 2 m1.small --property hw_rng:allowed='True'
     openstack flavor delete m1.medium
-    openstack flavor create --ram 6144 --disk 20 --ephemeral 5 --vcpus 4 --public --id 3 m1.medium --property hw_rng:allowed='True'
+    openstack flavor create --ram 6144 --disk 20 --ephemeral 5 --vcpus 2 --public --id 3 m1.medium --property hw_rng:allowed='True'
 
     # Adjust the CPU quota
     openstack quota set --cores 32 demo

--- a/hack/ci/cloud-init/worker.yaml.tpl
+++ b/hack/ci/cloud-init/worker.yaml.tpl
@@ -25,15 +25,23 @@
     DATABASE_TYPE=mysql
     DATABASE_HOST=$SERVICE_HOST
 
+    # Nova
+    ENABLED_SERVICES=n-cpu,placement-client,c-vol
+    VOLUME_BACKING_FILE_SIZE=100G
+
     # Neutron
     enable_plugin neutron https://github.com/openstack/neutron stable/${OPENSTACK_RELEASE}
-
-    # Nova
-    ENABLED_SERVICES=n-cpu,placement-client,c-vol,neutron-agent
-    VOLUME_BACKING_FILE_SIZE=100G
+    ENABLED_SERVICES+=,ovn-controller,ovs-vswitchd,ovsdb-server,q-fake,q-ovn-metadata-agent
+    DISABLED_SERVICES=q-svc,horizon,ovn-northd,q-agt,q-dhcp,q-l3,q-meta,q-metering,q-vpn
+    PUBLIC_BRIDGE_MTU=${MTU}
+    ENABLE_CHASSIS_AS_GW="False"
+    OVN_DBS_LOG_LEVEL="dbg"
+    Q_ML2_PLUGIN_MECHANISM_DRIVERS="ovn,logger"
+    Q_AGENT="ovn"
 
     # Additional services
     ENABLED_SERVICES+=${OPENSTACK_ADDITIONAL_SERVICES}
+    DISABLED_SERVICES+=${OPENSTACK_DISABLED_SERVICES}
 
     [[post-config|$NOVA_CONF]]
     [DEFAULT]
@@ -43,9 +51,9 @@
     [DEFAULT]
     storage_availability_zone = ${SECONDARY_AZ}
 
-    [[post-config|/$NEUTRON_CORE_PLUGIN_CONF]]
-    [ml2]
-    path_mtu = ${MTU}
+    [[post-config|$NEUTRON_CONF]]
+    [DEFAULT]
+    global_physnet_mtu = ${MTU}
 - path: /root/devstack.sh
   permissions: "0755"
   content: |

--- a/hack/ci/gce-project.sh
+++ b/hack/ci/gce-project.sh
@@ -95,7 +95,7 @@ function create_vm {
         --zone "$GCP_ZONE" \
         --enable-nested-virtualization \
         --image-project ubuntu-os-cloud \
-        --image-family ubuntu-2004-lts \
+        --image-family ubuntu-2204-lts \
         --boot-disk-size 200G \
         --boot-disk-type pd-ssd \
         --can-ip-forward \

--- a/hack/ci/openstack.sh
+++ b/hack/ci/openstack.sh
@@ -30,7 +30,7 @@ function cloud_init {
     OPENSTACK_SUBNET_NAME=${OPENSTACK_SUBNET_NAME:-${CLUSTER_NAME}-subnet}
     OPENSTACK_SECGROUP_NAME=${OPENSTACK_SECGROUP_NAME:-${CLUSTER_NAME}-secgroup}
     OPENSTACK_ROUTER_NAME=${OPENSTACK_ROUTER_NAME:-${CLUSTER_NAME}-router}
-    OPENSTACK_IMAGE_NAME=${OPENSTACK_IMAGE_NAME:-ubuntu-2004-lts}
+    OPENSTACK_IMAGE_NAME=${OPENSTACK_IMAGE_NAME:-ubuntu-2204-lts}
 
     OPENSTACK_FLAVOR=${OPENSTACK_FLAVOR:-m1.xlarge}
     OPENSTACK_FLAVOR_controller=${OPENSTACK_FLAVOR_controller:-$OPENSTACK_FLAVOR}
@@ -88,9 +88,9 @@ function init_infrastructure() {
     # We don't tag the image with the cluster name as we expect it to be shared
     if ! imageid=$(openstack image show "$OPENSTACK_IMAGE_NAME" -f value -c id 2>/dev/null)
     then
-        curl -o /tmp/ubuntu-2004.qcow2 https://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64.img
-        imageid=$(openstack image create --disk-format qcow2 --file /tmp/ubuntu-2004.qcow2 "$OPENSTACK_IMAGE_NAME" -f value -c id)
-        rm /tmp/ubuntu-2004.qcow2
+        curl -o /tmp/ubuntu-2204.qcow2 https://cloud-images.ubuntu.com/releases/jammy/release/ubuntu-22.04-server-cloudimg-amd64.img
+        imageid=$(openstack image create --disk-format qcow2 --file /tmp/ubuntu-2204.qcow2 "$OPENSTACK_IMAGE_NAME" -f value -c id)
+        rm /tmp/ubuntu-2204.qcow2
     fi
 }
 

--- a/scripts/ci-conformance.sh
+++ b/scripts/ci-conformance.sh
@@ -47,7 +47,7 @@ trap cleanup EXIT
 
 apt-get update -y
 # Install requests module explicitly for HTTP calls.
-# libffi required for pip install cffi (yoga dependency)
+# libffi required for pip install cffi (bobcat dependency)
 apt-get install -y python3-requests libffi-dev
 rm -rf /var/lib/apt/lists/*
 

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -48,7 +48,7 @@ trap cleanup EXIT
 
 apt-get update -y
 # Install requests module explicitly for HTTP calls.
-# libffi required for pip install cffi (yoga dependency)
+# libffi required for pip install cffi (bobcat dependency)
 apt-get install -y python3-requests libffi-dev
 rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Update devstack configuration to deploy OpenStack Bobcat with OVN on Ubuntu 22.04.
