### PR TITLE
🐛 Make LB additional ports security-group generation are dynamic

### DIFF
--- a/pkg/cloud/services/networking/securitygroups_rules.go
+++ b/pkg/cloud/services/networking/securitygroups_rules.go
@@ -223,11 +223,9 @@ func getSGControlPlaneAdditionalPorts(ports []int) []resolvedSecurityGroupRuleSp
 			Protocol:    "tcp",
 		},
 	}
-	for _, p := range ports {
-		r[0].PortRangeMin = p
-		r[0].PortRangeMax = p
-		r[1].PortRangeMin = p
-		r[1].PortRangeMax = p
+	for i, p := range ports {
+		r[i].PortRangeMin = p
+		r[i].PortRangeMax = p
 		controlPlaneRules = append(controlPlaneRules, r...)
 	}
 	return controlPlaneRules


### PR DESCRIPTION

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR makes sure that the logic for LB additional ports is dynamic to avoid unintended behaviour.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1917

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
