### PR TITLE
🐛Fix a stacktrace in LB logic by removing listener name from an error message when not set

### DIFF
--- a/pkg/cloud/services/loadbalancer/loadbalancer.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer.go
@@ -285,9 +285,10 @@ func (s *Service) getOrUpdateAllowedCIDRS(openStackCluster *infrav1.OpenStackClu
 			AllowedCIDRs: &allowedCIDRs,
 		}
 
+		listenerID := listener.ID
 		listener, err := s.loadbalancerClient.UpdateListener(listener.ID, listenerUpdateOpts)
 		if err != nil {
-			record.Warnf(openStackCluster, "FailedUpdateListener", "Failed to update listener %s: %v", listener.Name, err)
+			record.Warnf(openStackCluster, "FailedUpdateListener", "Failed to update listener %s: %v", listenerID, err)
 			return err
 		}
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
When a load balancer listener fails to be created an stacktrace apperas due to an error message trying to include the name of the listener that failed to be created.

Stacktrace:
```log
I0201 14:57:33.013415       1 controller.go:115] "Observed a panic in reconciler: runtime error: invalid memory address or nil pointer dereference" controller="openstackcluster" controllerGroup="infrastructure.cluster.x-k8s.io" controllerKind="OpenStackCluster" OpenStackCluster="default/hux-lab1" namespace="default" name="hux-lab1" reconcileID="d33d5039-62bd-4efe-a004-f939ad3ac7e2"
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x1c393e0]

goroutine 539 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:116 +0x1fa
panic({0x1e601c0, 0x365ba70})
	/usr/local/go/src/runtime/panic.go:884 +0x213
sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/loadbalancer.(*Service).getOrUpdateAllowedCIDRS(0xc000bbc360, 0xc000a01000, 0xc000f54000)
	/workspace/pkg/cloud/services/loadbalancer/loadbalancer.go:290 +0x9e0
sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/loadbalancer.(*Service).ReconcileLoadBalancer(0xc000bbc360, 0xc000a01000, {0xc000c834c0, 0x10}, 0x192b)
	/workspace/pkg/cloud/services/loadbalancer/loadbalancer.go:163 +0xa28
sigs.k8s.io/cluster-api-provider-openstack/controllers.reconcileNetworkComponents({0x24d05e0, 0xc000cdd480}, 0xc000b88820, 0xc000a01000)
	/workspace/controllers/openstackcluster_controller.go:567 +0x12d8
sigs.k8s.io/cluster-api-provider-openstack/controllers.reconcileNormal({0x24d05e0, 0xc000cdd480}, 0x0?, 0xc000a01000)
	/workspace/controllers/openstackcluster_controller.go:300 +0xf7
sigs.k8s.io/cluster-api-provider-openstack/controllers.(*OpenStackClusterReconciler).Reconcile(0xc000a80120, {0x24c6f58, 0xc000c033e0}, {{{0xc000a143c8?, 0x0?}, {0xc000a143c0?, 0xc00116bd48?}}})
	/workspace/controllers/openstackcluster_controller.go:138 +0x736
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x24ccc10?, {0x24c6f58?, 0xc000c033e0?}, {{{0xc000a143c8?, 0xb?}, {0xc000a143c0?, 0x0?}}})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:119 +0xc8
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc00066e000, {0x24c6eb0, 0xc00002bae0}, {0x1f2a740?, 0xc0005300e0?})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:316 +0x3ca
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc00066e000, {0x24c6eb0, 0xc00002bae0})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:266 +0x1d9
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:227 +0x85
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:223 +0x587
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
A part of the problem mentioned in https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/1687

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
