### PR TITLE
🐛 Fix server metadata length validation

### DIFF
--- a/api/v1beta1/openstackmachine_types.go
+++ b/api/v1beta1/openstackmachine_types.go
@@ -101,11 +101,13 @@ type OpenStackMachineSpec struct {
 
 type ServerMetadata struct {
 	// Key is the server metadata key
-	// kubebuilder:validation:MaxLength:=255
+	// +kubebuilder:validation:MaxLength:=255
+	// +kubebuilder:validation:Required
 	Key string `json:"key"`
 
 	// Value is the server metadata value
-	// kubebuilder:validation:MaxLength:=255
+	// +kubebuilder:validation:MaxLength:=255
+	// +kubebuilder:validation:Required
 	Value string `json:"value"`
 }
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -5536,14 +5536,12 @@ spec:
                         items:
                           properties:
                             key:
-                              description: |-
-                                Key is the server metadata key
-                                kubebuilder:validation:MaxLength:=255
+                              description: Key is the server metadata key
+                              maxLength: 255
                               type: string
                             value:
-                              description: |-
-                                Value is the server metadata value
-                                kubebuilder:validation:MaxLength:=255
+                              description: Value is the server metadata value
+                              maxLength: 255
                               type: string
                           required:
                           - key

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
@@ -2970,14 +2970,12 @@ spec:
                                 items:
                                   properties:
                                     key:
-                                      description: |-
-                                        Key is the server metadata key
-                                        kubebuilder:validation:MaxLength:=255
+                                      description: Key is the server metadata key
+                                      maxLength: 255
                                       type: string
                                     value:
-                                      description: |-
-                                        Value is the server metadata value
-                                        kubebuilder:validation:MaxLength:=255
+                                      description: Value is the server metadata value
+                                      maxLength: 255
                                       type: string
                                   required:
                                   - key

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
@@ -2318,14 +2318,12 @@ spec:
                 items:
                   properties:
                     key:
-                      description: |-
-                        Key is the server metadata key
-                        kubebuilder:validation:MaxLength:=255
+                      description: Key is the server metadata key
+                      maxLength: 255
                       type: string
                     value:
-                      description: |-
-                        Value is the server metadata value
-                        kubebuilder:validation:MaxLength:=255
+                      description: Value is the server metadata value
+                      maxLength: 255
                       type: string
                   required:
                   - key

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
@@ -1997,14 +1997,12 @@ spec:
                         items:
                           properties:
                             key:
-                              description: |-
-                                Key is the server metadata key
-                                kubebuilder:validation:MaxLength:=255
+                              description: Key is the server metadata key
+                              maxLength: 255
                               type: string
                             value:
-                              description: |-
-                                Value is the server metadata value
-                                kubebuilder:validation:MaxLength:=255
+                              description: Value is the server metadata value
+                              maxLength: 255
                               type: string
                           required:
                           - key

--- a/docs/book/src/api/v1beta1/api.md
+++ b/docs/book/src/api/v1beta1/api.md
@@ -4469,8 +4469,7 @@ string
 </em>
 </td>
 <td>
-<p>Key is the server metadata key
-kubebuilder:validation:MaxLength:=255</p>
+<p>Key is the server metadata key</p>
 </td>
 </tr>
 <tr>
@@ -4481,8 +4480,7 @@ string
 </em>
 </td>
 <td>
-<p>Value is the server metadata value
-kubebuilder:validation:MaxLength:=255</p>
+<p>Value is the server metadata value</p>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
A typo meant we weren't actually validating server metadata value lengths. Fix that, and add an apivalidation test which would have caught it.

/hold
