### PR TITLE
⚠️ Rename fields to correctly do uppercase acronyms

### DIFF
--- a/api/v1beta1/openstackcluster_types.go
+++ b/api/v1beta1/openstackcluster_types.go
@@ -59,7 +59,7 @@ type OpenStackClusterSpec struct {
 	// If left empty, the network will have the default MTU defined in Openstack network service.
 	// To use this field, the Openstack installation requires the net-mtu neutron API extension.
 	// +optional
-	NetworkMTU int `json:"networkMtu,omitempty"`
+	NetworkMTU int `json:"networkMTU,omitempty"`
 
 	// ExternalRouterIPs is an array of externalIPs on the respective subnets.
 	// This is necessary if the router needs a fixed ip in a specific subnet.

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -79,7 +79,7 @@ type SecurityGroupFilter struct {
 	ID          string `json:"id,omitempty"`
 	Name        string `json:"name,omitempty"`
 	Description string `json:"description,omitempty"`
-	ProjectID   string `json:"projectId,omitempty"`
+	ProjectID   string `json:"projectID,omitempty"`
 
 	FilterByNeutronTags `json:",inline"`
 }
@@ -87,7 +87,7 @@ type SecurityGroupFilter struct {
 type NetworkFilter struct {
 	Name        string `json:"name,omitempty"`
 	Description string `json:"description,omitempty"`
-	ProjectID   string `json:"projectId,omitempty"`
+	ProjectID   string `json:"projectID,omitempty"`
 	ID          string `json:"id,omitempty"`
 
 	FilterByNeutronTags `json:",inline"`
@@ -96,12 +96,12 @@ type NetworkFilter struct {
 type SubnetFilter struct {
 	Name            string `json:"name,omitempty"`
 	Description     string `json:"description,omitempty"`
-	ProjectID       string `json:"projectId,omitempty"`
+	ProjectID       string `json:"projectID,omitempty"`
 	IPVersion       int    `json:"ipVersion,omitempty"`
-	GatewayIP       string `json:"gateway_ip,omitempty"`
+	GatewayIP       string `json:"gatewayIP,omitempty"`
 	CIDR            string `json:"cidr,omitempty"`
 	IPv6AddressMode string `json:"ipv6AddressMode,omitempty"`
-	IPv6RAMode      string `json:"ipv6RaMode,omitempty"`
+	IPv6RAMode      string `json:"ipv6RAMode,omitempty"`
 	ID              string `json:"id,omitempty"`
 
 	FilterByNeutronTags `json:",inline"`
@@ -111,7 +111,7 @@ type RouterFilter struct {
 	ID          string `json:"id,omitempty"`
 	Name        string `json:"name,omitempty"`
 	Description string `json:"description,omitempty"`
-	ProjectID   string `json:"projectId,omitempty"`
+	ProjectID   string `json:"projectID,omitempty"`
 
 	FilterByNeutronTags `json:",inline"`
 }
@@ -190,7 +190,7 @@ type PortOpts struct {
 
 	// HostID specifies the ID of the host where the port resides.
 	// +optional
-	HostID optional.String `json:"hostId,omitempty"`
+	HostID optional.String `json:"hostID,omitempty"`
 
 	// VNICType specifies the type of vNIC which this port should be
 	// attached to. This is used to determine which mechanism driver(s) to
@@ -596,7 +596,7 @@ type APIServerLoadBalancer struct {
 	// AdditionalPorts adds additional tcp ports to the load balancer.
 	AdditionalPorts []int `json:"additionalPorts,omitempty"`
 	// AllowedCIDRs restrict access to all API-Server listeners to the given address CIDRs.
-	AllowedCIDRs []string `json:"allowedCidrs,omitempty"`
+	AllowedCIDRs []string `json:"allowedCIDRs,omitempty"`
 	// Octavia Provider Used to create load balancer
 	Provider string `json:"provider,omitempty"`
 }

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -4874,7 +4874,7 @@ spec:
                     items:
                       type: integer
                     type: array
-                  allowedCidrs:
+                  allowedCIDRs:
                     description: AllowedCIDRs restrict access to all API-Server listeners
                       to the given address CIDRs.
                     items:
@@ -5094,7 +5094,7 @@ spec:
                                         type: string
                                       description:
                                         type: string
-                                      gateway_ip:
+                                      gatewayIP:
                                         type: string
                                       id:
                                         type: string
@@ -5102,7 +5102,7 @@ spec:
                                         type: integer
                                       ipv6AddressMode:
                                         type: string
-                                      ipv6RaMode:
+                                      ipv6RAMode:
                                         type: string
                                       name:
                                         type: string
@@ -5132,7 +5132,7 @@ spec:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: set
-                                      projectId:
+                                      projectID:
                                         type: string
                                       tags:
                                         description: |-
@@ -5165,7 +5165,7 @@ spec:
                                 type: object
                               type: array
                               x-kubernetes-list-type: atomic
-                            hostId:
+                            hostID:
                               description: HostID specifies the ID of the host where
                                 the port resides.
                               type: string
@@ -5216,7 +5216,7 @@ spec:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: set
-                                projectId:
+                                projectID:
                                   type: string
                                 tags:
                                   description: |-
@@ -5307,7 +5307,7 @@ spec:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: set
-                                  projectId:
+                                  projectID:
                                     type: string
                                   tags:
                                     description: |-
@@ -5447,7 +5447,7 @@ spec:
                                 type: string
                               type: array
                               x-kubernetes-list-type: set
-                            projectId:
+                            projectID:
                               type: string
                             tags:
                               description: |-
@@ -5617,7 +5617,7 @@ spec:
                       type: string
                     type: array
                     x-kubernetes-list-type: set
-                  projectId:
+                  projectID:
                     type: string
                   tags:
                     description: |-
@@ -5664,7 +5664,7 @@ spec:
                           type: string
                         description:
                           type: string
-                        gateway_ip:
+                        gatewayIP:
                           type: string
                         id:
                           type: string
@@ -5672,7 +5672,7 @@ spec:
                           type: integer
                         ipv6AddressMode:
                           type: string
-                        ipv6RaMode:
+                        ipv6RAMode:
                           type: string
                         name:
                           type: string
@@ -5702,7 +5702,7 @@ spec:
                             type: string
                           type: array
                           x-kubernetes-list-type: set
-                        projectId:
+                        projectID:
                           type: string
                         tags:
                           description: |-
@@ -5930,7 +5930,7 @@ spec:
                       type: string
                     type: array
                     x-kubernetes-list-type: set
-                  projectId:
+                  projectID:
                     type: string
                   tags:
                     description: |-
@@ -5960,7 +5960,7 @@ spec:
                     type: array
                     x-kubernetes-list-type: set
                 type: object
-              networkMtu:
+              networkMTU:
                 description: |-
                   NetworkMTU sets the maximum transmission unit (MTU) value to address fragmentation for the private network ID.
                   This value will be used only if the Cluster actuator creates the network.
@@ -6004,7 +6004,7 @@ spec:
                       type: string
                     type: array
                     x-kubernetes-list-type: set
-                  projectId:
+                  projectID:
                     type: string
                   tags:
                     description: |-
@@ -6047,7 +6047,7 @@ spec:
                       type: string
                     description:
                       type: string
-                    gateway_ip:
+                    gatewayIP:
                       type: string
                     id:
                       type: string
@@ -6055,7 +6055,7 @@ spec:
                       type: integer
                     ipv6AddressMode:
                       type: string
-                    ipv6RaMode:
+                    ipv6RAMode:
                       type: string
                     name:
                       type: string
@@ -6085,7 +6085,7 @@ spec:
                         type: string
                       type: array
                       x-kubernetes-list-type: set
-                    projectId:
+                    projectID:
                       type: string
                     tags:
                       description: |-
@@ -6253,7 +6253,7 @@ spec:
                                         type: string
                                       description:
                                         type: string
-                                      gateway_ip:
+                                      gatewayIP:
                                         type: string
                                       id:
                                         type: string
@@ -6261,7 +6261,7 @@ spec:
                                         type: integer
                                       ipv6AddressMode:
                                         type: string
-                                      ipv6RaMode:
+                                      ipv6RAMode:
                                         type: string
                                       name:
                                         type: string
@@ -6291,7 +6291,7 @@ spec:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: set
-                                      projectId:
+                                      projectID:
                                         type: string
                                       tags:
                                         description: |-
@@ -6324,7 +6324,7 @@ spec:
                                 type: object
                               type: array
                               x-kubernetes-list-type: atomic
-                            hostId:
+                            hostID:
                               description: HostID specifies the ID of the host where
                                 the port resides.
                               type: string
@@ -6375,7 +6375,7 @@ spec:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: set
-                                projectId:
+                                projectID:
                                   type: string
                                 tags:
                                   description: |-
@@ -6466,7 +6466,7 @@ spec:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: set
-                                  projectId:
+                                  projectID:
                                     type: string
                                   tags:
                                     description: |-

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
@@ -2298,7 +2298,7 @@ spec:
                             items:
                               type: integer
                             type: array
-                          allowedCidrs:
+                          allowedCIDRs:
                             description: AllowedCIDRs restrict access to all API-Server
                               listeners to the given address CIDRs.
                             items:
@@ -2522,7 +2522,7 @@ spec:
                                                 type: string
                                               description:
                                                 type: string
-                                              gateway_ip:
+                                              gatewayIP:
                                                 type: string
                                               id:
                                                 type: string
@@ -2530,7 +2530,7 @@ spec:
                                                 type: integer
                                               ipv6AddressMode:
                                                 type: string
-                                              ipv6RaMode:
+                                              ipv6RAMode:
                                                 type: string
                                               name:
                                                 type: string
@@ -2560,7 +2560,7 @@ spec:
                                                   type: string
                                                 type: array
                                                 x-kubernetes-list-type: set
-                                              projectId:
+                                              projectID:
                                                 type: string
                                               tags:
                                                 description: |-
@@ -2593,7 +2593,7 @@ spec:
                                         type: object
                                       type: array
                                       x-kubernetes-list-type: atomic
-                                    hostId:
+                                    hostID:
                                       description: HostID specifies the ID of the
                                         host where the port resides.
                                       type: string
@@ -2645,7 +2645,7 @@ spec:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: set
-                                        projectId:
+                                        projectID:
                                           type: string
                                         tags:
                                           description: |-
@@ -2737,7 +2737,7 @@ spec:
                                               type: string
                                             type: array
                                             x-kubernetes-list-type: set
-                                          projectId:
+                                          projectID:
                                             type: string
                                           tags:
                                             description: |-
@@ -2878,7 +2878,7 @@ spec:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: set
-                                    projectId:
+                                    projectID:
                                       type: string
                                     tags:
                                       description: |-
@@ -3049,7 +3049,7 @@ spec:
                               type: string
                             type: array
                             x-kubernetes-list-type: set
-                          projectId:
+                          projectID:
                             type: string
                           tags:
                             description: |-
@@ -3096,7 +3096,7 @@ spec:
                                   type: string
                                 description:
                                   type: string
-                                gateway_ip:
+                                gatewayIP:
                                   type: string
                                 id:
                                   type: string
@@ -3104,7 +3104,7 @@ spec:
                                   type: integer
                                 ipv6AddressMode:
                                   type: string
-                                ipv6RaMode:
+                                ipv6RAMode:
                                   type: string
                                 name:
                                   type: string
@@ -3134,7 +3134,7 @@ spec:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: set
-                                projectId:
+                                projectID:
                                   type: string
                                 tags:
                                   description: |-
@@ -3364,7 +3364,7 @@ spec:
                               type: string
                             type: array
                             x-kubernetes-list-type: set
-                          projectId:
+                          projectID:
                             type: string
                           tags:
                             description: |-
@@ -3394,7 +3394,7 @@ spec:
                             type: array
                             x-kubernetes-list-type: set
                         type: object
-                      networkMtu:
+                      networkMTU:
                         description: |-
                           NetworkMTU sets the maximum transmission unit (MTU) value to address fragmentation for the private network ID.
                           This value will be used only if the Cluster actuator creates the network.
@@ -3438,7 +3438,7 @@ spec:
                               type: string
                             type: array
                             x-kubernetes-list-type: set
-                          projectId:
+                          projectID:
                             type: string
                           tags:
                             description: |-
@@ -3481,7 +3481,7 @@ spec:
                               type: string
                             description:
                               type: string
-                            gateway_ip:
+                            gatewayIP:
                               type: string
                             id:
                               type: string
@@ -3489,7 +3489,7 @@ spec:
                               type: integer
                             ipv6AddressMode:
                               type: string
-                            ipv6RaMode:
+                            ipv6RAMode:
                               type: string
                             name:
                               type: string
@@ -3519,7 +3519,7 @@ spec:
                                 type: string
                               type: array
                               x-kubernetes-list-type: set
-                            projectId:
+                            projectID:
                               type: string
                             tags:
                               description: |-

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
@@ -1895,7 +1895,7 @@ spec:
                                 type: string
                               description:
                                 type: string
-                              gateway_ip:
+                              gatewayIP:
                                 type: string
                               id:
                                 type: string
@@ -1903,7 +1903,7 @@ spec:
                                 type: integer
                               ipv6AddressMode:
                                 type: string
-                              ipv6RaMode:
+                              ipv6RAMode:
                                 type: string
                               name:
                                 type: string
@@ -1933,7 +1933,7 @@ spec:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: set
-                              projectId:
+                              projectID:
                                 type: string
                               tags:
                                 description: |-
@@ -1966,7 +1966,7 @@ spec:
                         type: object
                       type: array
                       x-kubernetes-list-type: atomic
-                    hostId:
+                    hostID:
                       description: HostID specifies the ID of the host where the port
                         resides.
                       type: string
@@ -2016,7 +2016,7 @@ spec:
                             type: string
                           type: array
                           x-kubernetes-list-type: set
-                        projectId:
+                        projectID:
                           type: string
                         tags:
                           description: |-
@@ -2107,7 +2107,7 @@ spec:
                               type: string
                             type: array
                             x-kubernetes-list-type: set
-                          projectId:
+                          projectID:
                             type: string
                           tags:
                             description: |-
@@ -2245,7 +2245,7 @@ spec:
                         type: string
                       type: array
                       x-kubernetes-list-type: set
-                    projectId:
+                    projectID:
                       type: string
                     tags:
                       description: |-
@@ -2514,7 +2514,7 @@ spec:
                                     type: string
                                   description:
                                     type: string
-                                  gateway_ip:
+                                  gatewayIP:
                                     type: string
                                   id:
                                     type: string
@@ -2522,7 +2522,7 @@ spec:
                                     type: integer
                                   ipv6AddressMode:
                                     type: string
-                                  ipv6RaMode:
+                                  ipv6RAMode:
                                     type: string
                                   name:
                                     type: string
@@ -2552,7 +2552,7 @@ spec:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: set
-                                  projectId:
+                                  projectID:
                                     type: string
                                   tags:
                                     description: |-
@@ -2585,7 +2585,7 @@ spec:
                             type: object
                           type: array
                           x-kubernetes-list-type: atomic
-                        hostId:
+                        hostID:
                           description: HostID specifies the ID of the host where the
                             port resides.
                           type: string
@@ -2635,7 +2635,7 @@ spec:
                                 type: string
                               type: array
                               x-kubernetes-list-type: set
-                            projectId:
+                            projectID:
                               type: string
                             tags:
                               description: |-
@@ -2726,7 +2726,7 @@ spec:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: set
-                              projectId:
+                              projectID:
                                 type: string
                               tags:
                                 description: |-

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
@@ -1569,7 +1569,7 @@ spec:
                                         type: string
                                       description:
                                         type: string
-                                      gateway_ip:
+                                      gatewayIP:
                                         type: string
                                       id:
                                         type: string
@@ -1577,7 +1577,7 @@ spec:
                                         type: integer
                                       ipv6AddressMode:
                                         type: string
-                                      ipv6RaMode:
+                                      ipv6RAMode:
                                         type: string
                                       name:
                                         type: string
@@ -1607,7 +1607,7 @@ spec:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: set
-                                      projectId:
+                                      projectID:
                                         type: string
                                       tags:
                                         description: |-
@@ -1640,7 +1640,7 @@ spec:
                                 type: object
                               type: array
                               x-kubernetes-list-type: atomic
-                            hostId:
+                            hostID:
                               description: HostID specifies the ID of the host where
                                 the port resides.
                               type: string
@@ -1691,7 +1691,7 @@ spec:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: set
-                                projectId:
+                                projectID:
                                   type: string
                                 tags:
                                   description: |-
@@ -1782,7 +1782,7 @@ spec:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: set
-                                  projectId:
+                                  projectID:
                                     type: string
                                   tags:
                                     description: |-
@@ -1922,7 +1922,7 @@ spec:
                                 type: string
                               type: array
                               x-kubernetes-list-type: set
-                            projectId:
+                            projectID:
                               type: string
                             tags:
                               description: |-

--- a/docs/book/src/api/v1beta1/api.md
+++ b/docs/book/src/api/v1beta1/api.md
@@ -131,7 +131,7 @@ must be IPv4 and the other IPv6.</p>
 </tr>
 <tr>
 <td>
-<code>networkMtu</code><br/>
+<code>networkMTU</code><br/>
 <em>
 int
 </em>
@@ -842,7 +842,7 @@ bool
 </tr>
 <tr>
 <td>
-<code>allowedCidrs</code><br/>
+<code>allowedCIDRs</code><br/>
 <em>
 []string
 </em>
@@ -1780,7 +1780,7 @@ string
 </tr>
 <tr>
 <td>
-<code>projectId</code><br/>
+<code>projectID</code><br/>
 <em>
 string
 </em>
@@ -2005,7 +2005,7 @@ must be IPv4 and the other IPv6.</p>
 </tr>
 <tr>
 <td>
-<code>networkMtu</code><br/>
+<code>networkMTU</code><br/>
 <em>
 int
 </em>
@@ -2550,7 +2550,7 @@ must be IPv4 and the other IPv6.</p>
 </tr>
 <tr>
 <td>
-<code>networkMtu</code><br/>
+<code>networkMTU</code><br/>
 <em>
 int
 </em>
@@ -3619,7 +3619,7 @@ bastion host.</p>
 </tr>
 <tr>
 <td>
-<code>hostId</code><br/>
+<code>hostID</code><br/>
 <em>
 string
 </em>
@@ -3968,7 +3968,7 @@ string
 </tr>
 <tr>
 <td>
-<code>projectId</code><br/>
+<code>projectID</code><br/>
 <em>
 string
 </em>
@@ -4042,7 +4042,7 @@ string
 </tr>
 <tr>
 <td>
-<code>projectId</code><br/>
+<code>projectID</code><br/>
 <em>
 string
 </em>
@@ -4590,7 +4590,7 @@ string
 </tr>
 <tr>
 <td>
-<code>projectId</code><br/>
+<code>projectID</code><br/>
 <em>
 string
 </em>
@@ -4610,7 +4610,7 @@ int
 </tr>
 <tr>
 <td>
-<code>gateway_ip</code><br/>
+<code>gatewayIP</code><br/>
 <em>
 string
 </em>
@@ -4640,7 +4640,7 @@ string
 </tr>
 <tr>
 <td>
-<code>ipv6RaMode</code><br/>
+<code>ipv6RAMode</code><br/>
 <em>
 string
 </em>

--- a/docs/book/src/clusteropenstack/configuration.md
+++ b/docs/book/src/clusteropenstack/configuration.md
@@ -313,7 +313,7 @@ metadata:
   namespace: <cluster-namespace>
 spec:
   apiServerLoadBalancer:
-    allowedCidrs:
+    allowedCIDRs:
     - 192.168.10/24
     - 10.10.0.0/16
 ```

--- a/docs/book/src/topics/crd-changes/v1alpha7-to-v1beta1.md
+++ b/docs/book/src/topics/crd-changes/v1alpha7-to-v1beta1.md
@@ -25,7 +25,10 @@
       - [Change to managedSecurityGroups](#change-to-managedsecuritygroups)
       - [Calico CNI](#calico-cni)
       - [Change to network](#change-to-network)
-    - [Changes to filter tags](#changes-to-filter-tags)
+      - [Change to networkMtu](#change-to-networkmtu)
+    - [Changes to filters](#changes-to-filters)
+      - [Changes to filter tags](#changes-to-filter-tags)
+      - [Field capitalization consistency](#field-capitalization-consistency)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -95,6 +98,11 @@ When specifying `allowedAddressPairs`, `ipAddress` is now required. Neutron has 
 Setting either of the following fields explicitly to the empty string would previously have caused the default behaviour to be used. In v1beta1 it will result in an empty string being used instead. To retain the default behaviour in v1beta1, do not set the value at all. When objects are upgraded automatically by the controller, empty values will become unset values by default, so this applies only to newly created objects.
 * nameSuffix
 * description
+
+The following fields in `PortOpts` are renamed in order to keep them consistent with K8s API conventions:
+
+* `hostId` becomes `hostID`
+* `allowedCidrs` becomes `allowedCIDRs`
 
 ### `OpenStackCluster`
 
@@ -314,7 +322,13 @@ allow backwards compatibility if `allowAllInClusterTraffic` is set to false.
 
 In v1beta1, when the `OpenStackCluster.Spec.Network` is not defined, the `Subnets` are now used to identify the `Network`.
 
-### Changes to filter tags
+#### Change to networkMtu
+
+In v1beta1, `OpenStackCluster.spec.NetworkMtu` becomes `OpenStackCluster.spec.NetworkMTU` in order to keep the name consistent with K8s API conventions.
+
+### Changes to filters
+
+#### Changes to filter tags
 
 We currently define filters on 4 different Neutron resources which are used throughout the API:
 * Networks
@@ -343,3 +357,18 @@ subnet:
 ```
 
 Due to the limitations of the encoding of tag queries in Neutron, tags must be non-empty and may not contain commas. Tags will be automatically converted to a list of tags during conversion.
+
+#### Field capitalization consistency
+
+In order to keep field names consistent with K8s API conventions, various fields in the `Filters` are renamed. This includes:
+
+* `SecurityGroupFilter`
+  * `projectId` becomes `projectID`
+* `NetworkFilter`
+  * `projectId` becomes `projectID`
+* `SubnetFilter`
+  * `projectId` becomes `projectID`
+  * `gateway_ip` becomes `gatewayIP`
+  * `ipv6RaMode` becomes `ipv6RAMode`
+* `RouterFilter`
+  * `projectId` becomes `projectID`


### PR DESCRIPTION
**What this PR does / why we need it**:
K8s API conventions require the acronyms in the field names to be uppercase if not being the first word in the name. We aren't following this in several places and this commit fixes these occurrences:

* `projectId` becomes `projectID`
* `gateway_ip` becomes `gatewayIP`
* `ipv6RaMode` becomes `ipv6RAMode`
* `networkMtu` becomes `networkMTU`
* `hostId` becomes `hostID`
* `allowedCidrs` becomes `allowedCIDRs`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1933

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- if necessary:
  - [X] includes documentation
  - [X] adds unit tests

/hold
