### PR TITLE
⚠️ Stop serving v1alpha5

### DIFF
--- a/api/v1alpha5/openstackcluster_types.go
+++ b/api/v1alpha5/openstackcluster_types.go
@@ -206,6 +206,7 @@ type OpenStackClusterStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 // +kubebuilder:deprecatedversion:warning="The v1alpha5 version of OpenStackCluster has been deprecated and will be removed in a future release of the API. Please upgrade."
 // +kubebuilder:resource:path=openstackclusters,scope=Namespaced,categories=cluster-api,shortName=osc
 // +kubebuilder:subresource:status

--- a/api/v1alpha5/openstackclustertemplate_types.go
+++ b/api/v1alpha5/openstackclustertemplate_types.go
@@ -31,6 +31,7 @@ type OpenStackClusterTemplateSpec struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 // +kubebuilder:deprecatedversion:warning="The v1alpha5 version of OpenStackClusterTemplate has been deprecated and will be removed in a future release of the API. Please upgrade."
 // +kubebuilder:resource:path=openstackclustertemplates,scope=Namespaced,categories=cluster-api,shortName=osct
 

--- a/api/v1alpha5/openstackmachine_types.go
+++ b/api/v1alpha5/openstackmachine_types.go
@@ -135,6 +135,7 @@ type OpenStackMachineStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 // +kubebuilder:deprecatedversion:warning="The v1alpha5 version of OpenStackMachine has been deprecated and will be removed in a future release of the API. Please upgrade."
 // +kubebuilder:resource:path=openstackmachines,scope=Namespaced,categories=cluster-api,shortName=osm
 // +kubebuilder:subresource:status

--- a/api/v1alpha5/openstackmachinetemplate_types.go
+++ b/api/v1alpha5/openstackmachinetemplate_types.go
@@ -26,6 +26,7 @@ type OpenStackMachineTemplateSpec struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 // +kubebuilder:deprecatedversion:warning="The v1alpha5 version of OpenStackMachineTemplate has been deprecated and will be removed in a future release of the API. Please upgrade."
 // +kubebuilder:resource:path=openstackmachinetemplates,scope=Namespaced,categories=cluster-api,shortName=osmt
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -1791,7 +1791,7 @@ spec:
             - ready
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
@@ -741,7 +741,7 @@ spec:
             - template
             type: object
         type: object
-    served: true
+    served: false
     storage: false
   - name: v1alpha6
     schema:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
@@ -565,7 +565,7 @@ spec:
                 type: boolean
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
@@ -462,7 +462,7 @@ spec:
             - template
             type: object
         type: object
-    served: true
+    served: false
     storage: false
   - name: v1alpha6
     schema:


### PR DESCRIPTION
With this change the apiserver will no longer recognise api version v1alpha5. Configurations using v1alpha5 will not work.

As a workaround, the CRD can be edited to temporarily re-enable v1alpha5 so that configurations can be upgraded to a more recent version, but this workaround will also be removed in the next release.