### PR TITLE
🐛 fix: skip port deletion when instances have no port

### DIFF
--- a/pkg/cloud/services/networking/port.go
+++ b/pkg/cloud/services/networking/port.go
@@ -315,6 +315,10 @@ func (s *Service) GarbageCollectErrorInstancesPort(eventObject runtime.Object, i
 			return fmt.Errorf("garbage collection of port %s failed, found %d ports with the same name", portName, len(portList))
 		}
 
+		if len(portList) == 0 {
+			continue
+		}
+
 		if err := s.DeletePort(eventObject, portList[0].ID); err != nil {
 			return err
 		}

--- a/pkg/cloud/services/networking/port_test.go
+++ b/pkg/cloud/services/networking/port_test.go
@@ -588,6 +588,19 @@ func Test_GarbageCollectErrorInstancesPort(t *testing.T) {
 				{},
 			},
 			wantErr: false,
+		}, {
+			name: "garbage collects no ports in an instance",
+			expect: func(m *mock.MockNetworkClientMockRecorder) {
+				o1 := ports.ListOpts{
+					Name: portName1,
+				}
+				p1 := []ports.Port{}
+				m.ListPort(o1).Return(p1, nil)
+			},
+			portOpts: []infrav1.PortOpts{
+				{},
+			},
+			wantErr: false,
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds a condition in GarbageCollectErrorInstancesPort to avoid index outOfRange error when an instance has no port because of some reason (maybe the instance provisioning failed because of infra issue).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1805

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- if necessary:
  - [x] adds unit tests

/hold