### PR TITLE
✨ Add NamePrefix field to OpenStackMachine.Spec

### DIFF
--- a/api/v1alpha6/openstackmachine_conversion.go
+++ b/api/v1alpha6/openstackmachine_conversion.go
@@ -190,6 +190,8 @@ func restorev1beta1MachineSpec(previous *infrav1.OpenStackMachineSpec, dst *infr
 	dst.ServerGroup = previous.ServerGroup
 	dst.Image = previous.Image
 	dst.FloatingIPPoolRef = previous.FloatingIPPoolRef
+	// NamePrefix is new in v1beta1
+	dst.NamePrefix = previous.NamePrefix
 
 	if len(dst.SecurityGroups) == len(previous.SecurityGroups) {
 		for i := range dst.SecurityGroups {

--- a/api/v1alpha6/zz_generated.conversion.go
+++ b/api/v1alpha6/zz_generated.conversion.go
@@ -1266,6 +1266,7 @@ func autoConvert_v1beta1_OpenStackMachineSpec_To_v1alpha6_OpenStackMachineSpec(i
 		out.IdentityRef = nil
 	}
 	// WARNING: in.FloatingIPPoolRef requires manual conversion: does not exist in peer-type
+	// WARNING: in.NamePrefix requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/api/v1alpha7/openstackmachine_conversion.go
+++ b/api/v1alpha7/openstackmachine_conversion.go
@@ -178,6 +178,8 @@ func restorev1beta1MachineSpec(previous *infrav1.OpenStackMachineSpec, dst *infr
 
 	dst.ServerGroup = previous.ServerGroup
 	dst.Image = previous.Image
+	// NamePrefix is new in v1beta1
+	dst.NamePrefix = previous.NamePrefix
 
 	if len(dst.SecurityGroups) == len(previous.SecurityGroups) {
 		for i := range dst.SecurityGroups {

--- a/api/v1alpha7/zz_generated.conversion.go
+++ b/api/v1alpha7/zz_generated.conversion.go
@@ -1519,6 +1519,7 @@ func autoConvert_v1beta1_OpenStackMachineSpec_To_v1alpha7_OpenStackMachineSpec(i
 		out.IdentityRef = nil
 	}
 	// WARNING: in.FloatingIPPoolRef requires manual conversion: does not exist in peer-type
+	// WARNING: in.NamePrefix requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/api/v1beta1/openstackmachine_types.go
+++ b/api/v1beta1/openstackmachine_types.go
@@ -98,6 +98,13 @@ type OpenStackMachineSpec struct {
 	// will be assigned to the OpenStackMachine.
 	// +optional
 	FloatingIPPoolRef *corev1.TypedLocalObjectReference `json:"floatingIPPoolRef,omitempty"`
+
+	// NamePrefix is an optional string that will be used as a prefix for the name of OpenStack
+	// resources created based on this OpenStackMachine. A random suffix will be added to the prefix.
+	// If omitted, the name of the OpenStackMachine will be used as name.
+	// +kubebuilder:validation:MaxLength:=255
+	// +optional
+	NamePrefix string `json:"namePrefix,omitempty"`
 }
 
 type ServerMetadata struct {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -3508,6 +3508,13 @@ spec:
                             format: uuid
                             type: string
                         type: object
+                      namePrefix:
+                        description: |-
+                          NamePrefix is an optional string that will be used as a prefix for the name of OpenStack
+                          resources created based on this OpenStackMachine. A random suffix will be added to the prefix.
+                          If omitted, the name of the OpenStackMachine will be used as name.
+                        maxLength: 255
+                        type: string
                       ports:
                         description: |-
                           Ports to be attached to the server instance. They are created if a port with the given name does not already exist.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
@@ -1995,6 +1995,13 @@ spec:
                                     format: uuid
                                     type: string
                                 type: object
+                              namePrefix:
+                                description: |-
+                                  NamePrefix is an optional string that will be used as a prefix for the name of OpenStack
+                                  resources created based on this OpenStackMachine. A random suffix will be added to the prefix.
+                                  If omitted, the name of the OpenStackMachine will be used as name.
+                                maxLength: 255
+                                type: string
                               ports:
                                 description: |-
                                   Ports to be attached to the server instance. They are created if a port with the given name does not already exist.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
@@ -1335,6 +1335,13 @@ spec:
                     format: uuid
                     type: string
                 type: object
+              namePrefix:
+                description: |-
+                  NamePrefix is an optional string that will be used as a prefix for the name of OpenStack
+                  resources created based on this OpenStackMachine. A random suffix will be added to the prefix.
+                  If omitted, the name of the OpenStackMachine will be used as name.
+                maxLength: 255
+                type: string
               ports:
                 description: |-
                   Ports to be attached to the server instance. They are created if a port with the given name does not already exist.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
@@ -1115,6 +1115,13 @@ spec:
                             format: uuid
                             type: string
                         type: object
+                      namePrefix:
+                        description: |-
+                          NamePrefix is an optional string that will be used as a prefix for the name of OpenStack
+                          resources created based on this OpenStackMachine. A random suffix will be added to the prefix.
+                          If omitted, the name of the OpenStackMachine will be used as name.
+                        maxLength: 255
+                        type: string
                       ports:
                         description: |-
                           Ports to be attached to the server instance. They are created if a port with the given name does not already exist.

--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	k8snames "k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -815,8 +816,13 @@ func machineToInstanceSpec(openStackCluster *infrav1.OpenStackCluster, machine *
 		serverMetadata[key] = value
 	}
 
+	instanceName := openStackMachine.Name
+	if openStackMachine.Spec.NamePrefix != "" {
+		instanceName = k8snames.SimpleNameGenerator.GenerateName(openStackMachine.Spec.NamePrefix)
+	}
+
 	instanceSpec := compute.InstanceSpec{
-		Name:                   openStackMachine.Name,
+		Name:                   instanceName,
 		ImageID:                resolved.ImageID,
 		Flavor:                 openStackMachine.Spec.Flavor,
 		SSHKeyName:             openStackMachine.Spec.SSHKeyName,

--- a/docs/book/src/api/v1beta1/api.md
+++ b/docs/book/src/api/v1beta1/api.md
@@ -744,6 +744,20 @@ to an IPAddressClaim. Once the IPAddressClaim is fulfilled, the FloatingIP
 will be assigned to the OpenStackMachine.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>namePrefix</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NamePrefix is an optional string that will be used as a prefix for the name of OpenStack
+resources created based on this OpenStackMachine. A random suffix will be added to the prefix.
+If omitted, the name of the OpenStackMachine will be used as name.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -3352,6 +3366,20 @@ to an IPAddressClaim. Once the IPAddressClaim is fulfilled, the FloatingIP
 will be assigned to the OpenStackMachine.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>namePrefix</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NamePrefix is an optional string that will be used as a prefix for the name of OpenStack
+resources created based on this OpenStackMachine. A random suffix will be added to the prefix.
+If omitted, the name of the OpenStackMachine will be used as name.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="infrastructure.cluster.x-k8s.io/v1beta1.OpenStackMachineStatus">OpenStackMachineStatus
@@ -3723,6 +3751,20 @@ Kubernetes core/v1.TypedLocalObjectReference
 <p>floatingIPPoolRef is a reference to a IPPool that will be assigned
 to an IPAddressClaim. Once the IPAddressClaim is fulfilled, the FloatingIP
 will be assigned to the OpenStackMachine.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>namePrefix</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NamePrefix is an optional string that will be used as a prefix for the name of OpenStack
+resources created based on this OpenStackMachine. A random suffix will be added to the prefix.
+If omitted, the name of the OpenStackMachine will be used as name.</p>
 </td>
 </tr>
 </table>

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	k8s.io/api v0.29.3
 	k8s.io/apiextensions-apiserver v0.29.3
 	k8s.io/apimachinery v0.29.3
+	k8s.io/apiserver v0.29.3
 	k8s.io/client-go v0.29.3
 	k8s.io/component-base v0.29.3
 	k8s.io/klog/v2 v2.110.1
@@ -144,7 +145,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiserver v0.29.3 // indirect
 	k8s.io/cluster-bootstrap v0.29.3 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.28.0 // indirect


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This adds a new field to the spec of OpenStackMachines: `namePrefix`. It is an optional field that can be specified as a way to influence how OpenStack resources are named. If it is not specified, the OpenStackMachine name will be used (current behavior).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2039, related to https://github.com/kubernetes-sigs/cluster-api/issues/10463.

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [x] adds unit tests

/hold
