### PR TITLE
Revert "✨ Bump Go to 1.22.0"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.22.0 as builder
+FROM golang:1.21.6 as builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg goproxy=$(go env GOPROXY) to override the goproxy

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api-provider-openstack
 
-go 1.22
+go 1.21
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api-provider-openstack/hack/tools
 
-go 1.22
+go 1.21
 
 require (
 	github.com/a8m/envsubst v1.2.0


### PR DESCRIPTION
Reverts kubernetes-sigs/cluster-api-provider-openstack#1877

We need to wait for CAPI & controller-runtime being bumped first.