### PR TITLE
✨ Modify OpenStackCluster.Spec.Network API

### DIFF
--- a/docs/book/src/topics/crd-changes/v1alpha7-to-v1alpha8.md
+++ b/docs/book/src/topics/crd-changes/v1alpha7-to-v1alpha8.md
@@ -243,3 +243,7 @@ Now the user needs to request creation of the security group rules by using the 
 
 Note that when upgrading from a previous version, the Calico CNI security group rules will be added automatically to
 allow backwards compatibility if `allowAllInClusterTraffic` is set to false.
+
+#### ⚠️ Change to network
+
+In v1alpha8, when the `OpenStackCluster.Spec.Network` is not defined, the `Subnets` are now used to identify the `Network`.

--- a/pkg/cloud/services/networking/network.go
+++ b/pkg/cloud/services/networking/network.go
@@ -386,14 +386,11 @@ func getNetworkName(clusterName string) string {
 	return fmt.Sprintf("%s-cluster-%s", networkPrefix, clusterName)
 }
 
-// ConvertOpenStackSubnetToCAPOSubnet converts an OpenStack subnet to a capo subnet and adds to a slice.
-// It returns the slice with the converted subnet.
-func (s *Service) ConvertOpenStackSubnetToCAPOSubnet(subnets []infrav1.Subnet, filteredSubnet *subnets.Subnet) []infrav1.Subnet {
-	subnets = append(subnets, infrav1.Subnet{
-		ID:   filteredSubnet.ID,
-		Name: filteredSubnet.Name,
-		CIDR: filteredSubnet.CIDR,
-		Tags: filteredSubnet.Tags,
-	})
-	return subnets
+// GetNetworkByID retrieves network by the ID.
+func (s *Service) GetNetworkByID(networkID string) (*networks.Network, error) {
+	network, err := s.client.GetNetwork(networkID)
+	if err != nil {
+		return &networks.Network{}, err
+	}
+	return network, nil
 }

--- a/pkg/cloud/services/networking/network_test.go
+++ b/pkg/cloud/services/networking/network_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package networking
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -25,7 +24,6 @@ import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/pointer"
 
@@ -420,45 +418,5 @@ func Test_ReconcileExternalNetwork(t *testing.T) {
 			}
 			g.Expect(tt.openStackCluster).To(Equal(tt.want))
 		})
-	}
-}
-
-func Test_ConvertOpenStackSubnetToCAPOSubnet(t *testing.T) {
-	caposubnets := []infrav1.Subnet{
-		{
-			ID:   "subnet1",
-			Name: "subnet1",
-			CIDR: "10.0.0.0/24",
-			Tags: []string{"tag1", "tag2"},
-		},
-	}
-
-	filteredSubnet := &subnets.Subnet{
-		ID:   "subnet2",
-		Name: "subnet2",
-		CIDR: "192.168.0.0/24",
-		Tags: []string{"tag3", "tag4"},
-	}
-
-	s := Service{}
-	result := s.ConvertOpenStackSubnetToCAPOSubnet(caposubnets, filteredSubnet)
-
-	expected := []infrav1.Subnet{
-		{
-			ID:   "subnet1",
-			Name: "subnet1",
-			CIDR: "10.0.0.0/24",
-			Tags: []string{"tag1", "tag2"},
-		},
-		{
-			ID:   "subnet2",
-			Name: "subnet2",
-			CIDR: "192.168.0.0/24",
-			Tags: []string{"tag3", "tag4"},
-		},
-	}
-
-	if !reflect.DeepEqual(result, expected) {
-		t.Errorf("ConvertOpenStackSubnetToCAPOSubnet() = %v, want %v", result, expected)
 	}
 }


### PR DESCRIPTION
For the BYO scenario, when the `OpenStackCluster.Spec.Network`
is not specified the query to OpenStack will return all the
Networks available in the cloud and fail the reconciliation.
To avoid this, if any Subnets were specified under
`OpenStackCluster.Spec.Subnets` this can used to identify
which Network to use.

Note, this pattern to infer a field based on another field has already been used by the
`OpenStackCluster.Spec.Subnets` and also when no Network is defined in a Port.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

  - [x] includes documentation
  - [x] adds unit tests

/hold
