### PR TITLE
🌱 Drop dulek from reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -24,4 +24,3 @@ aliases:
     - mdbooth
   cluster-api-openstack-reviewers:
     - emilienm
-    - dulek


### PR DESCRIPTION
**What this PR does / why we need it**:
Going forward I won't be able to contribute time to both CPO and CAPO, so this commit drops me from CAPO reviewers list.