### PR TITLE
🐛 Remove logger from scope

### DIFF
--- a/controllers/openstackcluster_controller_test.go
+++ b/controllers/openstackcluster_controller_test.go
@@ -22,7 +22,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
@@ -105,7 +104,7 @@ var _ = Describe("OpenStackCluster controller", func() {
 		framework.CreateNamespace(ctx, input)
 
 		mockCtrl = gomock.NewController(GinkgoT())
-		mockScopeFactory = scope.NewMockScopeFactory(mockCtrl, "", logr.Discard())
+		mockScopeFactory = scope.NewMockScopeFactory(mockCtrl, "")
 		reconciler = func() *OpenStackClusterReconciler {
 			return &OpenStackClusterReconciler{
 				Client:       k8sClient,
@@ -207,8 +206,10 @@ var _ = Describe("OpenStackCluster controller", func() {
 		}
 		err = k8sClient.Status().Update(ctx, testCluster)
 		Expect(err).To(BeNil())
-		scope, err := mockScopeFactory.NewClientScopeFromCluster(ctx, k8sClient, testCluster, nil, logr.Discard())
+		log := GinkgoLogr
+		clientScope, err := mockScopeFactory.NewClientScopeFromCluster(ctx, k8sClient, testCluster, nil, log)
 		Expect(err).To(BeNil())
+		scope := scope.NewWithLogger(clientScope, log)
 
 		computeClientRecorder := mockScopeFactory.ComputeClient.EXPECT()
 		computeClientRecorder.GetServer("bastion-uuid").Return(nil, gophercloud.ErrResourceNotFound{})
@@ -258,8 +259,10 @@ var _ = Describe("OpenStackCluster controller", func() {
 		err = k8sClient.Status().Update(ctx, testCluster)
 		Expect(err).To(BeNil())
 
-		scope, err := mockScopeFactory.NewClientScopeFromCluster(ctx, k8sClient, testCluster, nil, logr.Discard())
+		log := GinkgoLogr
+		clientScope, err := mockScopeFactory.NewClientScopeFromCluster(ctx, k8sClient, testCluster, nil, log)
 		Expect(err).To(BeNil())
+		scope := scope.NewWithLogger(clientScope, log)
 
 		server := clients.ServerExt{}
 		server.ID = "adopted-bastion-uuid"
@@ -342,8 +345,10 @@ var _ = Describe("OpenStackCluster controller", func() {
 		err = k8sClient.Status().Update(ctx, testCluster)
 		Expect(err).To(BeNil())
 
-		scope, err := mockScopeFactory.NewClientScopeFromCluster(ctx, k8sClient, testCluster, nil, logr.Discard())
+		log := GinkgoLogr
+		clientScope, err := mockScopeFactory.NewClientScopeFromCluster(ctx, k8sClient, testCluster, nil, log)
 		Expect(err).To(BeNil())
+		scope := scope.NewWithLogger(clientScope, log)
 
 		server := clients.ServerExt{}
 		server.ID = "adopted-fip-bastion-uuid"
@@ -425,8 +430,10 @@ var _ = Describe("OpenStackCluster controller", func() {
 		err = k8sClient.Status().Update(ctx, testCluster)
 		Expect(err).To(BeNil())
 
-		scope, err := mockScopeFactory.NewClientScopeFromCluster(ctx, k8sClient, testCluster, nil, logr.Discard())
+		log := GinkgoLogr
+		clientScope, err := mockScopeFactory.NewClientScopeFromCluster(ctx, k8sClient, testCluster, nil, log)
 		Expect(err).To(BeNil())
+		scope := scope.NewWithLogger(clientScope, log)
 
 		server := clients.ServerExt{}
 		server.ID = "requeue-bastion-uuid"
@@ -484,8 +491,10 @@ var _ = Describe("OpenStackCluster controller", func() {
 		err = k8sClient.Status().Update(ctx, testCluster)
 		Expect(err).To(BeNil())
 
-		scope, err := mockScopeFactory.NewClientScopeFromCluster(ctx, k8sClient, testCluster, nil, logr.Discard())
+		log := GinkgoLogr
+		clientScope, err := mockScopeFactory.NewClientScopeFromCluster(ctx, k8sClient, testCluster, nil, log)
 		Expect(err).To(BeNil())
+		scope := scope.NewWithLogger(clientScope, log)
 
 		server := clients.ServerExt{}
 		server.ID = "delete-bastion-uuid"
@@ -534,8 +543,11 @@ var _ = Describe("OpenStackCluster controller", func() {
 		Expect(err).To(BeNil())
 		err = k8sClient.Create(ctx, capiCluster)
 		Expect(err).To(BeNil())
-		scope, err := mockScopeFactory.NewClientScopeFromCluster(ctx, k8sClient, testCluster, nil, logr.Discard())
+
+		log := GinkgoLogr
+		clientScope, err := mockScopeFactory.NewClientScopeFromCluster(ctx, k8sClient, testCluster, nil, log)
 		Expect(err).To(BeNil())
+		scope := scope.NewWithLogger(clientScope, log)
 
 		networkClientRecorder := mockScopeFactory.NetworkClient.EXPECT()
 
@@ -614,8 +626,11 @@ var _ = Describe("OpenStackCluster controller", func() {
 		Expect(err).To(BeNil())
 		err = k8sClient.Create(ctx, capiCluster)
 		Expect(err).To(BeNil())
-		scope, err := mockScopeFactory.NewClientScopeFromCluster(ctx, k8sClient, testCluster, nil, logr.Discard())
+
+		log := GinkgoLogr
+		clientScope, err := mockScopeFactory.NewClientScopeFromCluster(ctx, k8sClient, testCluster, nil, log)
 		Expect(err).To(BeNil())
+		scope := scope.NewWithLogger(clientScope, log)
 
 		networkClientRecorder := mockScopeFactory.NetworkClient.EXPECT()
 
@@ -675,8 +690,11 @@ var _ = Describe("OpenStackCluster controller", func() {
 		Expect(err).To(BeNil())
 		err = k8sClient.Create(ctx, capiCluster)
 		Expect(err).To(BeNil())
-		scope, err := mockScopeFactory.NewClientScopeFromCluster(ctx, k8sClient, testCluster, nil, logr.Discard())
+
+		log := GinkgoLogr
+		clientScope, err := mockScopeFactory.NewClientScopeFromCluster(ctx, k8sClient, testCluster, nil, log)
 		Expect(err).To(BeNil())
+		scope := scope.NewWithLogger(clientScope, log)
 
 		networkClientRecorder := mockScopeFactory.NetworkClient.EXPECT()
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -22,7 +22,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -127,8 +126,9 @@ var _ = Describe("EnvTest sanity check", func() {
 })
 
 var _ = Describe("When calling getOrCreate", func() {
+	logger := GinkgoLogr
+
 	var (
-		logger           logr.Logger
 		reconsiler       OpenStackMachineReconciler
 		mockCtrl         *gomock.Controller
 		mockScopeFactory *scope.MockScopeFactory
@@ -138,11 +138,10 @@ var _ = Describe("When calling getOrCreate", func() {
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		logger = logr.Discard()
 		reconsiler = OpenStackMachineReconciler{}
 		mockCtrl = gomock.NewController(GinkgoT())
-		mockScopeFactory = scope.NewMockScopeFactory(mockCtrl, "1234", logger)
-		computeService, err = compute.NewService(mockScopeFactory)
+		mockScopeFactory = scope.NewMockScopeFactory(mockCtrl, "1234")
+		computeService, err = compute.NewService(scope.NewWithLogger(mockScopeFactory, logger))
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/pkg/cloud/services/compute/dependent_resources.go
+++ b/pkg/cloud/services/compute/dependent_resources.go
@@ -22,7 +22,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
 )
 
-func ResolveDependentMachineResources(scope scope.Scope, openStackMachine *infrav1.OpenStackMachine) (changed bool, err error) {
+func ResolveDependentMachineResources(scope *scope.WithLogger, openStackMachine *infrav1.OpenStackMachine) (changed bool, err error) {
 	changed = false
 
 	networkingService, err := networking.NewService(scope)
@@ -33,7 +33,7 @@ func ResolveDependentMachineResources(scope scope.Scope, openStackMachine *infra
 	return networkingService.AdoptMachinePorts(scope, openStackMachine, openStackMachine.Status.ReferencedResources.PortsOpts)
 }
 
-func ResolveDependentBastionResources(scope scope.Scope, openStackCluster *infrav1.OpenStackCluster, bastionName string) (changed bool, err error) {
+func ResolveDependentBastionResources(scope *scope.WithLogger, openStackCluster *infrav1.OpenStackCluster, bastionName string) (changed bool, err error) {
 	changed = false
 
 	networkingService, err := networking.NewService(scope)

--- a/pkg/cloud/services/compute/dependent_resources_test.go
+++ b/pkg/cloud/services/compute/dependent_resources_test.go
@@ -19,7 +19,7 @@ package compute
 import (
 	"testing"
 
-	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
@@ -93,8 +93,9 @@ func Test_ResolveDependentMachineResources(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
 			g := NewWithT(t)
+			log := testr.New(t)
 			mockCtrl := gomock.NewController(t)
-			mockScopeFactory := scope.NewMockScopeFactory(mockCtrl, "", logr.Discard())
+			mockScopeFactory := scope.NewMockScopeFactory(mockCtrl, "")
 
 			defaultOpenStackMachine := &infrav1.OpenStackMachine{
 				ObjectMeta: metav1.ObjectMeta{
@@ -103,7 +104,7 @@ func Test_ResolveDependentMachineResources(t *testing.T) {
 				Status: tt.openStackMachineStatus,
 			}
 
-			_, err := ResolveDependentMachineResources(mockScopeFactory, defaultOpenStackMachine)
+			_, err := ResolveDependentMachineResources(scope.NewWithLogger(mockScopeFactory, log), defaultOpenStackMachine)
 			if tt.wantErr {
 				g.Expect(err).Error()
 				return
@@ -192,10 +193,11 @@ func TestResolveDependentBastionResources(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
 			g := NewWithT(t)
+			log := testr.New(t)
 			mockCtrl := gomock.NewController(t)
-			mockScopeFactory := scope.NewMockScopeFactory(mockCtrl, "", logr.Discard())
+			mockScopeFactory := scope.NewMockScopeFactory(mockCtrl, "")
 
-			_, err := ResolveDependentBastionResources(mockScopeFactory, tt.openStackCluster, bastionName)
+			_, err := ResolveDependentBastionResources(scope.NewWithLogger(mockScopeFactory, log), tt.openStackCluster, bastionName)
 			if tt.wantErr {
 				g.Expect(err).Error()
 				return

--- a/pkg/cloud/services/compute/instance_test.go
+++ b/pkg/cloud/services/compute/instance_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
 	"github.com/golang/mock/gomock"
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
@@ -120,9 +120,10 @@ func TestService_getImageID(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			mockScopeFactory := scope.NewMockScopeFactory(mockCtrl, "", logr.Discard())
+			log := testr.New(t)
+			mockScopeFactory := scope.NewMockScopeFactory(mockCtrl, "")
 
-			s, err := NewService(mockScopeFactory)
+			s, err := NewService(scope.NewWithLogger(mockScopeFactory, log))
 			if err != nil {
 				t.Fatalf("Failed to create service: %v", err)
 			}
@@ -666,7 +667,8 @@ func TestService_ReconcileInstance(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			mockScopeFactory := scope.NewMockScopeFactory(mockCtrl, "", logr.Discard())
+			log := testr.New(t)
+			mockScopeFactory := scope.NewMockScopeFactory(mockCtrl, "")
 
 			computeRecorder := mockScopeFactory.ComputeClient.EXPECT()
 			imageRecorder := mockScopeFactory.ImageClient.EXPECT()
@@ -675,7 +677,7 @@ func TestService_ReconcileInstance(t *testing.T) {
 
 			tt.expect(&recorders{computeRecorder, imageRecorder, networkRecorder, volumeRecorder})
 
-			s, err := NewService(mockScopeFactory)
+			s, err := NewService(scope.NewWithLogger(mockScopeFactory, log))
 			if err != nil {
 				t.Fatalf("Failed to create service: %v", err)
 			}
@@ -759,7 +761,8 @@ func TestService_DeleteInstance(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			mockScopeFactory := scope.NewMockScopeFactory(mockCtrl, "", logr.Discard())
+			log := testr.New(t)
+			mockScopeFactory := scope.NewMockScopeFactory(mockCtrl, "")
 
 			computeRecorder := mockScopeFactory.ComputeClient.EXPECT()
 			networkRecorder := mockScopeFactory.NetworkClient.EXPECT()
@@ -767,7 +770,7 @@ func TestService_DeleteInstance(t *testing.T) {
 
 			tt.expect(&recorders{computeRecorder, networkRecorder, volumeRecorder})
 
-			s, err := NewService(mockScopeFactory)
+			s, err := NewService(scope.NewWithLogger(mockScopeFactory, log))
 			if err != nil {
 				t.Fatalf("Failed to create service: %v", err)
 			}

--- a/pkg/cloud/services/compute/instance_types_test.go
+++ b/pkg/cloud/services/compute/instance_types_test.go
@@ -19,7 +19,7 @@ package compute
 import (
 	"testing"
 
-	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 
@@ -196,10 +196,11 @@ func TestNetworkStatus_Addresses(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
+			log := testr.New(t)
 
 			is := &InstanceStatus{
 				server: serverWithAddresses(tt.addresses),
-				logger: logr.Discard(),
+				logger: log,
 			}
 			instanceNS, err := is.NetworkStatus()
 			g.Expect(err).NotTo(HaveOccurred())
@@ -411,10 +412,11 @@ func TestInstanceNetworkStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
+			log := testr.New(t)
 
 			is := &InstanceStatus{
 				server: serverWithAddresses(tt.addresses),
-				logger: logr.Discard(),
+				logger: log,
 			}
 			ns, err := is.NetworkStatus()
 			g.Expect(err).NotTo(HaveOccurred())

--- a/pkg/cloud/services/compute/referenced_resources.go
+++ b/pkg/cloud/services/compute/referenced_resources.go
@@ -28,7 +28,7 @@ import (
 // Note that we only set the fields in ReferencedMachineResources that are not set yet. This is ok because:
 // - OpenStackMachine is immutable, so we can't change the spec after the machine is created.
 // - the bastion is mutable, but we delete the bastion when the spec changes, so the bastion status will be empty.
-func ResolveReferencedMachineResources(scope scope.Scope, openStackCluster *infrav1.OpenStackCluster, spec *infrav1.OpenStackMachineSpec, resources *infrav1.ReferencedMachineResources) (changed bool, err error) {
+func ResolveReferencedMachineResources(scope *scope.WithLogger, openStackCluster *infrav1.OpenStackCluster, spec *infrav1.OpenStackMachineSpec, resources *infrav1.ReferencedMachineResources) (changed bool, err error) {
 	changed = false
 
 	computeService, err := NewService(scope)

--- a/pkg/cloud/services/compute/referenced_resources_test.go
+++ b/pkg/cloud/services/compute/referenced_resources_test.go
@@ -19,7 +19,7 @@ package compute
 import (
 	"testing"
 
-	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups"
@@ -148,8 +148,9 @@ func Test_ResolveReferencedMachineResources(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
 			g := NewWithT(t)
+			log := testr.New(t)
 			mockCtrl := gomock.NewController(t)
-			mockScopeFactory := scope.NewMockScopeFactory(mockCtrl, "", logr.Discard())
+			mockScopeFactory := scope.NewMockScopeFactory(mockCtrl, "")
 
 			tt.expectComputeMock(mockScopeFactory.ComputeClient.EXPECT())
 			tt.expectImageMock(mockScopeFactory.ImageClient.EXPECT())
@@ -178,7 +179,8 @@ func Test_ResolveReferencedMachineResources(t *testing.T) {
 
 			resources := &infrav1.ReferencedMachineResources{}
 
-			_, err := ResolveReferencedMachineResources(mockScopeFactory, openStackCluster, machineSpec, resources)
+			scope := scope.NewWithLogger(mockScopeFactory, log)
+			_, err := ResolveReferencedMachineResources(scope, openStackCluster, machineSpec, resources)
 			if tt.wantErr {
 				g.Expect(err).Error()
 				return

--- a/pkg/cloud/services/compute/servergroup_test.go
+++ b/pkg/cloud/services/compute/servergroup_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
 	"github.com/golang/mock/gomock"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups"
 
@@ -107,9 +107,10 @@ func TestService_GetServerGroupID(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			mockScopeFactory := scope.NewMockScopeFactory(mockCtrl, "", logr.Discard())
+			log := testr.New(t)
+			mockScopeFactory := scope.NewMockScopeFactory(mockCtrl, "")
 
-			s, err := NewService(mockScopeFactory)
+			s, err := NewService(scope.NewWithLogger(mockScopeFactory, log))
 			if err != nil {
 				t.Fatalf("Failed to create service: %v", err)
 			}

--- a/pkg/cloud/services/compute/service.go
+++ b/pkg/cloud/services/compute/service.go
@@ -25,7 +25,7 @@ import (
 )
 
 type Service struct {
-	scope              scope.Scope
+	scope              *scope.WithLogger
 	_computeClient     clients.ComputeClient
 	_volumeClient      clients.VolumeClient
 	_imageClient       clients.ImageClient
@@ -33,7 +33,7 @@ type Service struct {
 }
 
 // NewService returns an instance of the compute service.
-func NewService(scope scope.Scope) (*Service, error) {
+func NewService(scope *scope.WithLogger) (*Service, error) {
 	return &Service{
 		scope: scope,
 	}, nil

--- a/pkg/cloud/services/loadbalancer/loadbalancer_test.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer_test.go
@@ -22,7 +22,7 @@ import (
 	"net"
 	"testing"
 
-	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
 	"github.com/golang/mock/gomock"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/apiversions"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners"
@@ -139,9 +139,10 @@ func Test_ReconcileLoadBalancer(t *testing.T) {
 	for _, tt := range lbtests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
+			log := testr.New(t)
 
-			mockScopeFactory := scope.NewMockScopeFactory(mockCtrl, "", logr.Discard())
-			lbs, err := NewService(mockScopeFactory)
+			mockScopeFactory := scope.NewMockScopeFactory(mockCtrl, "")
+			lbs, err := NewService(scope.NewWithLogger(mockScopeFactory, log))
 			g.Expect(err).NotTo(HaveOccurred())
 
 			tt.expectNetwork(mockScopeFactory.NetworkClient.EXPECT())
@@ -485,9 +486,10 @@ func Test_getOrCreateAPILoadBalancer(t *testing.T) {
 	for _, tt := range lbtests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
+			log := testr.New(t)
 
-			mockScopeFactory := scope.NewMockScopeFactory(mockCtrl, "", logr.Discard())
-			lbs, err := NewService(mockScopeFactory)
+			mockScopeFactory := scope.NewMockScopeFactory(mockCtrl, "")
+			lbs, err := NewService(scope.NewWithLogger(mockScopeFactory, log))
 			g.Expect(err).NotTo(HaveOccurred())
 
 			tt.expectLoadBalancer(mockScopeFactory.LbClient.EXPECT())

--- a/pkg/cloud/services/loadbalancer/service.go
+++ b/pkg/cloud/services/loadbalancer/service.go
@@ -26,13 +26,13 @@ import (
 
 // Service interfaces with the OpenStack Neutron LBaaS v2 API.
 type Service struct {
-	scope              scope.Scope
+	scope              *scope.WithLogger
 	loadbalancerClient clients.LbClient
 	networkingService  *networking.Service
 }
 
 // NewService returns an instance of the loadbalancer service.
-func NewService(scope scope.Scope) (*Service, error) {
+func NewService(scope *scope.WithLogger) (*Service, error) {
 	loadbalancerClient, err := scope.NewLbClient()
 	if err != nil {
 		return nil, err

--- a/pkg/cloud/services/networking/network_test.go
+++ b/pkg/cloud/services/networking/network_test.go
@@ -19,7 +19,7 @@ package networking
 import (
 	"testing"
 
-	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
 	"github.com/golang/mock/gomock"
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external"
@@ -188,9 +188,12 @@ func Test_ReconcileNetwork(t *testing.T) {
 			g := NewWithT(t)
 			mockClient := mock.NewMockNetworkClient(mockCtrl)
 			tt.expect(mockClient.EXPECT())
+
+			scopeFactory := scope.NewMockScopeFactory(mockCtrl, "")
+			log := testr.New(t)
 			s := Service{
 				client: mockClient,
-				scope:  scope.NewMockScopeFactory(mockCtrl, "", logr.Discard()),
+				scope:  scope.NewWithLogger(scopeFactory, log),
 			}
 			err := s.ReconcileNetwork(tt.openStackCluster, clusterName)
 			g.Expect(err).ShouldNot(HaveOccurred())
@@ -410,9 +413,12 @@ func Test_ReconcileExternalNetwork(t *testing.T) {
 			g := NewWithT(t)
 			mockClient := mock.NewMockNetworkClient(mockCtrl)
 			tt.expect(mockClient.EXPECT())
+
+			scopeFactory := scope.NewMockScopeFactory(mockCtrl, "")
+			log := testr.New(t)
 			s := Service{
 				client: mockClient,
-				scope:  scope.NewMockScopeFactory(mockCtrl, "", logr.Discard()),
+				scope:  scope.NewWithLogger(scopeFactory, log),
 			}
 			err := s.ReconcileExternalNetwork(tt.openStackCluster)
 			if (err != nil) != tt.wantErr {
@@ -668,11 +674,13 @@ func Test_ReconcileSubnet(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
+			log := testr.New(t)
 			mockClient := mock.NewMockNetworkClient(mockCtrl)
 			tt.expect(mockClient.EXPECT())
+			mockScopeFactory := scope.NewMockScopeFactory(mockCtrl, "")
 			s := Service{
 				client: mockClient,
-				scope:  scope.NewMockScopeFactory(mockCtrl, "", logr.Discard()),
+				scope:  scope.NewWithLogger(mockScopeFactory, log),
 			}
 			err := s.ReconcileSubnet(tt.openStackCluster, clusterName)
 			g.Expect(err).ShouldNot(HaveOccurred())

--- a/pkg/cloud/services/networking/port.go
+++ b/pkg/cloud/services/networking/port.go
@@ -518,7 +518,7 @@ func (s *Service) IsTrunkExtSupported() (trunknSupported bool, err error) {
 // by checking if they exist and if they do, it'll add them to the OpenStackMachine status.
 // A port is searched by name and network ID and has to be unique.
 // If the port is not found, it'll be ignored because it'll be created after the adoption.
-func (s *Service) AdoptMachinePorts(scope scope.Scope, openStackMachine *infrav1.OpenStackMachine, desiredPorts []infrav1.PortOpts) (changed bool, err error) {
+func (s *Service) AdoptMachinePorts(scope *scope.WithLogger, openStackMachine *infrav1.OpenStackMachine, desiredPorts []infrav1.PortOpts) (changed bool, err error) {
 	changed = false
 
 	// We can skip adoption if the instance is ready because OpenStackMachine is immutable once ready
@@ -572,7 +572,7 @@ func (s *Service) AdoptMachinePorts(scope scope.Scope, openStackMachine *infrav1
 // it'll add them to the OpenStackCluster status.
 // A port is searched by name and network ID and has to be unique.
 // If the port is not found, it'll be ignored because it'll be created after the adoption.
-func (s *Service) AdoptBastionPorts(scope scope.Scope, openStackCluster *infrav1.OpenStackCluster, bastionName string) (changed bool, err error) {
+func (s *Service) AdoptBastionPorts(scope *scope.WithLogger, openStackCluster *infrav1.OpenStackCluster, bastionName string) (changed bool, err error) {
 	changed = false
 
 	if openStackCluster.Status.Network == nil {

--- a/pkg/cloud/services/networking/port_test.go
+++ b/pkg/cloud/services/networking/port_test.go
@@ -19,7 +19,7 @@ package networking
 import (
 	"testing"
 
-	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags"
@@ -774,14 +774,16 @@ func TestService_normalizePorts(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
+			log := testr.New(t)
 
 			mockClient := mock.NewMockNetworkClient(mockCtrl)
 			if tt.expectNetwork != nil {
 				tt.expectNetwork(mockClient.EXPECT())
 			}
+			mockScopeFactory := scope.NewMockScopeFactory(mockCtrl, "")
 			s := Service{
 				client: mockClient,
-				scope:  scope.NewMockScopeFactory(mockCtrl, "", logr.Discard()),
+				scope:  scope.NewWithLogger(mockScopeFactory, log),
 			}
 
 			got, err := s.normalizePorts(tt.ports, openStackCluster, tt.instanceTrunk)

--- a/pkg/cloud/services/networking/securitygroups_test.go
+++ b/pkg/cloud/services/networking/securitygroups_test.go
@@ -19,7 +19,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
 	"github.com/golang/mock/gomock"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
@@ -342,9 +342,10 @@ func TestGenerateDesiredSecGroups(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			mockScopeFactory := scope.NewMockScopeFactory(mockCtrl, "", logr.Discard())
+			log := testr.New(t)
+			mockScopeFactory := scope.NewMockScopeFactory(mockCtrl, "")
 
-			s, err := NewService(mockScopeFactory)
+			s, err := NewService(scope.NewWithLogger(mockScopeFactory, log))
 			if err != nil {
 				t.Fatalf("Failed to create service: %v", err)
 			}
@@ -515,9 +516,10 @@ func TestReconcileGroupRules(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			mockScopeFactory := scope.NewMockScopeFactory(mockCtrl, "", logr.Discard())
+			log := testr.New(t)
+			mockScopeFactory := scope.NewMockScopeFactory(mockCtrl, "")
 
-			s, err := NewService(mockScopeFactory)
+			s, err := NewService(scope.NewWithLogger(mockScopeFactory, log))
 			if err != nil {
 				t.Fatalf("Failed to create service: %v", err)
 			}

--- a/pkg/cloud/services/networking/service.go
+++ b/pkg/cloud/services/networking/service.go
@@ -37,12 +37,12 @@ const (
 // Service interfaces with the OpenStack Networking API.
 // It will create a network related infrastructure for the cluster, like network, subnet, router, security groups.
 type Service struct {
-	scope  scope.Scope
+	scope  *scope.WithLogger
 	client clients.NetworkClient
 }
 
 // NewService returns an instance of the networking service.
-func NewService(scope scope.Scope) (*Service, error) {
+func NewService(scope *scope.WithLogger) (*Service, error) {
 	networkClient, err := scope.NewNetworkClient()
 	if err != nil {
 		return nil, err

--- a/pkg/scope/mock.go
+++ b/pkg/scope/mock.go
@@ -40,12 +40,11 @@ type MockScopeFactory struct {
 	ImageClient   *mock.MockImageClient
 	LbClient      *mock.MockLbClient
 
-	logger                 logr.Logger
 	projectID              string
 	clientScopeCreateError error
 }
 
-func NewMockScopeFactory(mockCtrl *gomock.Controller, projectID string, logger logr.Logger) *MockScopeFactory {
+func NewMockScopeFactory(mockCtrl *gomock.Controller, projectID string) *MockScopeFactory {
 	computeClient := mock.NewMockComputeClient(mockCtrl)
 	volumeClient := mock.NewMockVolumeClient(mockCtrl)
 	imageClient := mock.NewMockImageClient(mockCtrl)
@@ -59,7 +58,6 @@ func NewMockScopeFactory(mockCtrl *gomock.Controller, projectID string, logger l
 		NetworkClient: networkClient,
 		LbClient:      lbClient,
 		projectID:     projectID,
-		logger:        logger,
 	}
 }
 
@@ -106,10 +104,6 @@ func (f *MockScopeFactory) NewNetworkClient() (clients.NetworkClient, error) {
 
 func (f *MockScopeFactory) NewLbClient() (clients.LbClient, error) {
 	return f.LbClient, nil
-}
-
-func (f *MockScopeFactory) Logger() logr.Logger {
-	return f.logger
 }
 
 func (f *MockScopeFactory) ProjectID() string {

--- a/pkg/scope/provider.go
+++ b/pkg/scope/provider.go
@@ -141,7 +141,6 @@ type providerScope struct {
 	providerClient     *gophercloud.ProviderClient
 	providerClientOpts *clientconfig.ClientOpts
 	projectID          string
-	logger             logr.Logger
 }
 
 func NewProviderScope(cloud clientconfig.Cloud, caCert []byte, logger logr.Logger) (Scope, error) {
@@ -154,7 +153,6 @@ func NewProviderScope(cloud clientconfig.Cloud, caCert []byte, logger logr.Logge
 		providerClient:     providerClient,
 		providerClientOpts: clientOpts,
 		projectID:          projectID,
-		logger:             logger,
 	}, nil
 }
 
@@ -184,10 +182,6 @@ func NewCachedProviderScope(cache *cache.LRUExpireCache, cloud clientconfig.Clou
 
 	cache.Add(key, scope, expiry)
 	return scope, nil
-}
-
-func (s *providerScope) Logger() logr.Logger {
-	return s.logger
 }
 
 func (s *providerScope) ProjectID() string {

--- a/pkg/scope/scope.go
+++ b/pkg/scope/scope.go
@@ -54,7 +54,24 @@ type Scope interface {
 	NewImageClient() (clients.ImageClient, error)
 	NewNetworkClient() (clients.NetworkClient, error)
 	NewLbClient() (clients.LbClient, error)
-	Logger() logr.Logger
 	ProjectID() string
 	ExtractToken() (*tokens.Token, error)
+}
+
+// WithLogger extends Scope with a logger.
+type WithLogger struct {
+	Scope
+
+	logger logr.Logger
+}
+
+func NewWithLogger(scope Scope, logger logr.Logger) *WithLogger {
+	return &WithLogger{
+		Scope:  scope,
+		logger: logger,
+	}
+}
+
+func (s *WithLogger) Logger() logr.Logger {
+	return s.logger
 }


### PR DESCRIPTION
Scope encapsulates an initialised OpenStack client which can be safely shared between reconciles which share the same credentials. The logger is initialised with context specific to an individual reconcile, so it cannot be shared between reconciles.

To avoid code churn we preserve the previous interface of Scope with the creation of scope.WithLogger, which changes the initialisation to ensure that the returned logger always comes from the current reconcile even if the scope was cached.

While touching logging in tests, we also take the opportunity to replace uses of logr.Discard with GinkgoLogr or logr/testr as appropriate, so test logs are now captured.

Fixes #1840

/hold
