### PR TITLE
🌱 E2E: Bump CAPI, cert-manager, coredns and etcd

### DIFF
--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -12,28 +12,28 @@
 managementClusterName: capo-e2e
 
 images:
-- name: gcr.io/k8s-staging-cluster-api/cluster-api-controller:v1.6.0
+- name: gcr.io/k8s-staging-cluster-api/cluster-api-controller:v1.7.2
   loadBehavior: tryLoad
-- name: gcr.io/k8s-staging-cluster-api/kubeadm-bootstrap-controller:v1.6.0
+- name: gcr.io/k8s-staging-cluster-api/kubeadm-bootstrap-controller:v1.7.2
   loadBehavior: tryLoad
-- name: gcr.io/k8s-staging-cluster-api/kubeadm-control-plane-controller:v1.6.0
+- name: gcr.io/k8s-staging-cluster-api/kubeadm-control-plane-controller:v1.7.2
   loadBehavior: tryLoad
 # Use local dev images built source tree;
 - name: gcr.io/k8s-staging-capi-openstack/capi-openstack-controller:e2e
   loadBehavior: mustLoad
-- name: quay.io/jetstack/cert-manager-cainjector:v1.12.1
+- name: quay.io/jetstack/cert-manager-cainjector:v1.14.5
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-webhook:v1.12.1
+- name: quay.io/jetstack/cert-manager-webhook:v1.14.5
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-controller:v1.12.1
+- name: quay.io/jetstack/cert-manager-controller:v1.14.5
   loadBehavior: tryLoad
 
 providers:
 - name: cluster-api
   type: CoreProvider
   versions:
-  - name: v1.6.0
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.0/core-components.yaml"
+  - name: v1.7.2
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.2/core-components.yaml"
     type: url
     contract: v1beta1
     files:
@@ -44,8 +44,8 @@ providers:
     - old: "--leader-elect"
       new: "--leader-elect=false\n        - --sync-period=1m"
   # For clusterctl upgrade test
-  - name: v1.4.6
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.4.6/core-components.yaml"
+  - name: v1.6.0
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.0/core-components.yaml"
     type: url
     contract: v1beta1
     files:
@@ -58,7 +58,7 @@ providers:
 - name: kubeadm
   type: BootstrapProvider
   versions:
-  - name: v1.6.0
+  - name: v1.7.2
     value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.0/bootstrap-components.yaml"
     type: url
     contract: v1beta1
@@ -70,8 +70,8 @@ providers:
     - old: "--leader-elect"
       new: "--leader-elect=false\n        - --sync-period=1m"
   # For clusterctl upgrade test
-  - name: v1.4.6
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.4.6/bootstrap-components.yaml"
+  - name: v1.6.0
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.0/bootstrap-components.yaml"
     type: url
     contract: v1beta1
     files:
@@ -84,8 +84,8 @@ providers:
 - name: kubeadm
   type: ControlPlaneProvider
   versions:
-  - name: v1.6.0
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.0/control-plane-components.yaml"
+  - name: v1.7.2
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.2/control-plane-components.yaml"
     type: url
     contract: v1beta1
     files:
@@ -96,8 +96,8 @@ providers:
     - old: "--leader-elect"
       new: "--leader-elect=false\n        - --sync-period=1m"
   # For clusterctl upgrade test
-  - name: v1.4.6
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.4.6/control-plane-components.yaml"
+  - name: v1.6.0
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.0/control-plane-components.yaml"
     type: url
     contract: v1beta1
     files:
@@ -111,34 +111,6 @@ providers:
   type: InfrastructureProvider
   versions:
   # This is only for clusterctl upgrade tests
-  - name: v0.7.2
-    value: "https://github.com/kubernetes-sigs/cluster-api-provider-openstack/releases/download/v0.7.2/infrastructure-components.yaml"
-    type: url
-    contract: v1beta1
-    files:
-    - sourcePath: "../data/shared/v1beta1_provider/metadata.yaml"
-    - sourcePath: "./infrastructure-openstack-no-artifact/cluster-template.yaml"
-    replacements:
-    - old: "imagePullPolicy: Always"
-      new: "imagePullPolicy: IfNotPresent"
-    - old: "--v=2"
-      new: "--v=4"
-    - old: "--leader-elect"
-      new: "--leader-elect=false\n        - --sync-period=1m"
-  - name: v0.8.0
-    value: "https://github.com/kubernetes-sigs/cluster-api-provider-openstack/releases/download/v0.8.0/infrastructure-components.yaml"
-    type: url
-    contract: v1beta1
-    files:
-    - sourcePath: "../data/shared/v1beta1_provider/metadata.yaml"
-    - sourcePath: "./infrastructure-openstack-no-artifact/cluster-template.yaml"
-    replacements:
-    - old: "imagePullPolicy: Always"
-      new: "imagePullPolicy: IfNotPresent"
-    - old: "--v=2"
-      new: "--v=4"
-    - old: "--leader-elect"
-      new: "--leader-elect=false\n        - --sync-period=1m"
   - name: v0.9.0
     value: "https://github.com/kubernetes-sigs/cluster-api-provider-openstack/releases/download/v0.9.0/infrastructure-components.yaml"
     type: url
@@ -181,8 +153,9 @@ variables:
   KUBERNETES_VERSION: "v1.28.5"
   KUBERNETES_VERSION_UPGRADE_FROM: "v1.27.2"
   KUBERNETES_VERSION_UPGRADE_TO: "v1.28.5"
-  ETCD_VERSION_UPGRADE_TO: "3.5.9-0"
-  COREDNS_VERSION_UPGRADE_TO: "v1.10.1"
+  # NOTE: To see default images run kubeadm config images list (optionally with --kubernetes-version=vX.Y.Z)
+  ETCD_VERSION_UPGRADE_TO: "3.5.12-0"
+  COREDNS_VERSION_UPGRADE_TO: "v1.11.1"
   CONTROL_PLANE_MACHINE_TEMPLATE_UPGRADE_TO: "upgrade-to-control-plane"
   WORKERS_MACHINE_TEMPLATE_UPGRADE_TO: "upgrade-to-md-0"
   CNI: "../../data/cni/calico.yaml"

--- a/test/e2e/data/shared/v1beta1/metadata.yaml
+++ b/test/e2e/data/shared/v1beta1/metadata.yaml
@@ -16,3 +16,6 @@ releaseSeries:
   - major: 1
     minor: 6
     contract: v1beta1
+  - major: 1
+    minor: 7
+    contract: v1beta1


### PR DESCRIPTION
**What this PR does / why we need it**:

This bumps CAPI, cert-manager, coredns and etcd versions used in the e2e tests.
Also cleans up unused CAPO/CAPI versions from the e2e config.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
