### PR TITLE
🐛 Fix panic executing manager without valid kube context

### DIFF
--- a/main.go
+++ b/main.go
@@ -231,6 +231,7 @@ func main() {
 	cfg, err := config.GetConfigWithContext(os.Getenv("KUBECONTEXT"))
 	if err != nil {
 		setupLog.Error(err, "unable to get kubeconfig")
+		os.Exit(1)
 	}
 	cfg.QPS = restConfigQPS
 	cfg.Burst = restConfigBurst


### PR DESCRIPTION
Fixes #2054 

/hold
