### PR TITLE
WIP - use logger from ctx instead of scope

### DIFF
--- a/controllers/openstackcluster_controller_test.go
+++ b/controllers/openstackcluster_controller_test.go
@@ -217,7 +217,7 @@ var _ = Describe("OpenStackCluster controller", func() {
 		networkClientRecorder := mockScopeFactory.NetworkClient.EXPECT()
 		networkClientRecorder.ListSecGroup(gomock.Any()).Return([]groups.SecGroup{}, nil)
 
-		err = deleteBastion(scope, capiCluster, testCluster)
+		err = deleteBastion(ctx, scope, capiCluster, testCluster)
 		Expect(testCluster.Status.Bastion).To(BeNil())
 		Expect(err).To(BeNil())
 	})
@@ -263,7 +263,7 @@ var _ = Describe("OpenStackCluster controller", func() {
 		networkClientRecorder.ListPort(gomock.Any()).Return([]ports.Port{{ID: "portID"}}, nil)
 		networkClientRecorder.ListFloatingIP(floatingips.ListOpts{PortID: "portID"}).Return(make([]floatingips.FloatingIP, 1), nil)
 
-		res, err := reconcileBastion(scope, capiCluster, testCluster)
+		res, err := reconcileBastion(ctx, scope, capiCluster, testCluster)
 		Expect(testCluster.Status.Bastion).To(Equal(&infrav1.BastionStatus{
 			ID:    "adopted-bastion-uuid",
 			State: "ACTIVE",
@@ -315,7 +315,7 @@ var _ = Describe("OpenStackCluster controller", func() {
 		networkClientRecorder.ListPort(gomock.Any()).Return([]ports.Port{{ID: "portID"}}, nil)
 		networkClientRecorder.ListFloatingIP(floatingips.ListOpts{PortID: "portID"}).Return([]floatingips.FloatingIP{{FloatingIP: "1.2.3.4"}}, nil)
 
-		res, err := reconcileBastion(scope, capiCluster, testCluster)
+		res, err := reconcileBastion(ctx, scope, capiCluster, testCluster)
 		Expect(testCluster.Status.Bastion).To(Equal(&infrav1.BastionStatus{
 			ID:         "adopted-fip-bastion-uuid",
 			FloatingIP: "1.2.3.4",
@@ -364,7 +364,7 @@ var _ = Describe("OpenStackCluster controller", func() {
 		computeClientRecorder := mockScopeFactory.ComputeClient.EXPECT()
 		computeClientRecorder.GetServer("requeue-bastion-uuid").Return(&server, nil)
 
-		res, err := reconcileBastion(scope, capiCluster, testCluster)
+		res, err := reconcileBastion(ctx, scope, capiCluster, testCluster)
 		Expect(testCluster.Status.Bastion).To(Equal(&infrav1.BastionStatus{
 			ID:    "requeue-bastion-uuid",
 			State: "BUILD",
@@ -412,7 +412,7 @@ var _ = Describe("OpenStackCluster controller", func() {
 		networkClientRecorder.ListExtensions().Return([]extensions.Extension{}, nil)
 		networkClientRecorder.ListSecGroup(gomock.Any()).Return([]groups.SecGroup{}, nil)
 
-		err = deleteBastion(scope, capiCluster, testCluster)
+		err = deleteBastion(ctx, scope, capiCluster, testCluster)
 		Expect(err).To(BeNil())
 	})
 	It("should implicitly filter cluster subnets by cluster network", func() {
@@ -473,7 +473,7 @@ var _ = Describe("OpenStackCluster controller", func() {
 			},
 		}, nil)
 
-		err = reconcileNetworkComponents(scope, capiCluster, testCluster)
+		err = reconcileNetworkComponents(ctx, scope, capiCluster, testCluster)
 		Expect(err).To(BeNil())
 	})
 
@@ -540,7 +540,7 @@ var _ = Describe("OpenStackCluster controller", func() {
 			CIDR: "2001:db8:2222:5555::/64",
 		}, nil)
 
-		err = reconcileNetworkComponents(scope, capiCluster, testCluster)
+		err = reconcileNetworkComponents(ctx, scope, capiCluster, testCluster)
 		Expect(err).To(BeNil())
 		Expect(len(testCluster.Status.Network.Subnets)).To(Equal(2))
 	})

--- a/pkg/cloud/services/compute/service.go
+++ b/pkg/cloud/services/compute/service.go
@@ -17,6 +17,7 @@ limitations under the License.
 package compute
 
 import (
+	"context"
 	"fmt"
 
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients"
@@ -26,6 +27,7 @@ import (
 
 type Service struct {
 	scope              scope.Scope
+	ctx                context.Context
 	_computeClient     clients.ComputeClient
 	_volumeClient      clients.VolumeClient
 	_imageClient       clients.ImageClient
@@ -80,7 +82,7 @@ func (s Service) getImageClient() clients.ImageClient {
 
 func (s Service) getNetworkingService() (*networking.Service, error) {
 	if s._networkingService == nil {
-		networkingService, err := networking.NewService(s.scope)
+		networkingService, err := networking.NewService(s.ctx, s.scope)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create networking service: %v", err)
 		}

--- a/pkg/cloud/services/loadbalancer/loadbalancer_test.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package loadbalancer
 
 import (
+	"context"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -33,6 +34,8 @@ import (
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients/mock"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
 )
+
+var ctx context.Context
 
 func Test_ReconcileLoadBalancer(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
@@ -127,7 +130,7 @@ func Test_ReconcileLoadBalancer(t *testing.T) {
 			g := NewWithT(t)
 
 			mockScopeFactory := scope.NewMockScopeFactory(mockCtrl, "", logr.Discard())
-			lbs, err := NewService(mockScopeFactory)
+			lbs, err := NewService(ctx, mockScopeFactory)
 			g.Expect(err).NotTo(HaveOccurred())
 
 			tt.expectNetwork(mockScopeFactory.NetworkClient.EXPECT())

--- a/pkg/cloud/services/loadbalancer/service.go
+++ b/pkg/cloud/services/loadbalancer/service.go
@@ -17,6 +17,7 @@ limitations under the License.
 package loadbalancer
 
 import (
+	"context"
 	"fmt"
 
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients"
@@ -29,16 +30,17 @@ type Service struct {
 	scope              scope.Scope
 	loadbalancerClient clients.LbClient
 	networkingService  *networking.Service
+	ctx                context.Context
 }
 
 // NewService returns an instance of the loadbalancer service.
-func NewService(scope scope.Scope) (*Service, error) {
+func NewService(ctx context.Context, scope scope.Scope) (*Service, error) {
 	loadbalancerClient, err := scope.NewLbClient()
 	if err != nil {
 		return nil, err
 	}
 
-	networkingService, err := networking.NewService(scope)
+	networkingService, err := networking.NewService(ctx, scope)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create networking service: %v", err)
 	}
@@ -47,5 +49,6 @@ func NewService(scope scope.Scope) (*Service, error) {
 		scope:              scope,
 		loadbalancerClient: loadbalancerClient,
 		networkingService:  networkingService,
+		ctx:                ctx,
 	}, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Wwe create a cached provider scope and we put the logger in it. This has caused issue #1840 so now we'll get the logger from context.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1840

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
