### PR TITLE
⚠️ Simplify v1alpha6 cluster restorer

### DIFF
--- a/api/v1alpha6/openstackclustertemplate_conversion.go
+++ b/api/v1alpha6/openstackclustertemplate_conversion.go
@@ -69,47 +69,15 @@ var v1alpha6OpenStackClusterTemplateRestorer = conversion.RestorerFor[*OpenStack
 }
 
 var v1beta1OpenStackClusterTemplateRestorer = conversion.RestorerFor[*infrav1.OpenStackClusterTemplate]{
-	"externalNetwork": conversion.UnconditionalFieldRestorer(
-		func(c *infrav1.OpenStackClusterTemplate) *infrav1.NetworkFilter {
-			return &c.Spec.Template.Spec.ExternalNetwork
+	"spec": conversion.HashedFieldRestorer(
+		func(c *infrav1.OpenStackClusterTemplate) *infrav1.OpenStackClusterTemplateSpec {
+			return &c.Spec
 		},
+		restorev1beta1ClusterTemplateSpec,
 	),
-	"disableExternalNetwork": conversion.UnconditionalFieldRestorer(
-		func(c *infrav1.OpenStackClusterTemplate) *bool {
-			return &c.Spec.Template.Spec.DisableExternalNetwork
-		},
-	),
-	"router": conversion.UnconditionalFieldRestorer(
-		func(c *infrav1.OpenStackClusterTemplate) **infrav1.RouterFilter {
-			return &c.Spec.Template.Spec.Router
-		},
-	),
-	"networkMtu": conversion.UnconditionalFieldRestorer(
-		func(c *infrav1.OpenStackClusterTemplate) *int {
-			return &c.Spec.Template.Spec.NetworkMTU
-		},
-	),
-	"bastion": conversion.HashedFieldRestorer(
-		func(c *infrav1.OpenStackClusterTemplate) **infrav1.Bastion {
-			return &c.Spec.Template.Spec.Bastion
-		},
-		restorev1beta1Bastion,
-	),
-	"subnets": conversion.HashedFieldRestorer(
-		func(c *infrav1.OpenStackClusterTemplate) *[]infrav1.SubnetFilter {
-			return &c.Spec.Template.Spec.Subnets
-		},
-		restorev1beta1Subnets,
-	),
-	"allNodesSecurityGroupRules": conversion.HashedFieldRestorer(
-		func(c *infrav1.OpenStackClusterTemplate) *infrav1.ManagedSecurityGroups {
-			return c.Spec.Template.Spec.ManagedSecurityGroups
-		},
-		restorev1beta1ManagedSecurityGroups,
-	),
-	"managedSubnets": conversion.UnconditionalFieldRestorer(
-		func(c *infrav1.OpenStackClusterTemplate) *[]infrav1.SubnetSpec {
-			return &c.Spec.Template.Spec.ManagedSubnets
-		},
-	),
+}
+
+func restorev1beta1ClusterTemplateSpec(previous *infrav1.OpenStackClusterTemplateSpec, dst *infrav1.OpenStackClusterTemplateSpec) {
+	restorev1beta1Bastion(&previous.Template.Spec.Bastion, &dst.Template.Spec.Bastion)
+	restorev1beta1ClusterSpec(&previous.Template.Spec, &dst.Template.Spec)
 }

--- a/api/v1alpha6/types_conversion.go
+++ b/api/v1alpha6/types_conversion.go
@@ -137,12 +137,6 @@ func restorev1alpha6SubnetFilter(previous *SubnetFilter, dst *SubnetFilter) {
 	dst.NotTagsAny = previous.NotTagsAny
 }
 
-func restorev1beta1Subnets(previous *[]infrav1.SubnetFilter, dst *[]infrav1.SubnetFilter) {
-	if len(*previous) > 1 {
-		*dst = append(*dst, (*previous)[1:]...)
-	}
-}
-
 func Convert_v1alpha6_SubnetParam_To_v1beta1_SubnetFilter(in *SubnetParam, out *infrav1.SubnetFilter, s apiconversion.Scope) error {
 	if err := Convert_v1alpha6_SubnetFilter_To_v1beta1_SubnetFilter(&in.Filter, out, s); err != nil {
 		return err

--- a/api/v1alpha7/openstackcluster_conversion.go
+++ b/api/v1alpha7/openstackcluster_conversion.go
@@ -74,7 +74,6 @@ var v1alpha7OpenStackClusterRestorer = conversion.RestorerFor[*OpenStackCluster]
 			return &c.Spec
 		},
 		restorev1alpha7ClusterSpec,
-
 		// Filter out Bastion, which is restored separately
 		conversion.HashedFilterField[*OpenStackCluster, OpenStackClusterSpec](
 			func(s *OpenStackClusterSpec) *OpenStackClusterSpec {
@@ -107,7 +106,6 @@ var v1beta1OpenStackClusterRestorer = conversion.RestorerFor[*infrav1.OpenStackC
 			return &c.Spec
 		},
 		restorev1beta1ClusterSpec,
-
 		// Filter out Bastion, which is restored separately
 		conversion.HashedFilterField[*infrav1.OpenStackCluster, infrav1.OpenStackClusterSpec](
 			func(s *infrav1.OpenStackClusterSpec) *infrav1.OpenStackClusterSpec {
@@ -167,11 +165,7 @@ func restorev1alpha7ClusterSpec(previous *OpenStackClusterSpec, dst *OpenStackCl
 }
 
 func restorev1beta1ClusterSpec(previous *infrav1.OpenStackClusterSpec, dst *infrav1.OpenStackClusterSpec) {
-	prevBastion := previous.Bastion
-	dstBastion := dst.Bastion
-	if prevBastion != nil && dstBastion != nil {
-		restorev1beta1MachineSpec(&prevBastion.Instance, &dstBastion.Instance)
-	}
+	// Bastion is restored separately
 
 	// Restore all fields except ID, which should have been copied over in conversion
 	dst.ExternalNetwork.Name = previous.ExternalNetwork.Name

--- a/api/v1alpha7/openstackmachine_conversion.go
+++ b/api/v1alpha7/openstackmachine_conversion.go
@@ -81,7 +81,6 @@ var v1beta1OpenStackMachineRestorer = conversion.RestorerFor[*infrav1.OpenStackM
 			return &c.Status.DependentResources
 		},
 	),
-
 	// No equivalent in v1alpha7
 	"refresources": conversion.UnconditionalFieldRestorer(
 		func(c *infrav1.OpenStackMachine) *infrav1.ReferencedMachineResources {


### PR DESCRIPTION
This is a breaking change, although it should not have any negative effects in practise.

The v1alpha6 cluster restorer had become too complex with too many individual fields. This change reduces the number of fields to be consistent with the v1alpha7 restorer.

With this change, an object stored as v1alpha6 with previous v1beta1 annotations could have fields in its spec restored to a semantically equivalent but slightly different serialisation when converted to v1beta1. Differences in the bastion and status are not affected.

In practise this should not matter for 2 reasons:
* The storage version is v1beta1, so the annotation should have been freshly generated in the new format anyway.
* Even if it were not, and the v1alpha6 were under external control, the external controller would observe a difference and restore it to the previous version. It would then be converted again with the new annotation. This would happen only once per object.

Note that if the object is not under external control these differences should not matter anyway.

/hold
