### PR TITLE
✨ Add API docs for v1alpha1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,7 +289,7 @@ generate-manifests: $(CONTROLLER_GEN) ## Generate manifests e.g. CRD, RBAC etc.
 		rbac:roleName=manager-role
 
 .PHONY: generate-api-docs
-generate-api-docs: generate-api-docs-v1beta1 generate-api-docs-v1alpha7 generate-api-docs-v1alpha6
+generate-api-docs: generate-api-docs-v1beta1 generate-api-docs-v1alpha7 generate-api-docs-v1alpha6 generate-api-docs-v1alpha1
 generate-api-docs-%: $(GEN_CRD_API_REFERENCE_DOCS) FORCE
 	$(GEN_CRD_API_REFERENCE_DOCS) \
 		-api-dir=./api/$* \

--- a/api/v1alpha1/doc.go
+++ b/api/v1alpha1/doc.go
@@ -14,4 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// package v1alpha1 contains API Schema definitions for the infrastructure v1alpha1 API group
+// +kubebuilder:object:generate=true
+// +groupName=infrastructure.cluster.x-k8s.io
 package v1alpha1

--- a/docs/book/gen-crd-api-reference-docs/config.json
+++ b/docs/book/gen-crd-api-reference-docs/config.json
@@ -17,15 +17,15 @@
       },
       {
         "typeMatchPrefix": "^sigs\\.k8s\\.io/cluster-api/api/v1beta1",
-        "docsURLTemplate": "https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.5.1"
-      },
-      {
-        "typeMatchPrefix": "^sigs\\.k8s\\.io/cluster-api/api/v1beta1",
-        "docsURLTemplate": "https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.5.1"
+        "docsURLTemplate": "https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.6.0"
       },
       {
         "typeMatchPrefix": "^sigs\\.k8s\\.io/cluster-api/errors",
         "docsURLTemplate": "https://pkg.go.dev/sigs.k8s.io/cluster-api@v1.5.1/errors#{{.TypeIdentifier}}"
+      },
+      {
+        "typeMatchPrefix": "^sigs\\.k8s\\.io/cluster-api-provider-openstack/api/v1beta1",
+        "docsURLTemplate": "https://cluster-api-openstack.sigs.k8s.io/api/v1beta1/api#infrastructure.cluster.x-k8s.io/v1beta1.{{.TypeIdentifier}}"
       }
     ],
     "typeDisplayNamePrefixOverrides": {

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -13,6 +13,7 @@
         - [v1alpha6 to v1alpha7](./topics/crd-changes/v1alpha6-to-v1alpha7.md)
         - [v1alpha7 to v1beta1](./topics/crd-changes/v1alpha7-to-v1beta1.md)
 - [API reference](./api/index.md)
+    - [v1alpha1](./api/v1alpha1/api.md)
     - [v1alpha6](./api/v1alpha6/api.md)
     - [v1alpha7](./api/v1alpha7/api.md)
     - [v1beta1](./api/v1beta1/api.md)

--- a/docs/book/src/api/v1alpha1/api.md
+++ b/docs/book/src/api/v1alpha1/api.md
@@ -1,0 +1,317 @@
+<h2 id="infrastructure.cluster.x-k8s.io/v1alpha1">infrastructure.cluster.x-k8s.io/v1alpha1</h2>
+<p>
+<p>package v1alpha1 contains API Schema definitions for the infrastructure v1alpha1 API group</p>
+</p>
+Resource Types:
+<ul></ul>
+<h3 id="infrastructure.cluster.x-k8s.io/v1alpha1.OpenStackFloatingIPPool">OpenStackFloatingIPPool
+</h3>
+<p>
+<p>OpenStackFloatingIPPool is the Schema for the openstackfloatingippools API.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+Kubernetes meta/v1.ObjectMeta
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha1.OpenStackFloatingIPPoolSpec">
+OpenStackFloatingIPPoolSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>preAllocatedFloatingIPs</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>PreAllocatedFloatingIPs is a list of floating IPs precreated in OpenStack that should be used by this pool.
+These are used before allocating new ones and are not deleted from OpenStack when the pool is deleted.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>maxIPs</code><br/>
+<em>
+int
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MaxIPs is the maximum number of floating ips that can be allocated from this pool, if nil there is no limit.
+If set, the pool will stop allocating floating ips when it reaches this number of ClaimedIPs.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>identityRef</code><br/>
+<em>
+<a href="https://cluster-api-openstack.sigs.k8s.io/api/v1beta1/api#infrastructure.cluster.x-k8s.io/v1beta1.OpenStackIdentityReference">
+sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1.OpenStackIdentityReference
+</a>
+</em>
+</td>
+<td>
+<p>IdentityRef is a reference to a identity to be used when reconciling this pool.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>floatingIPNetwork</code><br/>
+<em>
+<a href="https://cluster-api-openstack.sigs.k8s.io/api/v1beta1/api#infrastructure.cluster.x-k8s.io/v1beta1.NetworkParam">
+sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1.NetworkParam
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>FloatingIPNetwork is the external network to use for floating ips, if there&rsquo;s only one external network it will be used by default</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reclaimPolicy</code><br/>
+<em>
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha1.ReclaimPolicy">
+ReclaimPolicy
+</a>
+</em>
+</td>
+<td>
+<p>The stratergy to use for reclaiming floating ips when they are released from a machine</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha1.OpenStackFloatingIPPoolStatus">
+OpenStackFloatingIPPoolStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="infrastructure.cluster.x-k8s.io/v1alpha1.OpenStackFloatingIPPoolSpec">OpenStackFloatingIPPoolSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha1.OpenStackFloatingIPPool">OpenStackFloatingIPPool</a>)
+</p>
+<p>
+<p>OpenStackFloatingIPPoolSpec defines the desired state of OpenStackFloatingIPPool.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>preAllocatedFloatingIPs</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>PreAllocatedFloatingIPs is a list of floating IPs precreated in OpenStack that should be used by this pool.
+These are used before allocating new ones and are not deleted from OpenStack when the pool is deleted.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>maxIPs</code><br/>
+<em>
+int
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MaxIPs is the maximum number of floating ips that can be allocated from this pool, if nil there is no limit.
+If set, the pool will stop allocating floating ips when it reaches this number of ClaimedIPs.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>identityRef</code><br/>
+<em>
+<a href="https://cluster-api-openstack.sigs.k8s.io/api/v1beta1/api#infrastructure.cluster.x-k8s.io/v1beta1.OpenStackIdentityReference">
+sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1.OpenStackIdentityReference
+</a>
+</em>
+</td>
+<td>
+<p>IdentityRef is a reference to a identity to be used when reconciling this pool.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>floatingIPNetwork</code><br/>
+<em>
+<a href="https://cluster-api-openstack.sigs.k8s.io/api/v1beta1/api#infrastructure.cluster.x-k8s.io/v1beta1.NetworkParam">
+sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1.NetworkParam
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>FloatingIPNetwork is the external network to use for floating ips, if there&rsquo;s only one external network it will be used by default</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reclaimPolicy</code><br/>
+<em>
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha1.ReclaimPolicy">
+ReclaimPolicy
+</a>
+</em>
+</td>
+<td>
+<p>The stratergy to use for reclaiming floating ips when they are released from a machine</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="infrastructure.cluster.x-k8s.io/v1alpha1.OpenStackFloatingIPPoolStatus">OpenStackFloatingIPPoolStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha1.OpenStackFloatingIPPool">OpenStackFloatingIPPool</a>)
+</p>
+<p>
+<p>OpenStackFloatingIPPoolStatus defines the observed state of OpenStackFloatingIPPool.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>claimedIPs</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>availableIPs</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>failedIPs</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>FailedIPs contains a list of floating ips that failed to be allocated</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>floatingIPNetwork</code><br/>
+<em>
+<a href="https://cluster-api-openstack.sigs.k8s.io/api/v1beta1/api#infrastructure.cluster.x-k8s.io/v1beta1.NetworkStatus">
+sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1.NetworkStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>floatingIPNetwork contains information about the network used for floating ips</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>conditions</code><br/>
+<em>
+<a href="https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.6.0">
+sigs.k8s.io/cluster-api/api/v1beta1.Conditions
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="infrastructure.cluster.x-k8s.io/v1alpha1.ReclaimPolicy">ReclaimPolicy
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha1.OpenStackFloatingIPPoolSpec">OpenStackFloatingIPPoolSpec</a>)
+</p>
+<p>
+<p>ReclaimPolicy is a string type alias to represent reclaim policies for floating ips.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Delete&#34;</p></td>
+<td><p>ReclaimDelete is the reclaim policy for floating ips.</p>
+</td>
+</tr><tr><td><p>&#34;Retain&#34;</p></td>
+<td><p>ReclaimRetain is the reclaim policy for floating ips.</p>
+</td>
+</tr></tbody>
+</table>
+<hr/>
+<p><em>
+Generated with <code>gen-crd-api-reference-docs</code>.
+</em></p>

--- a/docs/book/src/api/v1alpha6/api.md
+++ b/docs/book/src/api/v1alpha6/api.md
@@ -299,7 +299,7 @@ Kubernetes cluster, which also disables SecurityGroups</p>
 <td>
 <code>controlPlaneEndpoint</code><br/>
 <em>
-<a href="https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.5.1">
+<a href="https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.6.0">
 sigs.k8s.io/cluster-api/api/v1beta1.APIEndpoint
 </a>
 </em>
@@ -1897,7 +1897,7 @@ Kubernetes cluster, which also disables SecurityGroups</p>
 <td>
 <code>controlPlaneEndpoint</code><br/>
 <em>
-<a href="https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.5.1">
+<a href="https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.6.0">
 sigs.k8s.io/cluster-api/api/v1beta1.APIEndpoint
 </a>
 </em>
@@ -2021,7 +2021,7 @@ Network
 <td>
 <code>failureDomains</code><br/>
 <em>
-<a href="https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.5.1">
+<a href="https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.6.0">
 sigs.k8s.io/cluster-api/api/v1beta1.FailureDomains
 </a>
 </em>
@@ -2398,7 +2398,7 @@ Kubernetes cluster, which also disables SecurityGroups</p>
 <td>
 <code>controlPlaneEndpoint</code><br/>
 <em>
-<a href="https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.5.1">
+<a href="https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.6.0">
 sigs.k8s.io/cluster-api/api/v1beta1.APIEndpoint
 </a>
 </em>
@@ -2887,7 +2887,7 @@ controller&rsquo;s output.</p>
 <td>
 <code>conditions</code><br/>
 <em>
-<a href="https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.5.1">
+<a href="https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.6.0">
 sigs.k8s.io/cluster-api/api/v1beta1.Conditions
 </a>
 </em>

--- a/docs/book/src/api/v1alpha7/api.md
+++ b/docs/book/src/api/v1alpha7/api.md
@@ -328,7 +328,7 @@ Kubernetes cluster, which also disables SecurityGroups</p>
 <td>
 <code>controlPlaneEndpoint</code><br/>
 <em>
-<a href="https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.5.1">
+<a href="https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.6.0">
 sigs.k8s.io/cluster-api/api/v1beta1.APIEndpoint
 </a>
 </em>
@@ -1948,7 +1948,7 @@ Kubernetes cluster, which also disables SecurityGroups</p>
 <td>
 <code>controlPlaneEndpoint</code><br/>
 <em>
-<a href="https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.5.1">
+<a href="https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.6.0">
 sigs.k8s.io/cluster-api/api/v1beta1.APIEndpoint
 </a>
 </em>
@@ -2097,7 +2097,7 @@ LoadBalancer
 <td>
 <code>failureDomains</code><br/>
 <em>
-<a href="https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.5.1">
+<a href="https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.6.0">
 sigs.k8s.io/cluster-api/api/v1beta1.FailureDomains
 </a>
 </em>
@@ -2504,7 +2504,7 @@ Kubernetes cluster, which also disables SecurityGroups</p>
 <td>
 <code>controlPlaneEndpoint</code><br/>
 <em>
-<a href="https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.5.1">
+<a href="https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.6.0">
 sigs.k8s.io/cluster-api/api/v1beta1.APIEndpoint
 </a>
 </em>
@@ -2983,7 +2983,7 @@ controller&rsquo;s output.</p>
 <td>
 <code>conditions</code><br/>
 <em>
-<a href="https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.5.1">
+<a href="https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.6.0">
 sigs.k8s.io/cluster-api/api/v1beta1.Conditions
 </a>
 </em>

--- a/docs/book/src/api/v1beta1/api.md
+++ b/docs/book/src/api/v1beta1/api.md
@@ -331,7 +331,7 @@ Kubernetes cluster, which also disables SecurityGroups</p>
 <td>
 <code>controlPlaneEndpoint</code><br/>
 <em>
-<a href="https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.5.1">
+<a href="https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.6.0">
 sigs.k8s.io/cluster-api/api/v1beta1.APIEndpoint
 </a>
 </em>
@@ -2337,7 +2337,7 @@ Kubernetes cluster, which also disables SecurityGroups</p>
 <td>
 <code>controlPlaneEndpoint</code><br/>
 <em>
-<a href="https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.5.1">
+<a href="https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.6.0">
 sigs.k8s.io/cluster-api/api/v1beta1.APIEndpoint
 </a>
 </em>
@@ -2502,7 +2502,7 @@ LoadBalancer
 <td>
 <code>failureDomains</code><br/>
 <em>
-<a href="https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.5.1">
+<a href="https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.6.0">
 sigs.k8s.io/cluster-api/api/v1beta1.FailureDomains
 </a>
 </em>
@@ -2919,7 +2919,7 @@ Kubernetes cluster, which also disables SecurityGroups</p>
 <td>
 <code>controlPlaneEndpoint</code><br/>
 <em>
-<a href="https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.5.1">
+<a href="https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.6.0">
 sigs.k8s.io/cluster-api/api/v1beta1.APIEndpoint
 </a>
 </em>
@@ -3426,7 +3426,7 @@ controller&rsquo;s output.</p>
 <td>
 <code>conditions</code><br/>
 <em>
-<a href="https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.5.1">
+<a href="https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api@v1.6.0">
 sigs.k8s.io/cluster-api/api/v1beta1.Conditions
 </a>
 </em>


### PR DESCRIPTION
This includes documentation for the Floating IP IPAM pool.

Also bumps the external CAPI link to our current dep: 1.6.0.