### PR TITLE
🌱 cloud: Better error message on image lookup failure

### DIFF
--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -346,12 +346,20 @@ func (s *Service) GetImageID(image infrav1.ImageParam) (string, error) {
 
 	switch len(allImages) {
 	case 0:
-		return "", fmt.Errorf("no images were found with the given image filter: %v", image)
+		var name string
+		if image.Filter.Name != nil {
+			name = *image.Filter.Name
+		}
+		return "", fmt.Errorf("no images were found with the given image filter: name=%v, tags=%v", name, image.Filter.Tags)
 	case 1:
 		return allImages[0].ID, nil
 	default:
 		// this should never happen
-		return "", fmt.Errorf("too many images were found with the given image filter: %v", image)
+		var name string
+		if image.Filter.Name != nil {
+			name = *image.Filter.Name
+		}
+		return "", fmt.Errorf("too many images were found with the given image filter: name=%v, tags=%v", name, image.Filter.Tags)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, if cluster-api fails to find an image during machine creation it fails with the following, rather unhelpful error:

    "Reconciler error" err="no images were found with the given image filter: {<nil> 0xc000558880}" ...

Improve our error messages so we get something slightly more useful.

    "Reconciler error" err="no images were found with the given image filter: name=foo, tags=[]" ...

Signed-off-by: Stephen Finucane <stephenfin@redhat.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

None.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
