### PR TITLE
🌱 E2E: Bump Kubernetes to v1.29.5

### DIFF
--- a/hack/ci/cloud-init/controller.yaml.tpl
+++ b/hack/ci/cloud-init/controller.yaml.tpl
@@ -34,7 +34,7 @@
     # Neutron
     enable_plugin neutron https://github.com/openstack/neutron stable/${OPENSTACK_RELEASE}
     ENABLED_SERVICES+=,q-svc,neutron-trunk,ovn-controller,ovs-vswitchd,ovn-northd,ovsdb-server,q-ovn-metadata-agent
-    
+
     DISABLED_SERVICES=q-agt,q-dhcp,q-l3,q-meta,q-metering
     PUBLIC_BRIDGE_MTU=${MTU}
     ENABLE_CHASSIS_AS_GW="True"
@@ -68,9 +68,9 @@
     # https://docs.openstack.org/glance/latest/admin/quotas.html
     IMAGE_URLS="https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/amphora/2022-12-05/amphora-x64-haproxy.qcow2,"
     IMAGE_URLS+="https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/cirros/2022-12-05/cirros-0.6.1-x86_64-disk.img,"
-    IMAGE_URLS+="https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/ubuntu/2023-09-29/ubuntu-2204-kube-v1.27.2.img,"
     IMAGE_URLS+="https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/ubuntu/2024-01-10/ubuntu-2204-kube-v1.28.5.img,"
-    IMAGE_URLS+="https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/flatcar/flatcar-stable-3815.2.0-kube-v1.28.5.img,"
+    IMAGE_URLS+="https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/ubuntu/2024-05-28/ubuntu-2204-kube-v1.29.5.img,"
+    IMAGE_URLS+="https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/flatcar/flatcar-stable-3815.2.2-kube-v1.29.5.img,"
     IMAGE_URLS+="https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_openstack_image.img"
 
     [[post-config|$NOVA_CONF]]

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -150,9 +150,9 @@ providers:
 variables:
   # used to ensure we deploy to the correct management cluster
   KUBE_CONTEXT: "kind-capo-e2e"
-  KUBERNETES_VERSION: "v1.28.5"
-  KUBERNETES_VERSION_UPGRADE_FROM: "v1.27.2"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.28.5"
+  KUBERNETES_VERSION: "v1.29.5"
+  KUBERNETES_VERSION_UPGRADE_FROM: "v1.28.5"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.29.5"
   # NOTE: To see default images run kubeadm config images list (optionally with --kubernetes-version=vX.Y.Z)
   ETCD_VERSION_UPGRADE_TO: "3.5.12-0"
   COREDNS_VERSION_UPGRADE_TO: "v1.11.1"
@@ -172,8 +172,8 @@ variables:
   OPENSTACK_DNS_NAMESERVERS: "8.8.8.8"
   OPENSTACK_FAILURE_DOMAIN: "testaz1"
   OPENSTACK_FAILURE_DOMAIN_ALT: "testaz2"
-  OPENSTACK_IMAGE_NAME: "ubuntu-2204-kube-v1.28.5"
-  OPENSTACK_IMAGE_NAME_UPGRADE_FROM: "ubuntu-2204-kube-v1.27.2"
+  OPENSTACK_IMAGE_NAME: "ubuntu-2204-kube-v1.29.5"
+  OPENSTACK_IMAGE_NAME_UPGRADE_FROM: "ubuntu-2204-kube-v1.28.5"
   OPENSTACK_NODE_MACHINE_FLAVOR: "m1.small"
   OPENSTACK_SSH_KEY_NAME: "cluster-api-provider-openstack-sigs-k8s-io"
   # The default external network created by devstack
@@ -181,13 +181,13 @@ variables:
   OPENSTACK_VOLUME_TYPE_ALT: "test-volume-type"
   CONFORMANCE_WORKER_MACHINE_COUNT: "5"
   CONFORMANCE_CONTROL_PLANE_MACHINE_COUNT: "1"
-  INIT_WITH_KUBERNETES_VERSION: "v1.28.5"
+  INIT_WITH_KUBERNETES_VERSION: "v1.29.5"
   E2E_IMAGE_URL: "http://10.0.3.15/capo-e2e-image.tar"
   # The default user for SSH connections from bastion to machines
   SSH_USER_MACHINE: "ubuntu"
   EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION: "true"
   # The Flatcar image produced by the image-builder
-  OPENSTACK_FLATCAR_IMAGE_NAME: "flatcar-stable-3815.2.0-kube-v1.28.5"
+  OPENSTACK_FLATCAR_IMAGE_NAME: "flatcar-stable-3815.2.2-kube-v1.29.5"
   # A plain Flatcar from the Flatcar releases server
   FLATCAR_IMAGE_NAME: "flatcar_production_openstack_image"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumping the Kubernetes versions used in e2e tests.
Upgrades are now from v1.28.5 to v1.29.5

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
