### PR TITLE
templates/clusterclass-dev: add external network with safe default

### DIFF
--- a/templates/clusterclass-dev-test.yaml
+++ b/templates/clusterclass-dev-test.yaml
@@ -117,6 +117,9 @@ spec:
     spec:
       apiServerLoadBalancer:
         enabled: true
+      externalNetwork:
+        filter:
+          name: ${OPENSTACK_EXTERNAL_NETWORK_NAME:=public}
       identityRef:
         name: dev-test-cloud-config
         cloudName: ${OPENSTACK_CLOUD:=capo-e2e}


### PR DESCRIPTION
**What this PR does / why we need it**:

Add the externalNetwork for the cluster with a safe default.
