### PR TITLE
🌱 IdentityRefProvider: DRY obtaining OpenStackIdentityRef

### DIFF
--- a/api/v1alpha1/openstackfloatingippool_types.go
+++ b/api/v1alpha1/openstackfloatingippool_types.go
@@ -127,6 +127,13 @@ func (r *OpenStackFloatingIPPool) GetFloatingIPTag() string {
 	return fmt.Sprintf("cluster-api-provider-openstack-fip-pool-%s", r.Name)
 }
 
+var _ infrav1.IdentityRefProvider = &OpenStackFloatingIPPool{}
+
+// GetIdentifyRef returns the FloatingIPPool's namespace and IdentityRef.
+func (r *OpenStackFloatingIPPool) GetIdentityRef() (*string, *infrav1.OpenStackIdentityReference) {
+	return &r.Namespace, &r.Spec.IdentityRef
+}
+
 func init() {
 	SchemeBuilder.Register(&OpenStackFloatingIPPool{}, &OpenStackFloatingIPPoolList{})
 }

--- a/api/v1beta1/identity_types.go
+++ b/api/v1beta1/identity_types.go
@@ -29,3 +29,10 @@ type OpenStackIdentityReference struct {
 	// +kubebuilder:validation:Required
 	CloudName string `json:"cloudName"`
 }
+
+// IdentityRefProvider is an interface for obtaining OpenStack credentials from an API object
+// +kubebuilder:object:generate:=false
+type IdentityRefProvider interface {
+	// GetIdentifyRef returns the object's namespace and IdentityRef if it has an IdentityRef, or nulls if it does not
+	GetIdentityRef() (*string, *OpenStackIdentityReference)
+}

--- a/api/v1beta1/openstackcluster_types.go
+++ b/api/v1beta1/openstackcluster_types.go
@@ -325,6 +325,13 @@ type ManagedSecurityGroups struct {
 	AllowAllInClusterTraffic bool `json:"allowAllInClusterTraffic"`
 }
 
+var _ IdentityRefProvider = &OpenStackCluster{}
+
+// GetIdentifyRef returns the cluster's namespace and IdentityRef.
+func (c *OpenStackCluster) GetIdentityRef() (*string, *OpenStackIdentityReference) {
+	return &c.Namespace, &c.Spec.IdentityRef
+}
+
 func init() {
 	objectTypes = append(objectTypes, &OpenStackCluster{}, &OpenStackClusterList{})
 }

--- a/api/v1beta1/openstackmachine_types.go
+++ b/api/v1beta1/openstackmachine_types.go
@@ -209,6 +209,16 @@ func (r *OpenStackMachine) SetFailure(failureReason errors.MachineStatusError, f
 	r.Status.FailureMessage = ptr.To(failureMessage.Error())
 }
 
+var _ IdentityRefProvider = &OpenStackMachine{}
+
+// GetIdentifyRef returns the object's namespace and IdentityRef if it has an IdentityRef, or nulls if it does not.
+func (r *OpenStackMachine) GetIdentityRef() (*string, *OpenStackIdentityReference) {
+	if r.Spec.IdentityRef != nil {
+		return &r.Namespace, r.Spec.IdentityRef
+	}
+	return nil, nil
+}
+
 func init() {
 	objectTypes = append(objectTypes, &OpenStackMachine{}, &OpenStackMachineList{})
 }

--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -116,7 +116,7 @@ func (r *OpenStackClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 	}()
 
