### PR TITLE
🐛 api: openstackcluster.status default to false

### DIFF
--- a/api/v1alpha8/openstackcluster_types.go
+++ b/api/v1alpha8/openstackcluster_types.go
@@ -167,6 +167,8 @@ type OpenStackClusterSpec struct {
 
 // OpenStackClusterStatus defines the observed state of OpenStackCluster.
 type OpenStackClusterStatus struct {
+	// Ready is true when the cluster infrastructure is ready.
+	// +kubebuilder:default=false
 	Ready bool `json:"ready"`
 
 	// Network contains information about the created OpenStack Network.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -5849,6 +5849,8 @@ spec:
                 - name
                 type: object
               ready:
+                default: false
+                description: Ready is true when the cluster infrastructure is ready.
                 type: boolean
               router:
                 description: Router describes the default cluster router


### PR DESCRIPTION
**What this PR does / why we need it**:

When a reconcile loop for the bastion is requeued, we have
this error:
```
OpenStackCluster.infrastructure.cluster.x-k8s.io \"cluster-e2e-rha0r3\" is invalid: ready: Required value"
```

The OpenStackMachine.Status is false by default now, so if the status
has not been set to anything, patching the object will not fail with the
previous error.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1841


**TODOs**:

- [X] squashed commits
