### PR TITLE
[release-0.9] Fix port cleanup of servers in ERROR state

### DIFF
--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -680,7 +680,7 @@ func (s *Service) DeleteInstance(openStackCluster *infrav1.OpenStackCluster, eve
 			return err
 		}
 
-		if err := networkingService.GarbageCollectErrorInstancesPort(eventObject, instanceSpec.Name, portOpts); err != nil {
+		if err := networkingService.GarbageCollectErrorInstancesPort(eventObject, instanceSpec.Name, portOpts, trunkSupported); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Cleanup trunk ports if there are any.
Don't panic if ports don't exist.

Fixes: #2091 