### PR TITLE
🐛 Move flatcar-sysext to v1alpha8

### DIFF
--- a/kustomize/v1alpha8/flatcar-sysext/kustomization.yaml
+++ b/kustomize/v1alpha8/flatcar-sysext/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../default
+
+patches:
+- path: patch-flatcar.yaml

--- a/kustomize/v1alpha8/flatcar-sysext/patch-flatcar.yaml
+++ b/kustomize/v1alpha8/flatcar-sysext/patch-flatcar.yaml
@@ -1,0 +1,185 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha8
+kind: OpenStackCluster
+metadata:
+  name: ${CLUSTER_NAME}
+spec:
+  apiServerLoadBalancer:
+    $patch: delete
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  kubeadmConfigSpec:
+    joinConfiguration:
+      nodeRegistration:
+        name: $${COREOS_OPENSTACK_HOSTNAME}
+        kubeletExtraArgs:
+          provider-id: null
+    initConfiguration:
+      nodeRegistration:
+        name: $${COREOS_OPENSTACK_HOSTNAME}
+        kubeletExtraArgs:
+          # Fixme(lentzi90): This is here just to override the value set in the default
+          # kustomization. It will be replaced with a value that works for flatcar in
+          # https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1564
+          provider-id: null
+    format: ignition
+    ignition:
+      containerLinuxConfig:
+        additionalConfig: |
+          storage:
+            links:
+              - path: /etc/extensions/kubernetes.raw
+                hard: false
+                target: /opt/extensions/kubernetes/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
+            files:
+              - path: /etc/sysupdate.kubernetes.d/kubernetes-${KUBERNETES_VERSION%.*}.conf
+                mode: 0644
+                contents:
+                  remote:
+                    url: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-${KUBERNETES_VERSION%.*}.conf
+              - path: /etc/sysupdate.d/noop.conf
+                mode: 0644
+                contents:
+                  remote:
+                    url: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
+              - path: /opt/extensions/kubernetes/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
+                contents:
+                  remote:
+                    url: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
+          systemd:
+            units:
+              - name: systemd-sysupdate.service
+                dropins:
+                  - name: kubernetes.conf
+                    contents: |
+                      [Service]
+                      ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/kubernetes.raw > /tmp/kubernetes"
+                      ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C kubernetes update
+                      ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/kubernetes.raw > /tmp/kubernetes-new"
+                      ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/kubernetes /tmp/kubernetes-new; then touch /run/reboot-required; fi"
+              - name: update-engine.service
+                # Set this to 'false' if you want to enable Flatcar auto-update
+                mask: ${FLATCAR_DISABLE_AUTO_UPDATE:=true}
+              - name: locksmithd.service
+                # NOTE: To coordinate the node reboot in this context, we recommend to use Kured.
+                mask: true
+              - name: systemd-sysupdate.timer
+                # Set this to 'true' if you want to enable the Kubernetes auto-update.
+                # NOTE: Only patches version will be pulled.
+                enabled: false
+              - name: coreos-metadata-sshkeys@.service
+                enabled: true
+              - name: kubeadm.service
+                enabled: true
+                dropins:
+                  - name: 10-flatcar.conf
+                    contents: |
+                      [Unit]
+                      Requires=containerd.service coreos-metadata.service
+                      After=containerd.service coreos-metadata.service
+                      [Service]
+                      EnvironmentFile=/run/metadata/flatcar
+    preKubeadmCommands:
+      - export COREOS_OPENSTACK_HOSTNAME=$${COREOS_OPENSTACK_HOSTNAME%.*}
+      - envsubst < /etc/kubeadm.yml > /etc/kubeadm.yml.tmp
+      - mv /etc/kubeadm.yml.tmp /etc/kubeadm.yml
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          name: $${COREOS_OPENSTACK_HOSTNAME}
+          kubeletExtraArgs:
+            # Fixme(lentzi90): This is here just to override the value set in the default
+            # kustomization. It will be replaced with a value that works for flatcar in
+            # https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1564
+            provider-id: null
+      preKubeadmCommands:
+        - export COREOS_OPENSTACK_HOSTNAME=$${COREOS_OPENSTACK_HOSTNAME%.*}
+        - envsubst < /etc/kubeadm.yml > /etc/kubeadm.yml.tmp
+        - mv /etc/kubeadm.yml.tmp /etc/kubeadm.yml
+      format: ignition
+      ignition:
+        containerLinuxConfig:
+          additionalConfig: |
+            storage:
+              links:
+                - path: /etc/extensions/kubernetes.raw
+                  hard: false
+                  target: /opt/extensions/kubernetes/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
+              files:
+                - path: /etc/sysupdate.kubernetes.d/kubernetes-${KUBERNETES_VERSION%.*}.conf
+                  mode: 0644
+                  contents:
+                    remote:
+                      url: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-${KUBERNETES_VERSION%.*}.conf
+                - path: /etc/sysupdate.d/noop.conf
+                  mode: 0644
+                  contents:
+                    remote:
+                      url: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
+                - path: /opt/extensions/kubernetes/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
+                  contents:
+                    remote:
+                      url: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
+            systemd:
+              units:
+                - name: systemd-sysupdate.service
+                  dropins:
+                    - name: kubernetes.conf
+                      contents: |
+                        [Service]
+                        ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/kubernetes.raw > /tmp/kubernetes"
+                        ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C kubernetes update
+                        ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/kubernetes.raw > /tmp/kubernetes-new"
+                        ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/kubernetes /tmp/kubernetes-new; then touch /run/reboot-required; fi"
+                - name: update-engine.service
+                  # Set this to 'false' if you want to enable Flatcar auto-update
+                  mask: ${FLATCAR_DISABLE_AUTO_UPDATE:=true}
+                - name: locksmithd.service
+                  # NOTE: To coordinate the node reboot in this context, we recommend to use Kured.
+                  mask: true
+                - name: systemd-sysupdate.timer
+                  # Set this to 'true' if you want to enable the Kubernetes auto-update.
+                  # NOTE: Only patches version will be pulled.
+                  enabled: false
+                - name: coreos-metadata-sshkeys@.service
+                  enabled: true
+                - name: kubeadm.service
+                  enabled: true
+                  dropins:
+                    - name: 10-flatcar.conf
+                      contents: |
+                        [Unit]
+                        Requires=containerd.service coreos-metadata.service
+                        After=containerd.service coreos-metadata.service
+                        [Service]
+                        EnvironmentFile=/run/metadata/flatcar
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha8
+kind: OpenStackMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+spec:
+  template:
+    spec:
+      image: ${FLATCAR_IMAGE_NAME}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha8
+kind: OpenStackMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+spec:
+  template:
+    spec:
+      image: ${FLATCAR_IMAGE_NAME}

