### PR TITLE
🐛 Don't ignore 'identityRef.spec'

### DIFF
--- a/pkg/scope/provider.go
+++ b/pkg/scope/provider.go
@@ -59,9 +59,14 @@ func (f *providerScopeFactory) NewClientScopeFromMachine(ctx context.Context, ct
 
 	if openStackMachine.Spec.IdentityRef != nil {
 		var err error
-		cloud, caCert, err = getCloudFromSecret(ctx, ctrlClient, openStackMachine.Namespace, openStackMachine.Spec.IdentityRef.Name, openStackMachine.Spec.CloudName)
-		if err != nil {
-			return nil, err
+		switch openStackMachine.Spec.IdentityRef.Kind {
+		case "Secret", "":
+			cloud, caCert, err = getCloudFromSecret(ctx, ctrlClient, openStackMachine.Namespace, openStackMachine.Spec.IdentityRef.Name, openStackMachine.Spec.CloudName)
+			if err != nil {
+				return nil, err
+			}
+		default:
+			return nil, fmt.Errorf("unsupported type for identityRef: %s", openStackMachine.Spec.IdentityRef.Kind)
 		}
 	} else if openStackCluster.Spec.IdentityRef != nil {
 		var err error
@@ -88,9 +93,14 @@ func (f *providerScopeFactory) NewClientScopeFromCluster(ctx context.Context, ct
 
 	if openStackCluster.Spec.IdentityRef != nil {
 		var err error
-		cloud, caCert, err = getCloudFromSecret(ctx, ctrlClient, openStackCluster.Namespace, openStackCluster.Spec.IdentityRef.Name, openStackCluster.Spec.CloudName)
-		if err != nil {
-			return nil, err
+		switch openStackCluster.Spec.IdentityRef.Kind {
+		case "Secret", "":
+			cloud, caCert, err = getCloudFromSecret(ctx, ctrlClient, openStackCluster.Namespace, openStackCluster.Spec.IdentityRef.Name, openStackCluster.Spec.CloudName)
+			if err != nil {
+				return nil, err
+			}
+		default:
+			return nil, fmt.Errorf("unsupported type for identityRef: %s", openStackCluster.Spec.IdentityRef.Kind)
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We now check the value of `identityRef.spec` for machine template specs and cluster specs. This will allow us to expand the sources of identity ref in the future.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1882

**Special notes for your reviewer**:

Do we want to do this in the API also? Also, there's no explicit test coverage for this. Happy to add it but only if necessary.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
