### PR TITLE
🌱 Add .gitattributes to identify generated files to GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Tell GitHub about generated files
+
+# deepcopy and conversion-gen
+zz_generated.* linguist-generated=true
+
+# Generated parts of manifests
+/config/crd/bases/infrastructure.cluster.x-k8s.io_*.yaml linguist-generated=true
+/config/webhook/manifests.yaml linguist-generated=true
+/config/rbac/role.yaml linguist-generated=true
+
+# Generated API docs
+/docs/book/src/api/*/** linguist-generated=true


### PR DESCRIPTION
Example: https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github

A primary is to stop labelling relatively small commits as XXL just because they update some doctext which is referenced in several places in the CRDs.

This does what I intend in git:

```
> git check-attr linguist-generated ./config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml ./config/crd/kustomization.yaml
./config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml: linguist-generated: true
./config/crd/kustomization.yaml: linguist-generated: unspecified
```

However, I'm far from convinced the github integration is working. I originally included it in https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1962, but it still seemed to be mislabelled.

/hold
