### PR TITLE
🐛 [release-0.10] Fix enabling of disabled bastion on upgrade to v1beta1

### DIFF
--- a/api/v1alpha5/zz_generated.conversion.go
+++ b/api/v1alpha5/zz_generated.conversion.go
@@ -489,7 +489,7 @@ func Convert_v1beta1_AddressPair_To_v1alpha5_AddressPair(in *v1beta1.AddressPair
 }
 
 func autoConvert_v1alpha5_Bastion_To_v1beta1_Bastion(in *Bastion, out *v1beta1.Bastion, s conversion.Scope) error {
-	if err := optional.Convert_bool_To_optional_Bool(&in.Enabled, &out.Enabled, s); err != nil {
+	if err := v1.Convert_bool_To_Pointer_bool(&in.Enabled, &out.Enabled, s); err != nil {
 		return err
 	}
 	// WARNING: in.Instance requires manual conversion: does not exist in peer-type
@@ -500,7 +500,7 @@ func autoConvert_v1alpha5_Bastion_To_v1beta1_Bastion(in *Bastion, out *v1beta1.B
 }
 
 func autoConvert_v1beta1_Bastion_To_v1alpha5_Bastion(in *v1beta1.Bastion, out *Bastion, s conversion.Scope) error {
-	if err := optional.Convert_optional_Bool_To_bool(&in.Enabled, &out.Enabled, s); err != nil {
+	if err := v1.Convert_Pointer_bool_To_bool(&in.Enabled, &out.Enabled, s); err != nil {
 		return err
 	}
 	// WARNING: in.Spec requires manual conversion: does not exist in peer-type

--- a/api/v1alpha6/openstackcluster_conversion.go
+++ b/api/v1alpha6/openstackcluster_conversion.go
@@ -478,7 +478,10 @@ func restorev1beta1Bastion(previous **infrav1.Bastion, dst **infrav1.Bastion) {
 
 	optional.RestoreString(&(*previous).FloatingIP, &(*dst).FloatingIP)
 	optional.RestoreString(&(*previous).AvailabilityZone, &(*dst).AvailabilityZone)
-	optional.RestoreBool(&(*previous).Enabled, &(*dst).Enabled)
+
+	if (*dst).Enabled != nil && !*(*dst).Enabled {
+		(*dst).Enabled = (*previous).Enabled
+	}
 }
 
 func Convert_v1alpha6_Bastion_To_v1beta1_Bastion(in *Bastion, out *infrav1.Bastion, s apiconversion.Scope) error {

--- a/api/v1alpha6/zz_generated.conversion.go
+++ b/api/v1alpha6/zz_generated.conversion.go
@@ -503,7 +503,7 @@ func Convert_v1beta1_AddressPair_To_v1alpha6_AddressPair(in *v1beta1.AddressPair
 }
 
 func autoConvert_v1alpha6_Bastion_To_v1beta1_Bastion(in *Bastion, out *v1beta1.Bastion, s conversion.Scope) error {
-	if err := optional.Convert_bool_To_optional_Bool(&in.Enabled, &out.Enabled, s); err != nil {
+	if err := v1.Convert_bool_To_Pointer_bool(&in.Enabled, &out.Enabled, s); err != nil {
 		return err
 	}
 	// WARNING: in.Instance requires manual conversion: does not exist in peer-type
@@ -514,7 +514,7 @@ func autoConvert_v1alpha6_Bastion_To_v1beta1_Bastion(in *Bastion, out *v1beta1.B
 }
 
 func autoConvert_v1beta1_Bastion_To_v1alpha6_Bastion(in *v1beta1.Bastion, out *Bastion, s conversion.Scope) error {
-	if err := optional.Convert_optional_Bool_To_bool(&in.Enabled, &out.Enabled, s); err != nil {
+	if err := v1.Convert_Pointer_bool_To_bool(&in.Enabled, &out.Enabled, s); err != nil {
 		return err
 	}
 	// WARNING: in.Spec requires manual conversion: does not exist in peer-type

--- a/api/v1alpha7/openstackcluster_conversion.go
+++ b/api/v1alpha7/openstackcluster_conversion.go
@@ -416,7 +416,10 @@ func restorev1beta1Bastion(previous **infrav1.Bastion, dst **infrav1.Bastion) {
 	restorev1beta1MachineSpec((*previous).Spec, (*dst).Spec)
 	optional.RestoreString(&(*previous).FloatingIP, &(*dst).FloatingIP)
 	optional.RestoreString(&(*previous).AvailabilityZone, &(*dst).AvailabilityZone)
-	optional.RestoreBool(&(*previous).Enabled, &(*dst).Enabled)
+
+	if (*dst).Enabled != nil && !*(*dst).Enabled {
+		(*dst).Enabled = (*previous).Enabled
+	}
 }
 
 func Convert_v1alpha7_Bastion_To_v1beta1_Bastion(in *Bastion, out *infrav1.Bastion, s apiconversion.Scope) error {

--- a/api/v1alpha7/zz_generated.conversion.go
+++ b/api/v1alpha7/zz_generated.conversion.go
@@ -567,7 +567,7 @@ func Convert_v1beta1_AddressPair_To_v1alpha7_AddressPair(in *v1beta1.AddressPair
 }
 
 func autoConvert_v1alpha7_Bastion_To_v1beta1_Bastion(in *Bastion, out *v1beta1.Bastion, s conversion.Scope) error {
-	if err := optional.Convert_bool_To_optional_Bool(&in.Enabled, &out.Enabled, s); err != nil {
+	if err := v1.Convert_bool_To_Pointer_bool(&in.Enabled, &out.Enabled, s); err != nil {
 		return err
 	}
 	// WARNING: in.Instance requires manual conversion: does not exist in peer-type
@@ -578,7 +578,7 @@ func autoConvert_v1alpha7_Bastion_To_v1beta1_Bastion(in *Bastion, out *v1beta1.B
 }
 
 func autoConvert_v1beta1_Bastion_To_v1alpha7_Bastion(in *v1beta1.Bastion, out *Bastion, s conversion.Scope) error {
-	if err := optional.Convert_optional_Bool_To_bool(&in.Enabled, &out.Enabled, s); err != nil {
+	if err := v1.Convert_Pointer_bool_To_bool(&in.Enabled, &out.Enabled, s); err != nil {
 		return err
 	}
 	// WARNING: in.Spec requires manual conversion: does not exist in peer-type

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -795,7 +795,7 @@ type Bastion struct {
 	// waiting until the bastion has been deleted.
 	// +kubebuilder:default:=true
 	// +optional
-	Enabled optional.Bool `json:"enabled,omitempty"`
+	Enabled *bool `json:"enabled,omitempty"`
 
 	// Spec for the bastion itself
 	Spec *OpenStackMachineSpec `json:"spec,omitempty"`

--- a/test/e2e/suites/apivalidations/openstackcluster_test.go
+++ b/test/e2e/suites/apivalidations/openstackcluster_test.go
@@ -215,6 +215,24 @@ var _ = Describe("OpenStackCluster API validations", func() {
 			Expect(cluster.Spec.ControlPlaneEndpoint).To(Equal(*infrav1Cluster.Spec.ControlPlaneEndpoint), "Control plane endpoint should be restored")
 			Expect(cluster.Spec.IdentityRef.Kind).To(Equal("FakeKind"), "IdentityRef.Kind should be restored")
 		})
+
+		It("should not enable an explicitly disabled bastion when converting to v1beta1", func() {
+			cluster.Spec.Bastion = &infrav1alpha7.Bastion{Enabled: false}
+			Expect(create(cluster)).To(Succeed(), "OpenStackCluster creation should succeed")
+
+			// Fetch the infrav1 version of the cluster
+			infrav1Cluster := &infrav1.OpenStackCluster{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, infrav1Cluster)).To(Succeed(), "OpenStackCluster fetch should succeed")
+
+			infrav1Bastion := infrav1Cluster.Spec.Bastion
+
+			// NOTE(mdbooth): It may be reasonable to remove the
+			// bastion if it is disabled with no other properties.
+			// It would be reasonable to update the assertions
+			// accordingly if we did that.
+			Expect(infrav1Bastion).ToNot(BeNil(), "Bastion should not have been removed")
+			Expect(infrav1Bastion.Enabled).To(Equal(ptr.To(false)), "Bastion should remain disabled")
+		})
 	})
 
 	Context("v1alpha6", func() {
@@ -251,6 +269,24 @@ var _ = Describe("OpenStackCluster API validations", func() {
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: infrav1Cluster.Name, Namespace: infrav1Cluster.Namespace}, cluster)).To(Succeed(), "OpenStackCluster fetch should succeed")
 			Expect(cluster.Spec.ControlPlaneEndpoint).To(Equal(*infrav1Cluster.Spec.ControlPlaneEndpoint), "Control plane endpoint should be restored")
 			Expect(cluster.Spec.IdentityRef.Kind).To(Equal("FakeKind"), "IdentityRef.Kind should be restored")
+		})
+
+		It("should not enable an explicitly disabled bastion when converting to v1beta1", func() {
+			cluster.Spec.Bastion = &infrav1alpha6.Bastion{Enabled: false}
+			Expect(create(cluster)).To(Succeed(), "OpenStackCluster creation should succeed")
+
+			// Fetch the infrav1 version of the cluster
+			infrav1Cluster := &infrav1.OpenStackCluster{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, infrav1Cluster)).To(Succeed(), "OpenStackCluster fetch should succeed")
+
+			infrav1Bastion := infrav1Cluster.Spec.Bastion
+
+			// NOTE(mdbooth): It may be reasonable to remove the
+			// bastion if it is disabled with no other properties.
+			// It would be reasonable to update the assertions
+			// accordingly if we did that.
+			Expect(infrav1Bastion).ToNot(BeNil(), "Bastion should not have been removed")
+			Expect(infrav1Bastion.Enabled).To(Equal(ptr.To(false)), "Bastion should remain disabled")
 		})
 	})
 })


### PR DESCRIPTION
This is a manual backport of #2052. An automated backport is not possible due to the removal of v1alpha5 and v1alpha6 tests on main.

TODO:
- [ ] Merge #2052 

/hold
