### PR TITLE
✨ Adds MaxIPs to OpenstackFloatingIPPool

### DIFF
--- a/api/v1alpha1/conditions_consts.go
+++ b/api/v1alpha1/conditions_consts.go
@@ -19,4 +19,7 @@ package v1alpha1
 const (
 	// OpenstackFloatingIPPoolReadyCondition reports on the current status of the floating ip pool. Ready indicates that the pool is ready to be used.
 	OpenstackFloatingIPPoolReadyCondition = "OpenstackFloatingIPPoolReadyCondition"
+
+	// MaxIPsReachedReason is set when the maximum number of floating IPs has been reached.
+	MaxIPsReachedReason = "MaxIPsReached"
 )

--- a/api/v1alpha1/openstackfloatingippool_types.go
+++ b/api/v1alpha1/openstackfloatingippool_types.go
@@ -56,6 +56,11 @@ type OpenStackFloatingIPPoolSpec struct {
 	// These are used before allocating new ones and are not deleted from OpenStack when the pool is deleted.
 	PreAllocatedFloatingIPs []string `json:"preAllocatedFloatingIPs,omitempty"`
 
+	// MaxIPs is the maximum number of floating ips that can be allocated from this pool, if nil there is no limit.
+	// If set, the pool will stop allocating floating ips when it reaches this number of ClaimedIPs.
+	// +optional
+	MaxIPs *int `json:"maxIPs,omitempty"`
+
 	// IdentityRef is a reference to a identity to be used when reconciling this pool.
 	// +optional
 	IdentityRef *infrav1alpha7.OpenStackIdentityReference `json:"identityRef,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -93,6 +93,11 @@ func (in *OpenStackFloatingIPPoolSpec) DeepCopyInto(out *OpenStackFloatingIPPool
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.MaxIPs != nil {
+		in, out := &in.MaxIPs, &out.MaxIPs
+		*out = new(int)
+		**out = **in
+	}
 	if in.IdentityRef != nil {
 		in, out := &in.IdentityRef, &out.IdentityRef
 		*out = new(v1alpha7.OpenStackIdentityReference)

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackfloatingippools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackfloatingippools.yaml
@@ -86,6 +86,11 @@ spec:
                 - kind
                 - name
                 type: object
+              maxIPs:
+                description: |-
+                  MaxIPs is the maximum number of floating ips that can be allocated from this pool, if nil there is no limit.
+                  If set, the pool will stop allocating floating ips when it reaches this number of ClaimedIPs.
+                type: integer
               preAllocatedFloatingIPs:
                 description: |-
                   PreAllocatedFloatingIPs is a list of floating IPs precreated in OpenStack that should be used by this pool.


### PR DESCRIPTION
Adds MaxIPs to OpenstackFloatingIPPool, after the pool has claimed that amount it will no longer create new floating IPs. 

Relates to #1750 and solves a use case we have where we're preallocating entire ipranges, and we don't want random IPs if the pool is depleted. Our usecase could probably be solved by using [cluster-api-ipam-provider-in-cluster](https://github.com/kubernetes-sigs/cluster-api-ipam-provider-in-cluster) for those clusters but we probably want to be able to control how many IPs a pool allocates anyways.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
relates to #1750

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
