### PR TITLE
🌱 Decrease number of machines in e2e tests

### DIFF
--- a/test/e2e/suites/e2e/e2e_test.go
+++ b/test/e2e/suites/e2e/e2e_test.go
@@ -85,7 +85,7 @@ var _ = Describe("e2e tests [PR-Blocking]", func() {
 			shared.Logf("Creating a cluster")
 			clusterName := fmt.Sprintf("cluster-%s", namespace.Name)
 			configCluster := defaultConfigCluster(clusterName, namespace.Name)
-			configCluster.ControlPlaneMachineCount = pointer.Int64(3)
+			configCluster.ControlPlaneMachineCount = pointer.Int64(1)
 			configCluster.WorkerMachineCount = pointer.Int64(1)
 			configCluster.Flavor = shared.FlavorDefault
 			createCluster(ctx, configCluster, clusterResources)
@@ -103,7 +103,7 @@ var _ = Describe("e2e tests [PR-Blocking]", func() {
 				Namespace:   namespace.Name,
 			})
 			Expect(workerMachines).To(HaveLen(1))
-			Expect(controlPlaneMachines).To(HaveLen(3))
+			Expect(controlPlaneMachines).To(HaveLen(1))
 
 			shared.Logf("Waiting for worker nodes to be in Running phase")
 			statusChecks := []framework.MachineStatusCheck{framework.MachinePhaseCheck(string(clusterv1.MachinePhaseRunning))}
@@ -118,20 +118,20 @@ var _ = Describe("e2e tests [PR-Blocking]", func() {
 
 			waitForDaemonSetRunning(ctx, workloadCluster.GetClient(), "kube-system", "openstack-cloud-controller-manager")
 
-			waitForNodesReadyWithoutCCMTaint(ctx, workloadCluster.GetClient(), 4)
+			waitForNodesReadyWithoutCCMTaint(ctx, workloadCluster.GetClient(), 2)
 
 			// Tag: clusterName is declared on OpenStackCluster and gets propagated to all machines
 			// except the bastion host
 			allServers, err := shared.DumpOpenStackServers(e2eCtx, servers.ListOpts{Tags: clusterName})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(allServers).To(HaveLen(4))
+			Expect(allServers).To(HaveLen(2))
 
 			// When listing servers with multiple tags, nova api requires a single, comma-separated string
 			// with all the tags
 			controlPlaneTags := fmt.Sprintf("%s,%s", clusterName, "control-plane")
 			controlPlaneServers, err := shared.DumpOpenStackServers(e2eCtx, servers.ListOpts{Tags: controlPlaneTags})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(controlPlaneServers).To(HaveLen(3))
+			Expect(controlPlaneServers).To(HaveLen(1))
 
 			machineTags := fmt.Sprintf("%s,%s", clusterName, "machine")
 			machineServers, err := shared.DumpOpenStackServers(e2eCtx, servers.ListOpts{Tags: machineTags})
@@ -164,7 +164,7 @@ var _ = Describe("e2e tests [PR-Blocking]", func() {
 			shared.Logf("Creating a cluster")
 			clusterName := fmt.Sprintf("cluster-%s", namespace.Name)
 			configCluster := defaultConfigCluster(clusterName, namespace.Name)
-			configCluster.ControlPlaneMachineCount = pointer.Int64(3)
+			configCluster.ControlPlaneMachineCount = pointer.Int64(1)
 			configCluster.WorkerMachineCount = pointer.Int64(1)
 			configCluster.Flavor = shared.FlavorFlatcar
 			createCluster(ctx, configCluster, clusterResources)
@@ -182,7 +182,7 @@ var _ = Describe("e2e tests [PR-Blocking]", func() {
 				Namespace:   namespace.Name,
 			})
 			Expect(workerMachines).To(HaveLen(1))
-			Expect(controlPlaneMachines).To(HaveLen(3))
+			Expect(controlPlaneMachines).To(HaveLen(1))
 
 			shared.Logf("Waiting for worker nodes to be in Running phase")
 			statusChecks := []framework.MachineStatusCheck{framework.MachinePhaseCheck(string(clusterv1.MachinePhaseRunning))}
@@ -197,7 +197,7 @@ var _ = Describe("e2e tests [PR-Blocking]", func() {
 
 			waitForDaemonSetRunning(ctx, workloadCluster.GetClient(), "kube-system", "openstack-cloud-controller-manager")
 
-			waitForNodesReadyWithoutCCMTaint(ctx, workloadCluster.GetClient(), 4)
+			waitForNodesReadyWithoutCCMTaint(ctx, workloadCluster.GetClient(), 2)
 		})
 	})
 
@@ -209,7 +209,7 @@ var _ = Describe("e2e tests [PR-Blocking]", func() {
 			shared.Logf("Creating a cluster")
 			clusterName := fmt.Sprintf("cluster-%s", namespace.Name)
 			configCluster := defaultConfigCluster(clusterName, namespace.Name)
-			configCluster.ControlPlaneMachineCount = pointer.Int64(3)
+			configCluster.ControlPlaneMachineCount = pointer.Int64(1)
 			configCluster.WorkerMachineCount = pointer.Int64(1)
 			configCluster.Flavor = shared.FlavorFlatcarSysext
 			createCluster(ctx, configCluster, clusterResources)
@@ -227,7 +227,7 @@ var _ = Describe("e2e tests [PR-Blocking]", func() {
 				Namespace:   namespace.Name,
 			})
 			Expect(workerMachines).To(HaveLen(1))
-			Expect(controlPlaneMachines).To(HaveLen(3))
+			Expect(controlPlaneMachines).To(HaveLen(1))
 
 			shared.Logf("Waiting for worker nodes to be in Running phase")
 			statusChecks := []framework.MachineStatusCheck{framework.MachinePhaseCheck(string(clusterv1.MachinePhaseRunning))}
@@ -242,7 +242,7 @@ var _ = Describe("e2e tests [PR-Blocking]", func() {
 
 			waitForDaemonSetRunning(ctx, workloadCluster.GetClient(), "kube-system", "openstack-cloud-controller-manager")
 
-			waitForNodesReadyWithoutCCMTaint(ctx, workloadCluster.GetClient(), 4)
+			waitForNodesReadyWithoutCCMTaint(ctx, workloadCluster.GetClient(), 2)
 		})
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The e2e tests are currently very unstable. I suspect lack of resources in the devstack to be the issue. In an attempt to solve this, the number of control-plane nodes are reduced in this commit. Now only the multi-az test will use 3 CP. The rest will have 1 CP only.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
