### PR TITLE
🐛 Fix v1alpha7 e2e tests

### DIFF
--- a/test/e2e/data/kustomize/v1alpha7/kustomization.yaml
+++ b/test/e2e/data/kustomize/v1alpha7/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../../../../kustomize/v1alpha6/external-cloud-provider
+- ../../../../../kustomize/v1alpha7/default
 
 components:
 - ../common-patches/cluster-prev1beta1
@@ -9,18 +9,6 @@ components:
 - ../common-patches/ccm
 
 patches:
-- patch: |-
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
-    kind: OpenStackMachineTemplate
-    metadata:
-      name: ignored
-    spec:
-      template:
-        spec:
-          networks:
-          - {}
-  target:
-    kind: OpenStackMachineTemplate
 - path: bastion.yaml
   target:
     kind: OpenStackCluster


### PR DESCRIPTION
The v1alpha7 tests were previously testing v1alpha6.