### PR TITLE
test: bump Flatcar version

### DIFF
--- a/hack/ci/cloud-init/controller.yaml.tpl
+++ b/hack/ci/cloud-init/controller.yaml.tpl
@@ -70,7 +70,7 @@
     IMAGE_URLS+="https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/cirros/2022-12-05/cirros-0.6.1-x86_64-disk.img,"
     IMAGE_URLS+="https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/ubuntu/2023-09-29/ubuntu-2204-kube-v1.27.2.img,"
     IMAGE_URLS+="https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/ubuntu/2024-01-10/ubuntu-2204-kube-v1.28.5.img,"
-    IMAGE_URLS+="https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/flatcar/flatcar-stable-3760.2.0-kube-v1.28.5.img,"
+    IMAGE_URLS+="https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/flatcar/flatcar-stable-3815.2.0-kube-v1.28.5.img,"
     IMAGE_URLS+="https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_openstack_image.img"
 
     [[post-config|$NOVA_CONF]]

--- a/kustomize/v1alpha7/flatcar-sysext/patch-flatcar.yaml
+++ b/kustomize/v1alpha7/flatcar-sysext/patch-flatcar.yaml
@@ -18,15 +18,12 @@ spec:
       nodeRegistration:
         name: $${COREOS_OPENSTACK_HOSTNAME}
         kubeletExtraArgs:
-          provider-id: null
+          provider-id: openstack:///$${COREOS_OPENSTACK_INSTANCE_UUID}
     initConfiguration:
       nodeRegistration:
         name: $${COREOS_OPENSTACK_HOSTNAME}
         kubeletExtraArgs:
-          # Fixme(lentzi90): This is here just to override the value set in the default
-          # kustomization. It will be replaced with a value that works for flatcar in
-          # https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1564
-          provider-id: null
+          provider-id: openstack:///$${COREOS_OPENSTACK_INSTANCE_UUID}
     format: ignition
     ignition:
       containerLinuxConfig:
@@ -86,6 +83,7 @@ spec:
                       EnvironmentFile=/run/metadata/flatcar
     preKubeadmCommands:
       - export COREOS_OPENSTACK_HOSTNAME=$${COREOS_OPENSTACK_HOSTNAME%.*}
+      - export COREOS_OPENSTACK_INSTANCE_UUID=$${COREOS_OPENSTACK_INSTANCE_UUID}
       - envsubst < /etc/kubeadm.yml > /etc/kubeadm.yml.tmp
       - mv /etc/kubeadm.yml.tmp /etc/kubeadm.yml
 ---
@@ -100,12 +98,10 @@ spec:
         nodeRegistration:
           name: $${COREOS_OPENSTACK_HOSTNAME}
           kubeletExtraArgs:
-            # Fixme(lentzi90): This is here just to override the value set in the default
-            # kustomization. It will be replaced with a value that works for flatcar in
-            # https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1564
-            provider-id: null
+            provider-id: openstack:///$${COREOS_OPENSTACK_INSTANCE_UUID}
       preKubeadmCommands:
         - export COREOS_OPENSTACK_HOSTNAME=$${COREOS_OPENSTACK_HOSTNAME%.*}
+        - export COREOS_OPENSTACK_INSTANCE_UUID=$${COREOS_OPENSTACK_INSTANCE_UUID}
         - envsubst < /etc/kubeadm.yml > /etc/kubeadm.yml.tmp
         - mv /etc/kubeadm.yml.tmp /etc/kubeadm.yml
       format: ignition

--- a/kustomize/v1alpha7/flatcar/patch-flatcar.yaml
+++ b/kustomize/v1alpha7/flatcar/patch-flatcar.yaml
@@ -18,15 +18,12 @@ spec:
       nodeRegistration:
         name: $${COREOS_OPENSTACK_HOSTNAME}
         kubeletExtraArgs:
