### PR TITLE
🐛 Remove cluster dependency to resolve ports

### DIFF
--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -170,7 +170,7 @@ func resolveMachineResources(scope *scope.WithLogger, clusterResourceName string
 	}
 	// Resolve and store resources
 	return compute.ResolveMachineSpec(scope,
-		&openStackMachine.Spec, resolved,
+		&openStackMachine.Spec, DefaultPortsSpecs(openStackCluster, openStackMachine.Spec.Ports, openStackMachine.Spec.Trunk), resolved,
 		clusterResourceName, openStackMachine.Name,
 		openStackCluster, getManagedSecurityGroup(openStackCluster, machine))
 }

--- a/pkg/cloud/services/compute/referenced_resources.go
+++ b/pkg/cloud/services/compute/referenced_resources.go
@@ -31,7 +31,7 @@ import (
 // Note that we only set the fields in ResolvedMachineSpec that are not set yet. This is ok because:
 // - OpenStackMachine is immutable, so we can't change the spec after the machine is created.
 // - the bastion is mutable, but we delete the bastion when the spec changes, so the bastion status will be empty.
-func ResolveMachineSpec(scope *scope.WithLogger, spec *infrav1.OpenStackMachineSpec, resolved *infrav1.ResolvedMachineSpec, clusterResourceName, baseName string, openStackCluster *infrav1.OpenStackCluster, managedSecurityGroup *string) (changed bool, err error) {
+func ResolveMachineSpec(scope *scope.WithLogger, spec *infrav1.OpenStackMachineSpec, portsSpec []infrav1.PortOpts, resolved *infrav1.ResolvedMachineSpec, clusterResourceName, baseName string, openStackCluster *infrav1.OpenStackCluster, managedSecurityGroup *string) (changed bool, err error) {
 	changed = false
 
 	computeService, err := NewService(scope)
@@ -73,8 +73,7 @@ func ResolveMachineSpec(scope *scope.WithLogger, spec *infrav1.OpenStackMachineS
 
 	// Network resources are required in order to get ports options.
 	if len(resolved.Ports) == 0 {
-		defaultNetwork := openStackCluster.Status.Network
-		portsOpts, err := networkingService.ConstructPorts(spec, clusterResourceName, baseName, defaultNetwork, managedSecurityGroup, InstanceTags(spec, openStackCluster))
+		portsOpts, err := networkingService.ConstructPorts(portsSpec, spec.SecurityGroups, spec.Trunk, clusterResourceName, baseName, managedSecurityGroup, InstanceTags(spec, openStackCluster))
 		if err != nil {
 			return changed, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

The default network and some other ports parameters are now figured out
outside of the port functions, so they don't rely on the OpenStackMachine spec directly anymore.

/hold
