### PR TITLE
✨ Add flags for configuring rate limits

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,6 +69,8 @@ var (
 	openStackClusterConcurrency int
 	openStackMachineConcurrency int
 	syncPeriod                  time.Duration
+	restConfigQPS               float32
+	restConfigBurst             int
 	webhookPort                 int
 	webhookCertDir              string
 	healthAddr                  string
@@ -128,6 +130,12 @@ func InitFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&syncPeriod, "sync-period", 10*time.Minute,
 		"The minimum interval at which watched resources are reconciled (e.g. 15m)")
 
+	fs.Float32Var(&restConfigQPS, "kube-api-qps", 20,
+		"Maximum queries per second from the controller client to the Kubernetes API server. Defaults to 20")
+
+	fs.IntVar(&restConfigBurst, "kube-api-burst", 30,
+		"Maximum number of queries that should be allowed in one burst from the controller client to the Kubernetes API server. Defaults to 30")
+
 	fs.IntVar(&webhookPort, "webhook-port", 9443,
 		"Webhook Server port")
 
@@ -181,6 +189,8 @@ func main() {
 	if err != nil {
 		setupLog.Error(err, "unable to get kubeconfig")
 	}
+	cfg.QPS = restConfigQPS
+	cfg.Burst = restConfigBurst
 
 	var caCerts []byte
 	if caCertsPath != "" {


### PR DESCRIPTION
Our controller have built-in rate limits. It throttles itself if it hits this limit. So far it has not been possible to configure these limits. This commit adds flags to the controller for setting both the QPS and the burst for the rate limits. The default remains the same as before (20 QPS, 30 burst).

Copied from https://github.com/kubernetes-sigs/cluster-api/pull/8579

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
<sub>Tobias Giese <tobias.giese@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [legal info/Impressum](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)</sub>