-          provider-id: null
+          provider-id: openstack:///$${COREOS_OPENSTACK_INSTANCE_UUID}
     initConfiguration:
       nodeRegistration:
         name: $${COREOS_OPENSTACK_HOSTNAME}
         kubeletExtraArgs:
-          # Fixme(lentzi90): This is here just to override the value set in the default
-          # kustomization. It will be replaced with a value that works for flatcar in
-          # https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1564
-          provider-id: null
+          provider-id: openstack:///$${COREOS_OPENSTACK_INSTANCE_UUID}
     format: ignition
     ignition:
       containerLinuxConfig:
@@ -48,6 +45,7 @@ spec:
                   EnvironmentFile=/run/metadata/flatcar
     preKubeadmCommands:
       - export COREOS_OPENSTACK_HOSTNAME=$${COREOS_OPENSTACK_HOSTNAME%.*}
+      - export COREOS_OPENSTACK_INSTANCE_UUID=$${COREOS_OPENSTACK_INSTANCE_UUID}
       - envsubst < /etc/kubeadm.yml > /etc/kubeadm.yml.tmp
       - mv /etc/kubeadm.yml.tmp /etc/kubeadm.yml
 ---
@@ -62,12 +60,10 @@ spec:
         nodeRegistration:
           name: $${COREOS_OPENSTACK_HOSTNAME}
           kubeletExtraArgs:
-            # Fixme(lentzi90): This is here just to override the value set in the default
-            # kustomization. It will be replaced with a value that works for flatcar in
-            # https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1564
-            provider-id: null
+            provider-id: openstack:///$${COREOS_OPENSTACK_INSTANCE_UUID}
       preKubeadmCommands:
         - export COREOS_OPENSTACK_HOSTNAME=$${COREOS_OPENSTACK_HOSTNAME%.*}
+        - export COREOS_OPENSTACK_INSTANCE_UUID=$${COREOS_OPENSTACK_INSTANCE_UUID}
         - envsubst < /etc/kubeadm.yml > /etc/kubeadm.yml.tmp
         - mv /etc/kubeadm.yml.tmp /etc/kubeadm.yml
       format: ignition

--- a/kustomize/v1beta1/flatcar-sysext/patch-flatcar.yaml
+++ b/kustomize/v1beta1/flatcar-sysext/patch-flatcar.yaml
@@ -18,15 +18,12 @@ spec:
       nodeRegistration:
         name: $${COREOS_OPENSTACK_HOSTNAME}
         kubeletExtraArgs:
-          provider-id: null
+          provider-id: openstack:///$${COREOS_OPENSTACK_INSTANCE_UUID}
     initConfiguration:
       nodeRegistration:
         name: $${COREOS_OPENSTACK_HOSTNAME}
         kubeletExtraArgs:
-          # Fixme(lentzi90): This is here just to override the value set in the default
-          # kustomization. It will be replaced with a value that works for flatcar in
-          # https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1564
-          provider-id: null
+          provider-id: openstack:///$${COREOS_OPENSTACK_INSTANCE_UUID}
     format: ignition
     ignition:
       containerLinuxConfig:
@@ -86,6 +83,7 @@ spec:
                       EnvironmentFile=/run/metadata/flatcar
     preKubeadmCommands:
       - export COREOS_OPENSTACK_HOSTNAME=$${COREOS_OPENSTACK_HOSTNAME%.*}
+      - export COREOS_OPENSTACK_INSTANCE_UUID=$${COREOS_OPENSTACK_INSTANCE_UUID}
       - envsubst < /etc/kubeadm.yml > /etc/kubeadm.yml.tmp
       - mv /etc/kubeadm.yml.tmp /etc/kubeadm.yml
 ---
@@ -100,12 +98,10 @@ spec:
         nodeRegistration:
           name: $${COREOS_OPENSTACK_HOSTNAME}
           kubeletExtraArgs:
