### PR TITLE
🐛 instance: re-add error event if server creationg returned an error

### DIFF
--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -119,6 +119,7 @@ func (s *Service) createInstanceImpl(eventObject runtime.Object, instanceSpec *I
 		KeyName:           instanceSpec.SSHKeyName,
 	})
 	if err != nil {
+		record.Warnf(eventObject, "FailedCreateServer", "Failed to create server %s: %v", instanceSpec.Name, err)
 		return nil, fmt.Errorf("error creating Openstack instance: %v", err)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When creating a server, Nova can return an error immediately after the
call was made to create it or later (which would be seen when showing the server status with a different API call).

If it's returned immediately, we would like to restore the error event
that we used to have and that we actually test in our e2e when providing
a wrong availability zone.

**Which issue(s) this PR fixes**:
Fixes #2111