--- a/templates/cluster-template-flatcar-sysext.yaml
+++ b/templates/cluster-template-flatcar-sysext.yaml
@@ -98,7 +98,7 @@ spec:
     kind: KubeadmControlPlane
     name: ${CLUSTER_NAME}-control-plane
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha8
     kind: OpenStackCluster
     name: ${CLUSTER_NAME}
 ---
@@ -121,7 +121,7 @@ spec:
       clusterName: ${CLUSTER_NAME}
       failureDomain: ${OPENSTACK_FAILURE_DOMAIN}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha8
         kind: OpenStackMachineTemplate
         name: ${CLUSTER_NAME}-md-0
       version: ${KUBERNETES_VERSION}
@@ -213,13 +213,13 @@ spec:
     - mv /etc/kubeadm.yml.tmp /etc/kubeadm.yml
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
+      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha8
       kind: OpenStackMachineTemplate
       name: ${CLUSTER_NAME}-control-plane
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   version: ${KUBERNETES_VERSION}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha8
 kind: OpenStackCluster
 metadata:
   name: ${CLUSTER_NAME}
@@ -234,7 +234,7 @@ spec:
   managedSecurityGroups: true
   nodeCidr: 10.6.0.0/24
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha8
 kind: OpenStackMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-control-plane
@@ -249,7 +249,7 @@ spec:
       image: ${FLATCAR_IMAGE_NAME}
       sshKeyName: ${OPENSTACK_SSH_KEY_NAME}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha8
 kind: OpenStackMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0

--- a/test/e2e/data/kustomize/flatcar-sysext/kustomization.yaml
+++ b/test/e2e/data/kustomize/flatcar-sysext/kustomization.yaml
@@ -1,6 +1,6 @@
 ---
 resources:
-- ../../../../../kustomize/v1alpha7/flatcar-sysext
+- ../../../../../kustomize/v1alpha8/flatcar-sysext
 
 components:
 - ../common-patches/cni


### PR DESCRIPTION
This was added via v1alpha7 but the latest api is v1alpha8 and to keep
our CI consistent we will move the manifests to v1alpha8.