-            # Fixme(lentzi90): This is here just to override the value set in the default
-            # kustomization. It will be replaced with a value that works for flatcar in
-            # https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1564
-            provider-id: null
+            provider-id: openstack:///$${COREOS_OPENSTACK_INSTANCE_UUID}
       preKubeadmCommands:
         - export COREOS_OPENSTACK_HOSTNAME=$${COREOS_OPENSTACK_HOSTNAME%.*}
+        - export COREOS_OPENSTACK_INSTANCE_UUID=$${COREOS_OPENSTACK_INSTANCE_UUID}
         - envsubst < /etc/kubeadm.yml > /etc/kubeadm.yml.tmp
         - mv /etc/kubeadm.yml.tmp /etc/kubeadm.yml
       format: ignition

--- a/kustomize/v1beta1/flatcar/patch-flatcar.yaml
+++ b/kustomize/v1beta1/flatcar/patch-flatcar.yaml
@@ -18,15 +18,12 @@ spec:
       nodeRegistration:
         name: $${COREOS_OPENSTACK_HOSTNAME}
         kubeletExtraArgs:
-          provider-id: null
+          provider-id: openstack:///$${COREOS_OPENSTACK_INSTANCE_UUID}
     initConfiguration:
       nodeRegistration:
         name: $${COREOS_OPENSTACK_HOSTNAME}
         kubeletExtraArgs:
-          # Fixme(lentzi90): This is here just to override the value set in the default
-          # kustomization. It will be replaced with a value that works for flatcar in
-          # https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1564
-          provider-id: null
+          provider-id: openstack:///$${COREOS_OPENSTACK_INSTANCE_UUID}
     format: ignition
     ignition:
       containerLinuxConfig:
@@ -48,6 +45,7 @@ spec:
                   EnvironmentFile=/run/metadata/flatcar
     preKubeadmCommands:
       - export COREOS_OPENSTACK_HOSTNAME=$${COREOS_OPENSTACK_HOSTNAME%.*}
+      - export COREOS_OPENSTACK_INSTANCE_UUID=$${COREOS_OPENSTACK_INSTANCE_UUID}
       - envsubst < /etc/kubeadm.yml > /etc/kubeadm.yml.tmp
       - mv /etc/kubeadm.yml.tmp /etc/kubeadm.yml
 ---
@@ -62,12 +60,10 @@ spec:
         nodeRegistration:
           name: $${COREOS_OPENSTACK_HOSTNAME}
           kubeletExtraArgs:
-            # Fixme(lentzi90): This is here just to override the value set in the default
-            # kustomization. It will be replaced with a value that works for flatcar in
-            # https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1564
-            provider-id: null
+            provider-id: openstack:///$${COREOS_OPENSTACK_INSTANCE_UUID}
       preKubeadmCommands:
         - export COREOS_OPENSTACK_HOSTNAME=$${COREOS_OPENSTACK_HOSTNAME%.*}
+        - export COREOS_OPENSTACK_INSTANCE_UUID=$${COREOS_OPENSTACK_INSTANCE_UUID}
         - envsubst < /etc/kubeadm.yml > /etc/kubeadm.yml.tmp
         - mv /etc/kubeadm.yml.tmp /etc/kubeadm.yml
       format: ignition

--- a/templates/cluster-template-flatcar-sysext.yaml
+++ b/templates/cluster-template-flatcar-sysext.yaml
@@ -77,9 +77,11 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             cloud-provider: external
+            provider-id: openstack:///$${COREOS_OPENSTACK_INSTANCE_UUID}
           name: $${COREOS_OPENSTACK_HOSTNAME}
       preKubeadmCommands:
       - export COREOS_OPENSTACK_HOSTNAME=$${COREOS_OPENSTACK_HOSTNAME%.*}
+      - export COREOS_OPENSTACK_INSTANCE_UUID=$${COREOS_OPENSTACK_INSTANCE_UUID}
       - envsubst < /etc/kubeadm.yml > /etc/kubeadm.yml.tmp
       - mv /etc/kubeadm.yml.tmp /etc/kubeadm.yml
 ---
