### PR TITLE
:book: Fix rootVolume new fields name

### DIFF
--- a/docs/book/src/clusteropenstack/configuration.md
+++ b/docs/book/src/clusteropenstack/configuration.md
@@ -664,9 +664,10 @@ spec:
     spec:
       ...
         rootVolume:
-          diskSize: <image size>
-          volumeType: <a cinder volume type (*optional)>
-          availabilityZone: <the cinder availability zone for the root volume (*optional)>
+          sizeGiB: <image size>
+          type: <a cinder volume type (*optional)>
+          availabilityZone:
+            name: <The cinder availability zone name>
       ...
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Since v1beta1 fields for rootVolume got renamed : 

From :
```bash
 kubectl explain --api-version=infrastructure.cluster.x-k8s.io/v1alpha7 openstackmachinetemplate.spec.template.spec.rootVolume
GROUP:      infrastructure.cluster.x-k8s.io
KIND:       OpenStackMachineTemplate
VERSION:    v1alpha7

FIELD: rootVolume <Object>


DESCRIPTION:
    The volume metadata to boot from

FIELDS:
  availabilityZone      <string>
    <no description>

  diskSize      <integer>
    <no description>

  volumeType    <string>
    <no description>
```

To : 

```bash
 kubectl explain --api-version=infrastructure.cluster.x-k8s.io/v1beta1 openstackmachinetemplate.spec.template.spec.rootVolume --recursive
GROUP:      infrastructure.cluster.x-k8s.io
KIND:       OpenStackMachineTemplate
VERSION:    v1beta1

FIELD: rootVolume <Object>


DESCRIPTION:
    The volume metadata to boot from

FIELDS:
  availabilityZone      <Object>
    from        <string>
    enum: Name, Machine
    name        <string>
  sizeGiB       <integer> -required-
  type  <string>
```

This PR fix documentation example in the book.

**Special notes for your reviewer**:



**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
