### PR TITLE
fix --short flag is removed issue for CI

### DIFF
--- a/hack/ensure-kubectl.sh
+++ b/hack/ensure-kubectl.sh
@@ -40,7 +40,7 @@ verify_kubectl_version() {
   fi
 
   local kubectl_version
-  IFS=" " read -ra kubectl_version <<< "$(kubectl version --client --short)"
+  IFS=" " read -ra kubectl_version <<< "$(kubectl version --client)"
   if [[ "${MINIMUM_KUBECTL_VERSION}" != $(echo -e "${MINIMUM_KUBECTL_VERSION}\n${kubectl_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) ]]; then
     cat <<EOF
 Detected kubectl version: ${kubectl_version[2]}.

--- a/scripts/ci-conformance.sh
+++ b/scripts/ci-conformance.sh
@@ -45,13 +45,11 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Ensure that python3-pip is installed.
 apt-get update -y
-apt-get install -y python3-pip
+# Install requests module explicitly for HTTP calls.
+# libffi required for pip install cffi (yoga dependency)
+apt-get install -y python3-requests libffi-dev
 rm -rf /var/lib/apt/lists/*
-
-# Install/upgrade pip and requests module explicitly for HTTP calls.
-python3 -m pip install --upgrade pip requests
 
 # If BOSKOS_HOST is set then acquire a resource of type ${RESOURCE_TYPE} from Boskos.
 if [ -n "${BOSKOS_HOST:-}" ]; then

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -46,13 +46,11 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Ensure that python3-pip is installed.
 apt-get update -y
-apt-get install -y python3-pip
+# Install requests module explicitly for HTTP calls.
+# libffi required for pip install cffi (yoga dependency)
+apt-get install -y python3-requests libffi-dev
 rm -rf /var/lib/apt/lists/*
-
-# Install/upgrade pip and requests module explicitly for HTTP calls.
-python3 -m pip install --upgrade pip requests
 
 # If BOSKOS_HOST is set then acquire a resource of type ${RESOURCE_TYPE} from Boskos.
 if [ -n "${BOSKOS_HOST:-}" ]; then


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
fix CI to avoid --short flag  for kubectl command

https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1718/files
has a bigger fix but not sure whether it has side effect, so to unblock https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1808
try fix minimal place
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
