### PR TITLE
⚠️ More than one instance found is now an error

### DIFF
--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -51,6 +51,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/networking"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
 	utils "sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/controllers"
+	capoerrors "sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/errors"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/names"
 )
 
@@ -939,7 +940,7 @@ func getClusterSubnets(networkingService *networking.Service, openStackCluster *
 		clusterSubnets, err = networkingService.GetSubnetsByFilter(listOpts)
 		if err != nil {
 			err = fmt.Errorf("failed to find subnets: %w", err)
-			if errors.Is(err, networking.ErrFilterMatch) {
+			if errors.Is(err, capoerrors.ErrFilterMatch) {
 				handleUpdateOSCError(openStackCluster, err)
 			}
 			return nil, err
@@ -952,7 +953,7 @@ func getClusterSubnets(networkingService *networking.Service, openStackCluster *
 			filteredSubnet, err := networkingService.GetNetworkSubnetByParam(networkID, &openStackClusterSubnets[subnet])
 			if err != nil {
 				err = fmt.Errorf("failed to find subnet %d in network %s: %w", subnet, networkID, err)
-				if errors.Is(err, networking.ErrFilterMatch) {
+				if errors.Is(err, capoerrors.ErrFilterMatch) {
 					handleUpdateOSCError(openStackCluster, err)
 				}
 				return nil, err

--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -521,6 +521,7 @@ func (s *Service) GetInstanceStatusByName(eventObject runtime.Object, name strin
 
 	if len(serverList) > 1 {
 		record.Warnf(eventObject, "DuplicateServerNames", "Found %d servers with name '%s'. This is likely to cause errors.", len(serverList), name)
+		return nil, capoerrors.ErrMultipleMatches
 	}
 
 	// Return the first returned server, if any

--- a/pkg/cloud/services/networking/network.go
+++ b/pkg/cloud/services/networking/network.go
@@ -35,33 +35,6 @@ import (
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/names"
 )
 
-var (
-	ErrFilterMatch     = fmt.Errorf("filter match error")
-	ErrMultipleMatches = multipleMatchesError{}
-	ErrNoMatches       = noMatchesError{}
-)
-
-type (
-	multipleMatchesError struct{}
-	noMatchesError       struct{}
-)
-
-func (e multipleMatchesError) Error() string {
-	return "filter matched more than one resource"
-}
-
-func (e multipleMatchesError) Is(err error) bool {
-	return err == ErrFilterMatch
-}
-
-func (e noMatchesError) Error() string {
-	return "filter matched no resources"
-}
-
-func (e noMatchesError) Is(err error) bool {
-	return err == ErrFilterMatch
-}
-
 type createOpts struct {
 	AdminStateUp        *bool  `json:"admin_state_up,omitempty"`
 	Name                string `json:"name,omitempty"`
@@ -95,7 +68,7 @@ func (s *Service) ReconcileExternalNetwork(openStackCluster *infrav1.OpenStackCl
 		// Empty NetworkFilter will query all networks
 		var err error
 		network, err = s.getNetworkByFilter(&infrav1.NetworkFilter{}, ExternalNetworksOnly)
-		if errors.Is(err, ErrNoMatches) {
+		if errors.Is(err, capoerrors.ErrNoMatches) {
 			openStackCluster.Status.ExternalNetwork = nil
 			s.scope.Logger().Info("No external network found - proceeding with internal network only")
 			return nil
@@ -316,10 +289,10 @@ func (s *Service) getNetworkByFilter(filter *infrav1.NetworkFilter, opts ...GetN
 		return nil, err
 	}
 	if len(networks) == 0 {
-		return nil, ErrNoMatches
+		return nil, capoerrors.ErrNoMatches
 	}
 	if len(networks) > 1 {
-		return nil, ErrMultipleMatches
+		return nil, capoerrors.ErrMultipleMatches
 	}
 	return &networks[0], nil
 }
@@ -366,7 +339,7 @@ func (s *Service) GetSubnetsByFilter(opts subnets.ListOptsBuilder) ([]subnets.Su
 		return []subnets.Subnet{}, err
 	}
 	if len(subnetList) == 0 {
-		return nil, ErrNoMatches
+		return nil, capoerrors.ErrNoMatches
 	}
 	return subnetList, nil
 }
@@ -396,12 +369,12 @@ func (s *Service) GetNetworkSubnetByParam(networkID string, param *infrav1.Subne
 	if param.ID != nil {
 		subnet, err := s.client.GetSubnet(*param.ID)
 		if capoerrors.IsNotFound(err) {
-			return nil, ErrNoMatches
+			return nil, capoerrors.ErrNoMatches
 		}
 
 		if networkID != "" && subnet.NetworkID != networkID {
 			s.scope.Logger().V(4).Info("Subnet specified by ID does not belong to the given network", "subnetID", subnet.ID, "networkID", networkID)
-			return nil, ErrNoMatches
+			return nil, capoerrors.ErrNoMatches
 		}
 		return subnet, err
 	}
@@ -421,10 +394,10 @@ func (s *Service) GetNetworkSubnetByParam(networkID string, param *infrav1.Subne
 		return nil, err
 	}
 	if len(subnets) == 0 {
-		return nil, ErrNoMatches
+		return nil, capoerrors.ErrNoMatches
 	}
 	if len(subnets) > 1 {
-		return nil, ErrMultipleMatches
+		return nil, capoerrors.ErrMultipleMatches
 	}
 	return &subnets[0], nil
 }

--- a/pkg/cloud/services/networking/port.go
+++ b/pkg/cloud/services/networking/port.go
@@ -498,7 +498,7 @@ func (s *Service) normalizePortTarget(port *infrav1.PortOpts, defaultNetwork *in
 				subnet, err := s.GetSubnetByParam(fixedIP.Subnet)
 				if err != nil {
 					// Multiple matches might be ok later when we restrict matches to a single network
-					if errors.Is(err, ErrMultipleMatches) {
+					if errors.Is(err, capoerrors.ErrMultipleMatches) {
 						s.scope.Logger().V(4).Info("Couldn't infer network from subnet", "subnetIndex", i, "err", err)
 						continue
 					}

--- a/pkg/cloud/services/networking/router.go
+++ b/pkg/cloud/services/networking/router.go
@@ -142,7 +142,7 @@ func (s *Service) getExistingRouter(openStackCluster *infrav1.OpenStackCluster, 
 
 	router, err := s.getRouterByFilter(listOpts)
 	// It's ok if our managed router doesn't exist yet, just return nil
-	if errors.Is(err, ErrNoMatches) {
+	if errors.Is(err, capoerrors.ErrNoMatches) {
 		return nil, nil
 	}
 	return router, err
@@ -296,11 +296,11 @@ func (s *Service) getRouterByFilter(opts routers.ListOpts) (*routers.Router, err
 
 	switch len(routerList) {
 	case 0:
-		return nil, ErrNoMatches
+		return nil, capoerrors.ErrNoMatches
 	case 1:
 		return &routerList[0], nil
 	}
-	return nil, ErrMultipleMatches
+	return nil, capoerrors.ErrMultipleMatches
 }
 
 func (s *Service) getSubnetByName(subnetName string) (subnets.Subnet, error) {

--- a/pkg/utils/errors/errors.go
+++ b/pkg/utils/errors/errors.go
@@ -18,10 +18,38 @@ package errors
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/gophercloud/gophercloud"
 )
+
+var (
+	ErrFilterMatch     = fmt.Errorf("filter match error")
+	ErrMultipleMatches = multipleMatchesError{}
+	ErrNoMatches       = noMatchesError{}
+)
+
+type (
+	multipleMatchesError struct{}
+	noMatchesError       struct{}
+)
+
+func (e multipleMatchesError) Error() string {
+	return "filter matched more than one resource"
+}
+
+func (e multipleMatchesError) Is(err error) bool {
+	return err == ErrFilterMatch
+}
+
+func (e noMatchesError) Error() string {
+	return "filter matched no resources"
+}
+
+func (e noMatchesError) Is(err error) bool {
+	return err == ErrFilterMatch
+}
 
 func IsRetryable(err error) bool {
 	var errUnexpectedResponseCode gophercloud.ErrUnexpectedResponseCode


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

* Move errors functions/vars into capoerrors, so they can easily be
  re-used.
* Now we return an error if multiple instances with the same name were
  found (and not just a warning). There is no safe course of action here.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2088
