### PR TITLE
🐛 ci: fix upgrades by dropping cloudName

### DIFF
--- a/test/e2e/data/kustomize/k8s-upgrade/upgrade-from-template.yaml
+++ b/test/e2e/data/kustomize/k8s-upgrade/upgrade-from-template.yaml
@@ -6,10 +6,7 @@ metadata:
 spec:
   template:
     spec:
-      cloudName: ${OPENSTACK_CLOUD}
       flavor: ${OPENSTACK_CONTROL_PLANE_MACHINE_FLAVOR}
-      identityRef:
-        name: ${CLUSTER_NAME}-cloud-config
       image:
         name: ${OPENSTACK_IMAGE_NAME_UPGRADE_FROM}
       sshKeyName: ${OPENSTACK_SSH_KEY_NAME}
@@ -23,10 +20,7 @@ metadata:
 spec:
   template:
     spec:
-      cloudName: ${OPENSTACK_CLOUD}
       flavor: ${OPENSTACK_NODE_MACHINE_FLAVOR}
-      identityRef:
-        name: ${CLUSTER_NAME}-cloud-config
       image:
         name: ${OPENSTACK_IMAGE_NAME_UPGRADE_FROM}
       sshKeyName: ${OPENSTACK_SSH_KEY_NAME}

--- a/test/e2e/data/kustomize/k8s-upgrade/upgrade-to-template.yaml
+++ b/test/e2e/data/kustomize/k8s-upgrade/upgrade-to-template.yaml
@@ -13,10 +13,7 @@ metadata:
 spec:
   template:
     spec:
-      cloudName: ${OPENSTACK_CLOUD}
       flavor: ${OPENSTACK_CONTROL_PLANE_MACHINE_FLAVOR}
-      identityRef:
-        name: ${CLUSTER_NAME}-cloud-config
       image:
         name: ${OPENSTACK_IMAGE_NAME}
       sshKeyName: ${OPENSTACK_SSH_KEY_NAME}
@@ -32,10 +29,7 @@ metadata:
 spec:
   template:
     spec:
-      cloudName: ${OPENSTACK_CLOUD}
       flavor: ${OPENSTACK_NODE_MACHINE_FLAVOR}
-      identityRef:
-        name: ${CLUSTER_NAME}-cloud-config
       image:
         name: ${OPENSTACK_IMAGE_NAME}
       sshKeyName: ${OPENSTACK_SSH_KEY_NAME}


### PR DESCRIPTION
**What this PR does / why we need it**:

We missed these files when removing `cloudName` from CI configs.
