### PR TITLE
Fix CRD generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,9 +274,11 @@ generate-conversion-gen: $(CONVERSION_GEN)
 .PHONY: generate-manifests
 generate-manifests: $(CONTROLLER_GEN) ## Generate manifests e.g. CRD, RBAC etc.
 	$(CONTROLLER_GEN) \
-		paths=./pkg/webhooks/... \
+		paths=./api/... \
 		crd:crdVersions=v1 \
-		output:crd:dir=$(CRD_ROOT) \
+		output:crd:dir=$(CRD_ROOT)
+	$(CONTROLLER_GEN) \
+		paths=./pkg/webhooks/... \
 		output:webhook:dir=$(WEBHOOK_ROOT) \
 		webhook
 	$(CONTROLLER_GEN) \


### PR DESCRIPTION
When moving the webhooks in https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1920 we didn't separate CRD generation from webhook generation, meaning controller-gen was looking for CRDs to generate in pkg/webhook. This resulted in CRDs not being generated.