### PR TITLE
🌱 Set FallbackToLogsOnError on CAPO manager

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -46,6 +46,7 @@ spec:
             privileged: false
             runAsUser: 65532
             runAsGroup: 65532
+          terminationMessagePolicy: FallbackToLogsOnError
       terminationGracePeriodSeconds: 10
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
This gives us a better chance of useful content in the Pod termination message if CAPO quits unexpectedly.

Fixes: #2069 

/hold
