### PR TITLE
:bug: if the openstackcluster was ready, we don't want to set a terminalError

### DIFF
--- a/pkg/cloud/services/loadbalancer/loadbalancer.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer.go
@@ -82,6 +82,9 @@ func (s *Service) ReconcileLoadBalancer(openStackCluster *infrav1.OpenStackClust
 
 	lb, err := s.getOrCreateAPILoadBalancer(openStackCluster, clusterResourceName)
 	if err != nil {
+		if errors.Is(err, capoerrors.ErrFilterMatch) {
+			return true, err
+		}
 		return false, err
 	}
 
@@ -107,6 +110,9 @@ func (s *Service) ReconcileLoadBalancer(openStackCluster *infrav1.OpenStackClust
 
 		fp, err := s.networkingService.GetOrCreateFloatingIP(openStackCluster, openStackCluster, clusterResourceName, floatingIPAddress)
 		if err != nil {
+			if errors.Is(err, capoerrors.ErrFilterMatch) {
+				return true, err
+			}
 			return false, err
 		}
 


### PR DESCRIPTION
f.e if the creds break, but the cluster was ready, the operator can fix it.

**What this PR does / why we need it**:
Use transient Error if the Openstackcluster was once ready.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2097

**Special notes for your reviewer**:



/hold
