### PR TITLE
🌱 Allow generating api-docs for individual versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,22 +288,13 @@ generate-manifests: $(CONTROLLER_GEN) ## Generate manifests e.g. CRD, RBAC etc.
 		rbac:roleName=manager-role
 
 .PHONY: generate-api-docs
-generate-api-docs: $(GEN_CRD_API_REFERENCE_DOCS) ## Generate api documentation
+generate-api-docs: generate-api-docs-v1beta1 generate-api-docs-v1alpha7 generate-api-docs-v1alpha6
+generate-api-docs-%: $(GEN_CRD_API_REFERENCE_DOCS) FORCE
 	$(GEN_CRD_API_REFERENCE_DOCS) \
-		-api-dir=./api/v1beta1 \
+		-api-dir=./api/$* \
 		-config=./docs/book/gen-crd-api-reference-docs/config.json \
 		-template-dir=./docs/book/gen-crd-api-reference-docs/template \
-		-out-file=./docs/book/src/api/v1beta1/api.md
-	$(GEN_CRD_API_REFERENCE_DOCS) \
-		-api-dir=./api/v1alpha7 \
-		-config=./docs/book/gen-crd-api-reference-docs/config.json \
-		-template-dir=./docs/book/gen-crd-api-reference-docs/template \
-		-out-file=./docs/book/src/api/v1alpha7/api.md
-	$(GEN_CRD_API_REFERENCE_DOCS) \
-		-api-dir=./api/v1alpha6 \
-		-config=./docs/book/gen-crd-api-reference-docs/config.json \
-		-template-dir=./docs/book/gen-crd-api-reference-docs/template \
-		-out-file=./docs/book/src/api/v1alpha6/api.md
+		-out-file=./docs/book/src/api/$*/api.md
 
 ## --------------------------------------
 ##@ Docker


### PR DESCRIPTION
This change creates separate targets for individual API targets when generating api documentation. The generate-api-docs target continues to execute all of them as before.