### PR TITLE
🌱 port: no dependency on OpenStackMachine

### DIFF
--- a/pkg/cloud/services/compute/referenced_resources.go
+++ b/pkg/cloud/services/compute/referenced_resources.go
@@ -74,7 +74,7 @@ func ResolveMachineSpec(scope *scope.WithLogger, spec *infrav1.OpenStackMachineS
 	// Network resources are required in order to get ports options.
 	if len(resolved.Ports) == 0 {
 		defaultNetwork := openStackCluster.Status.Network
-		portsOpts, err := networkingService.ConstructPorts(spec, clusterResourceName, baseName, defaultNetwork, managedSecurityGroup, InstanceTags(spec, openStackCluster))
+		portsOpts, err := networkingService.ConstructPorts(spec.Ports, spec.SecurityGroups, spec.Trunk, clusterResourceName, baseName, defaultNetwork, managedSecurityGroup, InstanceTags(spec, openStackCluster))
 		if err != nil {
 			return changed, err
 		}

--- a/pkg/cloud/services/networking/port_test.go
+++ b/pkg/cloud/services/networking/port_test.go
@@ -811,7 +811,7 @@ func TestService_ConstructPorts(t *testing.T) {
 			clusterResourceName := "test-cluster"
 			baseName := "test-instance"
 			baseTags := []string{"test-tag"}
-			got, err := s.ConstructPorts(&tt.spec, clusterResourceName, baseName, defaultNetwork, tt.managedSecurityGroup, baseTags)
+			got, err := s.ConstructPorts(tt.spec.Ports, tt.spec.SecurityGroups, tt.spec.Trunk, clusterResourceName, baseName, defaultNetwork, tt.managedSecurityGroup, baseTags)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
 				return


### PR DESCRIPTION
**What this PR does / why we need it**:

It's some work we're preparing to build a new controller in charge of
creating servers and their dependencies (ports, etc). We don't want it
to depent on the OpenStack Machine object.