-	clientScope, err := r.ScopeFactory.NewClientScopeFromCluster(ctx, r.Client, openStackCluster, r.CaCertificates, log)
+	clientScope, err := r.ScopeFactory.NewClientScopeFromObject(ctx, r.Client, r.CaCertificates, log, openStackCluster)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/controllers/openstackcluster_controller_test.go
+++ b/controllers/openstackcluster_controller_test.go
@@ -216,7 +216,7 @@ var _ = Describe("OpenStackCluster controller", func() {
 		err = k8sClient.Status().Update(ctx, testCluster)
 		Expect(err).To(BeNil())
 		log := GinkgoLogr
-		clientScope, err := mockScopeFactory.NewClientScopeFromCluster(ctx, k8sClient, testCluster, nil, log)
+		clientScope, err := mockScopeFactory.NewClientScopeFromObject(ctx, k8sClient, nil, log, testCluster)
 		Expect(err).To(BeNil())
 		scope := scope.NewWithLogger(clientScope, log)
 
@@ -268,7 +268,7 @@ var _ = Describe("OpenStackCluster controller", func() {
 		Expect(err).To(BeNil())
 
 		log := GinkgoLogr
-		clientScope, err := mockScopeFactory.NewClientScopeFromCluster(ctx, k8sClient, testCluster, nil, log)
+		clientScope, err := mockScopeFactory.NewClientScopeFromObject(ctx, k8sClient, nil, log, testCluster)
 		Expect(err).To(BeNil())
 		scope := scope.NewWithLogger(clientScope, log)
 
@@ -352,7 +352,7 @@ var _ = Describe("OpenStackCluster controller", func() {
 		Expect(err).To(BeNil())
 
 		log := GinkgoLogr
-		clientScope, err := mockScopeFactory.NewClientScopeFromCluster(ctx, k8sClient, testCluster, nil, log)
+		clientScope, err := mockScopeFactory.NewClientScopeFromObject(ctx, k8sClient, nil, log, testCluster)
 		Expect(err).To(BeNil())
 		scope := scope.NewWithLogger(clientScope, log)
 
@@ -434,7 +434,7 @@ var _ = Describe("OpenStackCluster controller", func() {
 		Expect(err).To(BeNil())
 
 		log := GinkgoLogr
-		clientScope, err := mockScopeFactory.NewClientScopeFromCluster(ctx, k8sClient, testCluster, nil, log)
+		clientScope, err := mockScopeFactory.NewClientScopeFromObject(ctx, k8sClient, nil, log, testCluster)
 		Expect(err).To(BeNil())
 		scope := scope.NewWithLogger(clientScope, log)
 
@@ -491,7 +491,7 @@ var _ = Describe("OpenStackCluster controller", func() {
 		Expect(err).To(BeNil())
 
 		log := GinkgoLogr
-		clientScope, err := mockScopeFactory.NewClientScopeFromCluster(ctx, k8sClient, testCluster, nil, log)
+		clientScope, err := mockScopeFactory.NewClientScopeFromObject(ctx, k8sClient, nil, log, testCluster)
 		Expect(err).To(BeNil())
 		scope := scope.NewWithLogger(clientScope, log)
 
@@ -546,7 +546,7 @@ var _ = Describe("OpenStackCluster controller", func() {
 		Expect(err).To(BeNil())
 
 		log := GinkgoLogr
-		clientScope, err := mockScopeFactory.NewClientScopeFromCluster(ctx, k8sClient, testCluster, nil, log)
+		clientScope, err := mockScopeFactory.NewClientScopeFromObject(ctx, k8sClient, nil, log, testCluster)
 		Expect(err).To(BeNil())
 		scope := scope.NewWithLogger(clientScope, log)
 
@@ -620,7 +620,7 @@ var _ = Describe("OpenStackCluster controller", func() {
 		Expect(err).To(BeNil())
 
 		log := GinkgoLogr
-		clientScope, err := mockScopeFactory.NewClientScopeFromCluster(ctx, k8sClient, testCluster, nil, log)
+		clientScope, err := mockScopeFactory.NewClientScopeFromObject(ctx, k8sClient, nil, log, testCluster)
 		Expect(err).To(BeNil())
 		scope := scope.NewWithLogger(clientScope, log)
 
@@ -676,7 +676,7 @@ var _ = Describe("OpenStackCluster controller", func() {
 		Expect(err).To(BeNil())
 
 		log := GinkgoLogr
-		clientScope, err := mockScopeFactory.NewClientScopeFromCluster(ctx, k8sClient, testCluster, nil, log)
+		clientScope, err := mockScopeFactory.NewClientScopeFromObject(ctx, k8sClient, nil, log, testCluster)
 		Expect(err).To(BeNil())
 		scope := scope.NewWithLogger(clientScope, log)
 

--- a/controllers/openstackfloatingippool_controller.go
+++ b/controllers/openstackfloatingippool_controller.go
@@ -81,7 +81,7 @@ func (r *OpenStackFloatingIPPoolReconciler) Reconcile(ctx context.Context, req c
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	clientScope, err := r.ScopeFactory.NewClientScopeFromFloatingIPPool(ctx, r.Client, pool, r.CaCertificates, log)
+	clientScope, err := r.ScopeFactory.NewClientScopeFromObject(ctx, r.Client, r.CaCertificates, log, pool)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -145,7 +145,7 @@ func (r *OpenStackMachineReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 	}()
 
-	clientScope, err := r.ScopeFactory.NewClientScopeFromMachine(ctx, r.Client, openStackMachine, infraCluster, r.CaCertificates, log)
+	clientScope, err := r.ScopeFactory.NewClientScopeFromObject(ctx, r.Client, r.CaCertificates, log, openStackMachine, infraCluster)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/docs/book/src/api/v1beta1/api.md
+++ b/docs/book/src/api/v1beta1/api.md
@@ -1630,6 +1630,11 @@ address in any subnet of the port&rsquo;s network.</p>
 </tr>
 </tbody>
 </table>
+<h3 id="infrastructure.cluster.x-k8s.io/v1beta1.IdentityRefProvider">IdentityRefProvider
+</h3>
+<p>
+<p>IdentityRefProvider is an interface for obtaining OpenStack credentials from an API object</p>
+</p>
 <h3 id="infrastructure.cluster.x-k8s.io/v1beta1.ImageFilter">ImageFilter
 </h3>
 <p>

--- a/pkg/scope/mock.go
+++ b/pkg/scope/mock.go
@@ -25,7 +25,6 @@ import (
 	"go.uber.org/mock/gomock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	infrav1alpha1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha1"
 	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients/mock"
@@ -65,21 +64,7 @@ func (f *MockScopeFactory) SetClientScopeCreateError(err error) {
 	f.clientScopeCreateError = err
 }
 
-func (f *MockScopeFactory) NewClientScopeFromMachine(_ context.Context, _ client.Client, _ *infrav1.OpenStackMachine, _ *infrav1.OpenStackCluster, _ []byte, _ logr.Logger) (Scope, error) {
-	if f.clientScopeCreateError != nil {
-		return nil, f.clientScopeCreateError
-	}
-	return f, nil
-}
-
-func (f *MockScopeFactory) NewClientScopeFromCluster(_ context.Context, _ client.Client, _ *infrav1.OpenStackCluster, _ []byte, _ logr.Logger) (Scope, error) {
-	if f.clientScopeCreateError != nil {
-		return nil, f.clientScopeCreateError
-	}
-	return f, nil
-}
-
-func (f *MockScopeFactory) NewClientScopeFromFloatingIPPool(_ context.Context, _ client.Client, _ *infrav1alpha1.OpenStackFloatingIPPool, _ []byte, _ logr.Logger) (Scope, error) {
+func (f *MockScopeFactory) NewClientScopeFromObject(_ context.Context, _ client.Client, _ []byte, _ logr.Logger, _ ...infrav1.IdentityRefProvider) (Scope, error) {
 	if f.clientScopeCreateError != nil {
 		return nil, f.clientScopeCreateError
 	}

--- a/pkg/scope/scope.go
+++ b/pkg/scope/scope.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	infrav1alpha1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha1"
 	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients"
 )
@@ -40,11 +39,10 @@ func NewFactory(maxCacheSize int) Factory {
 	}
 }
 
-// Factory instantiates a new Scope using credentials from either a cluster or a machine.
+// Factory instantiates a new Scope using credentials from an IdentityRefProvider.
 type Factory interface {
-	NewClientScopeFromMachine(ctx context.Context, ctrlClient client.Client, openStackMachine *infrav1.OpenStackMachine, openStackCluster *infrav1.OpenStackCluster, defaultCACert []byte, logger logr.Logger) (Scope, error)
-	NewClientScopeFromCluster(ctx context.Context, ctrlClient client.Client, openStackCluster *infrav1.OpenStackCluster, defaultCACert []byte, logger logr.Logger) (Scope, error)
-	NewClientScopeFromFloatingIPPool(ctx context.Context, ctrlClient client.Client, openStackCluster *infrav1alpha1.OpenStackFloatingIPPool, defaultCACert []byte, logger logr.Logger) (Scope, error)
+	// NewClientScopeFromObject creates a new scope from the first object which returns an OpenStackIdentityRef
+	NewClientScopeFromObject(ctx context.Context, ctrlClient client.Client, defaultCACert []byte, logger logr.Logger, objects ...infrav1.IdentityRefProvider) (Scope, error)
 }
 
 // Scope contains arguments common to most operations.


### PR DESCRIPTION
As we add more resource controllers the pattern of adding another
NewClientScopeFromFoo to ScopeFactory is becoming more cumbersome. This
allows them all to use a common interface.

Summary of changes
* Addition of `infrav1.IdentityRefProvider`
* Implementations of IdentityRefProvider for OpenStackMachine, OpenStackCluster, and OpenStackFloatingIPPool
* Replace `NewClientScopeFrom*` in `scope.Factory` with a single `NewClientScopeScopeFromObject` which takes a list of IdentityRefProvider

The reason it takes a list rather than a single object is so OpenStackMachine can continue to implement a fallback where it will use the IdentityRef from OpenStackCluster if it is not defined on the OpenStackMachine.

/hold
