### PR TITLE
🐛 v1alpha5: Fix panic in conversion when port has no binding profile

### DIFF
--- a/api/v1alpha5/conversion.go
+++ b/api/v1alpha5/conversion.go
@@ -335,13 +335,16 @@ func Convert_v1beta1_PortOpts_To_v1alpha5_PortOpts(in *infrav1.PortOpts, out *Po
 		}
 	}
 
-	out.Profile = make(map[string]string)
-	if pointer.BoolDeref(in.Profile.OVSHWOffload, false) {
-		(out.Profile)["capabilities"] = "[\"switchdev\"]"
+	if in.Profile != nil {
+		out.Profile = make(map[string]string)
+		if pointer.BoolDeref(in.Profile.OVSHWOffload, false) {
+			(out.Profile)["capabilities"] = "[\"switchdev\"]"
+		}
+		if pointer.BoolDeref(in.Profile.TrustedVF, false) {
+			(out.Profile)["trusted"] = trueString
+		}
 	}
-	if pointer.BoolDeref(in.Profile.TrustedVF, false) {
-		(out.Profile)["trusted"] = trueString
-	}
+
 	return nil
 }
 


### PR DESCRIPTION
Fixes #1948 

/hold
