### PR TITLE
[release-0.9] ci: reduce vcpu for m1.medium

### DIFF
--- a/hack/ci/cloud-init/controller.yaml.tpl
+++ b/hack/ci/cloud-init/controller.yaml.tpl
@@ -167,7 +167,7 @@
     openstack flavor delete m1.small
     openstack flavor create --ram 4192 --disk 20 --ephemeral 5 --vcpus 2 --public --id 2 m1.small --property hw_rng:allowed='True'
     openstack flavor delete m1.medium
-    openstack flavor create --ram 6144 --disk 20 --ephemeral 5 --vcpus 4 --public --id 3 m1.medium --property hw_rng:allowed='True'
+    openstack flavor create --ram 6144 --disk 20 --ephemeral 5 --vcpus 2 --public --id 3 m1.medium --property hw_rng:allowed='True'
 
     # Adjust the CPU quota
     openstack quota set --cores 32 demo


### PR DESCRIPTION
(cherry picked from commit b75c40a315535a2682ee1d67f02b00bba3f9ba80)

Bringing release-0.9 CI closer to main.