### PR TITLE
🐛 api/additionalPorts: don't create UDP rules

### DIFF
--- a/pkg/cloud/services/networking/securitygroups_rules.go
+++ b/pkg/cloud/services/networking/securitygroups_rules.go
@@ -222,12 +222,6 @@ func getSGControlPlaneAdditionalPorts(ports []int) []resolvedSecurityGroupRuleSp
 			EtherType:   "IPv4",
 			Protocol:    "tcp",
 		},
-		{
-			Description: "Additional ports",
-			Direction:   "ingress",
-			EtherType:   "IPv4",
-			Protocol:    "udp",
-		},
 	}
 	for _, p := range ports {
 		r[0].PortRangeMin = p


### PR DESCRIPTION
**What this PR does / why we need it**:

When providing additional ports to open on the control plane security
group, we'll only open TCP from now as it was initially documented.

Opening UDP by default might not be desired for security reasons.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1704

/hold
