### PR TITLE
templates: fix clusterclass-dev

### DIFF
--- a/templates/clusterclass-dev-test.yaml
+++ b/templates/clusterclass-dev-test.yaml
@@ -154,7 +154,8 @@ spec:
     spec:
       flavor: ${OPENSTACK_CONTROL_PLANE_MACHINE_FLAVOR:=m1.medium}
       image:
-        name: overridden-by-patch
+        filter:
+          name: overridden-by-patch
       sshKeyName: ${OPENSTACK_SSH_KEY_NAME:=""}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -166,5 +167,6 @@ spec:
     spec:
       flavor: ${OPENSTACK_NODE_MACHINE_FLAVOR:=m1.small}
       image:
-        name: overridden-by-patch
+        filter:
+          name: overridden-by-patch
       sshKeyName: ${OPENSTACK_SSH_KEY_NAME:=""}


### PR DESCRIPTION
**What this PR does / why we need it**:

The image API wasn't updated.
