### PR TITLE
🌱 Enhancements to how controller-gen is invoked

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,14 +258,14 @@ generate-controller-gen: $(CONTROLLER_GEN)
 		object:headerFile=./hack/boilerplate/boilerplate.generatego.txt
 
 .PHONY: generate-conversion-gen
+capo_module := sigs.k8s.io/cluster-api-provider-openstack
 generate-conversion-gen: $(CONVERSION_GEN)
 	$(CONVERSION_GEN) \
-		--input-dirs=./api/v1alpha1 \
-		--input-dirs=./api/v1alpha5 \
-		--input-dirs=./api/v1alpha6 \
-		--input-dirs=./api/v1alpha7 \
-		--input-dirs=./api/v1beta1 \
+		--input-dirs=$(capo_module)/api/v1alpha5 \
+		--input-dirs=$(capo_module)/api/v1alpha6 \
+		--input-dirs=$(capo_module)/api/v1alpha7 \
 		--output-file-base=zz_generated.conversion \
+		--trim-path-prefix=$(capo_module)/ \
 		--go-header-file=./hack/boilerplate/boilerplate.generatego.txt
 
 .PHONY: generate-manifests

--- a/Makefile
+++ b/Makefile
@@ -245,16 +245,20 @@ modules: ## Runs go mod to ensure proper vendoring.
 	cd $(TOOLS_DIR); go mod tidy
 
 .PHONY: generate
-generate: ## Generate code
-	$(MAKE) generate-go
-	$(MAKE) generate-manifests
+generate: generate-controller-gen generate-conversion-gen generate-go generate-manifests ## Generate all generated code
 
 .PHONY: generate-go
 generate-go: $(MOCKGEN)
-	$(MAKE) -B $(CONTROLLER_GEN) $(CONVERSION_GEN)
+	go generate ./...
+
+.PHONY: generate-controller-gen
+generate-controller-gen: $(CONTROLLER_GEN)
 	$(CONTROLLER_GEN) \
 		paths=./api/... \
 		object:headerFile=./hack/boilerplate/boilerplate.generatego.txt
+
+.PHONY: generate-conversion-gen
+generate-conversion-gen: $(CONVERSION_GEN)
 	$(CONVERSION_GEN) \
 		--input-dirs=./api/v1alpha1 \
 		--input-dirs=./api/v1alpha5 \
@@ -263,7 +267,6 @@ generate-go: $(MOCKGEN)
 		--input-dirs=./api/v1beta1 \
 		--output-file-base=zz_generated.conversion \
 		--go-header-file=./hack/boilerplate/boilerplate.generatego.txt
-	go generate ./...
 
 .PHONY: generate-manifests
 generate-manifests: $(CONTROLLER_GEN) ## Generate manifests e.g. CRD, RBAC etc.


### PR DESCRIPTION
This PR includes 2 commits which each make a single change to how the Makefile does code generation.

The first adds the following 2 separate targets:
* generate-controller-gen
* generate-conversion-gen

These invoke `controller-gen` and `conversion-gen` respectively. These were previously invoked by the `generate-go` target, but that target is now reduced to simply executing `go generate ./...`.

The `generate` target continues to invoke all code generation.

The advantage of this is the ability to easily run only the generation you need during development.

The second commit changes the behaviour of `generate-conversion-gen`. This produces no change in output against the current codebase, but fixes an issue generating an incorrect package internal package name should conversion-gen want to add a dependency between packages. I encountered this when I made a change which caused it to do this, which has not yet landed.