### PR TITLE
🐛 allNodesSecurityGroupRules: relax remote fields

### DIFF
--- a/docs/book/src/clusteropenstack/configuration.md
+++ b/docs/book/src/clusteropenstack/configuration.md
@@ -565,6 +565,7 @@ permitted from anywhere, as with the default rules).
 We can add security group rules that authorize traffic from all nodes via `allNodesSecurityGroupRules`.
 It takes a list of security groups rules that should be applied to selected nodes.
 The following rule fields are mutually exclusive: `remoteManagedGroups`, `remoteGroupID` and `remoteIPPrefix`.
+If none of these fields are set, the rule will have a remote IP prefix of `0.0.0.0/0` per Neutron default.
 
 Valid values for `remoteManagedGroups` are `controlplane`, `worker` and `bastion`.
 

--- a/docs/book/src/topics/crd-changes/v1alpha7-to-v1beta1.md
+++ b/docs/book/src/topics/crd-changes/v1alpha7-to-v1beta1.md
@@ -394,6 +394,9 @@ The field `managedSecurityGroups` is now a pointer to a `ManagedSecurityGroups` 
 Also, we can now add security group rules that authorize traffic from all nodes via `allNodesSecurityGroupRules`.
 It takes a list of security groups rules that should be applied to selected nodes.
 The following rule fields are mutually exclusive: `remoteManagedGroups`, `remoteGroupID` and `remoteIPPrefix`.
+If none of these fields are set, the rule will have a remote IP prefix of `0.0.0.0/0` per Neutron default.
+
+```yaml
 Valid values for `remoteManagedGroups` are `controlplane`, `worker` and `bastion`.
 
 Also, `OpenStackCluster.Spec.AllowAllInClusterTraffic` moved under `ManagedSecurityGroups`.

--- a/pkg/cloud/services/networking/securitygroups.go
+++ b/pkg/cloud/services/networking/securitygroups.go
@@ -297,10 +297,6 @@ func getAllNodesRules(remoteManagedGroups map[string]string, allNodesSecurityGro
 
 // validateRemoteManagedGroups validates that the remoteManagedGroups target existing managed security groups.
 func validateRemoteManagedGroups(remoteManagedGroups map[string]string, ruleRemoteManagedGroups []infrav1.ManagedSecurityGroupName) error {
-	if len(ruleRemoteManagedGroups) == 0 {
-		return fmt.Errorf("remoteManagedGroups is required")
-	}
-
 	for _, group := range ruleRemoteManagedGroups {
 		if _, ok := remoteManagedGroups[group.String()]; !ok {
 			return fmt.Errorf("remoteManagedGroups: %s is not a valid remote managed security group", group)


### PR DESCRIPTION
**What this PR does / why we need it**:

This does the following:
Don't make `remoteManagedGroups` required, since a user can use `remoteIPPrefix` instead or even no remote parameter at all.
It's fine because Neutron will set it to an fully-open CIDR if no remote field is provided.

We made wrong assumptions when writing this and we're now relaxing it.

**Which issue(s) this PR fixes**:
Fixes #2075

- [X] squashed commits
- if necessary:
  - [X] includes documentation
  - [X] adds unit tests
