### PR TITLE
🐛 Revert accidental update to previous API templates

### DIFF
--- a/test/e2e/data/kustomize/v1alpha6/bastion.yaml
+++ b/test/e2e/data/kustomize/v1alpha6/bastion.yaml
@@ -3,7 +3,7 @@
   path: /spec/bastion
   value:
     enabled: true
-    spec:
+    instance:
       flavor: ${OPENSTACK_BASTION_MACHINE_FLAVOR}
       image: ${OPENSTACK_BASTION_IMAGE_NAME}
       sshKeyName: ${OPENSTACK_SSH_KEY_NAME}

--- a/test/e2e/data/kustomize/v1alpha7/bastion.yaml
+++ b/test/e2e/data/kustomize/v1alpha7/bastion.yaml
@@ -3,7 +3,7 @@
   path: /spec/bastion
   value:
     enabled: true
-    spec:
+    instance:
       flavor: ${OPENSTACK_BASTION_MACHINE_FLAVOR}
       image: ${OPENSTACK_BASTION_IMAGE_NAME}
       sshKeyName: ${OPENSTACK_SSH_KEY_NAME}


### PR DESCRIPTION
https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1959 accidentally updated the bastion spec for the v1alpha6 and v1alpha7 tests, which breaks the upgrade test.