### PR TITLE
:bug: Check cluster router status before reading IP list

### DIFF
--- a/pkg/cloud/services/loadbalancer/loadbalancer.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer.go
@@ -265,10 +265,10 @@ func (s *Service) getOrUpdateAllowedCIDRS(openStackCluster *infrav1.OpenStackClu
 					allowedCIDRs = append(allowedCIDRs, subnet.CIDR)
 				}
 			}
+		}
 
-			if len(openStackCluster.Status.Router.IPs) > 0 {
-				allowedCIDRs = append(allowedCIDRs, openStackCluster.Status.Router.IPs...)
-			}
+		if openStackCluster.Status.Router != nil && len(openStackCluster.Status.Router.IPs) > 0 {
+			allowedCIDRs = append(allowedCIDRs, openStackCluster.Status.Router.IPs...)
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The latest release so far, 0.9.0 has a bug that needs to be fixed. When setting the `OpenStackClusterSpec.APIServerLoadBalancer.AllowedCIDRs` property, the load balancer controller tries to read the router IP list to add to add to the list of allowedCIRs from the cluster status but if the router is not set the controller crashes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1976

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