@@ -201,14 +203,17 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
+          provider-id: openstack:///$${COREOS_OPENSTACK_INSTANCE_UUID}
         name: $${COREOS_OPENSTACK_HOSTNAME}
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
+          provider-id: openstack:///$${COREOS_OPENSTACK_INSTANCE_UUID}
         name: $${COREOS_OPENSTACK_HOSTNAME}
     preKubeadmCommands:
     - export COREOS_OPENSTACK_HOSTNAME=$${COREOS_OPENSTACK_HOSTNAME%.*}
+    - export COREOS_OPENSTACK_INSTANCE_UUID=$${COREOS_OPENSTACK_INSTANCE_UUID}
     - envsubst < /etc/kubeadm.yml > /etc/kubeadm.yml.tmp
     - mv /etc/kubeadm.yml.tmp /etc/kubeadm.yml
   machineTemplate:

--- a/templates/cluster-template-flatcar.yaml
+++ b/templates/cluster-template-flatcar.yaml
@@ -39,9 +39,11 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             cloud-provider: external
+            provider-id: openstack:///$${COREOS_OPENSTACK_INSTANCE_UUID}
           name: $${COREOS_OPENSTACK_HOSTNAME}
       preKubeadmCommands:
       - export COREOS_OPENSTACK_HOSTNAME=$${COREOS_OPENSTACK_HOSTNAME%.*}
+      - export COREOS_OPENSTACK_INSTANCE_UUID=$${COREOS_OPENSTACK_INSTANCE_UUID}
       - envsubst < /etc/kubeadm.yml > /etc/kubeadm.yml.tmp
       - mv /etc/kubeadm.yml.tmp /etc/kubeadm.yml
 ---
@@ -125,14 +127,17 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
+          provider-id: openstack:///$${COREOS_OPENSTACK_INSTANCE_UUID}
         name: $${COREOS_OPENSTACK_HOSTNAME}
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
+          provider-id: openstack:///$${COREOS_OPENSTACK_INSTANCE_UUID}
         name: $${COREOS_OPENSTACK_HOSTNAME}
     preKubeadmCommands:
     - export COREOS_OPENSTACK_HOSTNAME=$${COREOS_OPENSTACK_HOSTNAME%.*}
+    - export COREOS_OPENSTACK_INSTANCE_UUID=$${COREOS_OPENSTACK_INSTANCE_UUID}
     - envsubst < /etc/kubeadm.yml > /etc/kubeadm.yml.tmp
     - mv /etc/kubeadm.yml.tmp /etc/kubeadm.yml
   machineTemplate:

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -214,7 +214,7 @@ variables:
   SSH_USER_MACHINE: "ubuntu"
   EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION: "true"
   # The Flatcar image produced by the image-builder
-  OPENSTACK_FLATCAR_IMAGE_NAME: "flatcar-stable-3760.2.0-kube-v1.28.5"
+  OPENSTACK_FLATCAR_IMAGE_NAME: "flatcar-stable-3815.2.0-kube-v1.28.5"
   # A plain Flatcar from the Flatcar releases server
   FLATCAR_IMAGE_NAME: "flatcar_production_openstack_image"
 


### PR DESCRIPTION
**What this PR does / why we need it**: Bump the Flatcar major version used by the regular `flatcar` template tests.

**Special notes for your reviewer**:
* we released a new major stable quite quickly since the latest one to mitigate Docker CVEs and it ships interesting feature like `containerd` shipped as a systemd-sysext image
* this brings the Afterburn patch needed for: https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1564
* As usual a CAPO maintainer will need to download the image from https://tormath1-bucket.s3.fr-par.scw.cloud/flatcar-stable-3815.2.0-kube-v1.28.5.img to the CAPO GCS bucket


- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold

Closes: https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1564