### PR TITLE
🌱 Enforce restricted pod security standards

### DIFF
--- a/config/default/namespace.yaml
+++ b/config/default/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: system
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted


### PR DESCRIPTION
We should be able to run with the restricted policy and this will inprove our security.

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This enforces the restricted pod security standards profile. It ensures that we do not run containers as root or privileged for example. In a way it can be seen as a validation that we actually configure CAPO according to security best practices.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.
2. I was a bit unsure what icon to use for this actually but went with :seedling: eventually. It could be seen as breaking for user that modify the CAPO deployment or runs other workload in the namespace, but I would say that is outside of normal usage.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
