### PR TITLE
🐛 Fix loadbalancer timeout panic

### DIFF
--- a/pkg/cloud/services/loadbalancer/loadbalancer.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer.go
@@ -92,9 +92,10 @@ func (s *Service) ReconcileLoadBalancer(openStackCluster *infrav1.OpenStackClust
 
 	if lb.ProvisioningStatus != loadBalancerProvisioningStatusActive {
 		var err error
-		lb, err = s.waitForLoadBalancerActive(lb.ID)
+		lbID := lb.ID
+		lb, err = s.waitForLoadBalancerActive(lbID)
 		if err != nil {
-			return false, fmt.Errorf("load balancer %q with id %s is not active after timeout: %v", loadBalancerName, lb.ID, err)
+			return false, fmt.Errorf("load balancer %q with id %s is not active after timeout: %v", loadBalancerName, lbID, err)
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

If a loadbalancer is stuck in an non-active state it the reconciler eventually times out. The timeout error message included a nil pointer dereference.

**TODOs**:

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [x] adds unit tests

/hold
