### PR TITLE
🐛 controllers: do not return a RequeueAfter and an error at the same time

### DIFF
--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -76,7 +76,7 @@ const (
 // +kubebuilder:rbac:groups="",resources=secrets;,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch
 
-func (r *OpenStackMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
+func (r *OpenStackMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, reterr error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	// Fetch the OpenStackMachine instance.
@@ -137,6 +137,7 @@ func (r *OpenStackMachineReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// Always patch the openStackMachine when exiting this function so we can persist any OpenStackMachine changes.
 	defer func() {
 		if err := patchMachine(ctx, patchHelper, openStackMachine, machine); err != nil {
+			result = ctrl.Result{}
 			reterr = kerrors.NewAggregate([]error{reterr, err})
 		}
 	}()


### PR DESCRIPTION
**What this PR does / why we need it**:
Since controller-runtime kubernetes-sigs/controller-runtime#2451, a warning will be logged if a controller returns an error and a non-zero result (i.e. a result with a RequeueAfter).
It adjusts the OpenStackCluster controller to return errors first, as an error itself will already trigger a reconciliation (with exponential backoff).


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1838
