### PR TITLE
e2e: remove "allow-all-in-cluster-traffic" patch

### DIFF
--- a/test/e2e/data/kustomize/common-patches/ccm/kustomization.yaml
+++ b/test/e2e/data/kustomize/common-patches/ccm/kustomization.yaml
@@ -8,10 +8,6 @@ resources:
 
 patches:
 - target:
-    kind: OpenStackCluster
-    name: \${CLUSTER_NAME}
-  path: patch-allow-all-in-cluster-traffic.yaml
-- target:
     kind: KubeadmControlPlane
     name: \${CLUSTER_NAME}-control-plane
   path: patch-ccm-cloud-config.yaml

--- a/test/e2e/data/kustomize/common-patches/ccm/patch-allow-all-in-cluster-traffic.yaml
+++ b/test/e2e/data/kustomize/common-patches/ccm/patch-allow-all-in-cluster-traffic.yaml
@@ -1,4 +1,0 @@
----
-- op: add
-  path: /spec/allowAllInClusterTraffic
-  value: true


### PR DESCRIPTION
The default rules should be sufficient for Calico which is used by e2e
clusters; let's remove the allow-all-in-cluster-traffic patch which
should not be needed.
