### PR TITLE
:book: Fix dnsNameservers array in the v1beta1 changes docs

### DIFF
--- a/docs/book/src/topics/crd-changes/v1alpha7-to-v1beta1.md
+++ b/docs/book/src/topics/crd-changes/v1alpha7-to-v1beta1.md
@@ -370,7 +370,8 @@ In v1beta1, `OpenStackCluster.Spec.ManagedSubnets` array field is introduced. Th
 
 ```yaml
   nodeCidr: "10.0.0.0/24"
-  dnsNameservers: "10.0.0.123"
+  dnsNameservers:
+  - "10.0.0.123"
 ```
 
 In v1beta1, this will be automatically converted to:
@@ -378,7 +379,8 @@ In v1beta1, this will be automatically converted to:
 ```yaml
   managedSubnets:
   - cidr: "10.0.0.0/24"
-    dnsNameservers: "10.0.0.123"
+    dnsNameservers:
+    - "10.0.0.123"
 ```
 
 Please note that currently `managedSubnets` can only hold one element.


### PR DESCRIPTION
**What this PR does / why we need it**:
DNSNameservers is an array, not a string

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
