### PR TITLE
:bug:  Fix accidental parsing of password

### DIFF
--- a/templates/env.rc
+++ b/templates/env.rc
@@ -115,7 +115,7 @@ else
     if [[ "$CAPO_PASSWORD" = "" || "$CAPO_PASSWORD" = "null" ]]; then
         CAPO_OPENSTACK_CLOUD_YAML_SELECTED_CLOUD_B64=$(echo "${CAPO_OPENSTACK_CLOUD_YAML_CONTENT}" | yq e .clouds.${CAPO_CLOUD} - | yq e '{"clouds": {"'${CAPO_CLOUD}'": . }}' - | b64encode)
     else
-        CAPO_OPENSTACK_CLOUD_YAML_SELECTED_CLOUD_B64=$(echo "${CAPO_OPENSTACK_CLOUD_YAML_CONTENT}" | yq e .clouds.${CAPO_CLOUD} - | PASSWORD=${CAPO_PASSWORD} yq e '.auth.password = env(PASSWORD)' - | yq e '{"clouds": {"'${CAPO_CLOUD}'": . }}' - | b64encode)
+        CAPO_OPENSTACK_CLOUD_YAML_SELECTED_CLOUD_B64=$(echo "${CAPO_OPENSTACK_CLOUD_YAML_CONTENT}" | yq e .clouds.${CAPO_CLOUD} - | PASSWORD=${CAPO_PASSWORD} yq e '.auth.password = strenv(PASSWORD)' - | yq e '{"clouds": {"'${CAPO_CLOUD}'": . }}' - | b64encode)
     fi
 fi
 export OPENSTACK_CLOUD_YAML_B64="${CAPO_OPENSTACK_CLOUD_YAML_SELECTED_CLOUD_B64}"


### PR DESCRIPTION
**What this PR does / why we need it**:

When clouds.yaml gets parsed by `env.rc`, the `yq` command is accidentally parsing the contents of the password variable.

Under most circumstances the password contents is detected correctly as a string. This fixes failures when the password is accidentally parseable as a yaml structure.

More info at:
https://mikefarah.gitbook.io/yq/operators/env-variable-operators

**Which issue(s) this PR fixes**:

Fixes #1952 

/hold
