### PR TITLE
🐛 Rules are optional in security group rules before v1beta1

### DIFF
--- a/api/v1alpha5/types.go
+++ b/api/v1alpha5/types.go
@@ -241,7 +241,7 @@ type LoadBalancer struct {
 type SecurityGroup struct {
 	Name  string              `json:"name"`
 	ID    string              `json:"id"`
-	Rules []SecurityGroupRule `json:"rules"`
+	Rules []SecurityGroupRule `json:"rules,omitempty"`
 }
 
 // SecurityGroupRule represent the basic information of the associated OpenStack

--- a/api/v1alpha6/types.go
+++ b/api/v1alpha6/types.go
@@ -253,7 +253,7 @@ type LoadBalancer struct {
 type SecurityGroup struct {
 	Name  string              `json:"name"`
 	ID    string              `json:"id"`
-	Rules []SecurityGroupRule `json:"rules"`
+	Rules []SecurityGroupRule `json:"rules,omitempty"`
 }
 
 // SecurityGroupRule represent the basic information of the associated OpenStack

--- a/api/v1alpha7/types.go
+++ b/api/v1alpha7/types.go
@@ -281,7 +281,7 @@ type LoadBalancer struct {
 type SecurityGroup struct {
 	Name  string              `json:"name"`
 	ID    string              `json:"id"`
-	Rules []SecurityGroupRule `json:"rules"`
+	Rules []SecurityGroupRule `json:"rules,omitempty"`
 }
 
 // SecurityGroupRule represent the basic information of the associated OpenStack

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -1112,7 +1112,6 @@ spec:
                 required:
                 - id
                 - name
-                - rules
                 type: object
               controlPlaneSecurityGroup:
                 description: |-
@@ -1166,7 +1165,6 @@ spec:
                 required:
                 - id
                 - name
-                - rules
                 type: object
               externalNetwork:
                 description: External Network contains information about the created
@@ -1785,7 +1783,6 @@ spec:
                 required:
                 - id
                 - name
-                - rules
                 type: object
             required:
             - ready
@@ -2969,7 +2966,6 @@ spec:
                 required:
                 - id
                 - name
-                - rules
                 type: object
               controlPlaneSecurityGroup:
                 description: |-
@@ -3023,7 +3019,6 @@ spec:
                 required:
                 - id
                 - name
-                - rules
                 type: object
               externalNetwork:
                 description: External Network contains information about the created
@@ -3712,7 +3707,6 @@ spec:
                 required:
                 - id
                 - name
-                - rules
                 type: object
             required:
             - ready
@@ -4539,7 +4533,6 @@ spec:
                 required:
                 - id
                 - name
-                - rules
                 type: object
               controlPlaneSecurityGroup:
                 description: |-
@@ -4593,7 +4586,6 @@ spec:
                 required:
                 - id
                 - name
-                - rules
                 type: object
               externalNetwork:
                 description: externalNetwork contains information about the external
@@ -4784,7 +4776,6 @@ spec:
                 required:
                 - id
                 - name
-                - rules
                 type: object
             required:
             - ready


### PR DESCRIPTION
Rules were removed from the security group status in v1beta1. If the status is modified then an up-converted v1alphaN object will not have its security group rules restored on down-conversion. As the CRD requires rules, this results in an API error.

Fixes #1999

/hold
