### PR TITLE
[release-0.9] 🌱 Sync OWNERS_ALIASES with main

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -22,7 +22,5 @@ aliases:
     - jichenjc
     - lentzi90
     - mdbooth
-    - seanschneeweiss
-    - tobiasgiese
   cluster-api-openstack-reviewers:
-    - dulek
+    - emilienm


### PR DESCRIPTION
Prompted by https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/2082