### PR TITLE
:bug: Fix down-conversion of IdentityRef

### DIFF
--- a/api/v1alpha6/openstackcluster_conversion.go
+++ b/api/v1alpha6/openstackcluster_conversion.go
@@ -364,7 +364,10 @@ func Convert_v1beta1_OpenStackClusterSpec_To_v1alpha6_OpenStackClusterSpec(in *i
 	}
 
 	out.CloudName = in.IdentityRef.CloudName
-	out.IdentityRef = &OpenStackIdentityReference{Name: in.IdentityRef.Name}
+	out.IdentityRef = &OpenStackIdentityReference{}
+	if err := Convert_v1beta1_OpenStackIdentityReference_To_v1alpha6_OpenStackIdentityReference(&in.IdentityRef, out.IdentityRef, s); err != nil {
+		return err
+	}
 
 	if in.APIServerLoadBalancer != nil {
 		if err := Convert_v1beta1_APIServerLoadBalancer_To_v1alpha6_APIServerLoadBalancer(in.APIServerLoadBalancer, &out.APIServerLoadBalancer, s); err != nil {

--- a/api/v1alpha6/openstackmachine_conversion.go
+++ b/api/v1alpha6/openstackmachine_conversion.go
@@ -373,7 +373,6 @@ func Convert_v1beta1_OpenStackMachineSpec_To_v1alpha6_OpenStackMachineSpec(in *i
 	}
 
 	if in.IdentityRef != nil {
-		out.IdentityRef = &OpenStackIdentityReference{Name: in.IdentityRef.Name}
 		out.CloudName = in.IdentityRef.CloudName
 	}
 

--- a/api/v1alpha6/types_conversion.go
+++ b/api/v1alpha6/types_conversion.go
@@ -534,6 +534,8 @@ func Convert_v1alpha6_OpenStackIdentityReference_To_v1beta1_OpenStackIdentityRef
 
 func Convert_v1beta1_OpenStackIdentityReference_To_v1alpha6_OpenStackIdentityReference(in *infrav1.OpenStackIdentityReference, out *OpenStackIdentityReference, _ apiconversion.Scope) error {
 	out.Name = in.Name
+	// Kind will be overwritten during restore if it was previously set to some other value, but if not then some value is still required
+	out.Kind = "Secret"
 	return nil
 }
 

--- a/api/v1alpha7/openstackcluster_conversion.go
+++ b/api/v1alpha7/openstackcluster_conversion.go
@@ -361,7 +361,10 @@ func Convert_v1beta1_OpenStackClusterSpec_To_v1alpha7_OpenStackClusterSpec(in *i
 	}
 
 	out.CloudName = in.IdentityRef.CloudName
-	out.IdentityRef = &OpenStackIdentityReference{Name: in.IdentityRef.Name}
+	out.IdentityRef = &OpenStackIdentityReference{}
+	if err := Convert_v1beta1_OpenStackIdentityReference_To_v1alpha7_OpenStackIdentityReference(&in.IdentityRef, out.IdentityRef, s); err != nil {
+		return err
+	}
 
 	if in.APIServerLoadBalancer != nil {
 		if err := Convert_v1beta1_APIServerLoadBalancer_To_v1alpha7_APIServerLoadBalancer(in.APIServerLoadBalancer, &out.APIServerLoadBalancer, s); err != nil {

--- a/api/v1alpha7/types_conversion.go
+++ b/api/v1alpha7/types_conversion.go
@@ -536,6 +536,8 @@ func Convert_v1alpha7_OpenStackIdentityReference_To_v1beta1_OpenStackIdentityRef
 
 func Convert_v1beta1_OpenStackIdentityReference_To_v1alpha7_OpenStackIdentityReference(in *infrav1.OpenStackIdentityReference, out *OpenStackIdentityReference, _ apiconversion.Scope) error {
 	out.Name = in.Name
+	// Kind will be overwritten during restore if it was previously set to some other value, but if not then some value is still required
+	out.Kind = "Secret"
 	return nil
 }
 

--- a/test/e2e/suites/apivalidations/openstackcluster_test.go
+++ b/test/e2e/suites/apivalidations/openstackcluster_test.go
@@ -19,6 +19,7 @@ package apivalidations
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -32,16 +33,6 @@ import (
 
 var _ = Describe("OpenStackCluster API validations", func() {
 	var namespace *corev1.Namespace
-
-	create := func(obj client.Object) error {
-		err := k8sClient.Create(ctx, obj)
-		if err == nil {
-			DeferCleanup(func() error {
-				return k8sClient.Delete(ctx, obj)
-			})
-		}
-		return err
-	}
 
 	BeforeEach(func() {
 		namespace = createNamespace()
@@ -58,12 +49,12 @@ var _ = Describe("OpenStackCluster API validations", func() {
 		})
 
 		It("should allow the smallest permissible cluster spec", func() {
-			Expect(create(cluster)).To(Succeed(), "OpenStackCluster creation should succeed")
+			Expect(createObj(cluster)).To(Succeed(), "OpenStackCluster creation should succeed")
 		})
 
 		It("should only allow controlPlaneEndpoint to be set once", func() {
 			By("Creating a bare cluster")
-			Expect(create(cluster)).To(Succeed(), "OpenStackCluster creation should succeed")
+			Expect(createObj(cluster)).To(Succeed(), "OpenStackCluster creation should succeed")
 
 			By("Setting the control plane endpoint")
 			cluster.Spec.ControlPlaneEndpoint = &clusterv1.APIEndpoint{
@@ -79,12 +70,12 @@ var _ = Describe("OpenStackCluster API validations", func() {
 
 		It("should allow an empty managed security groups definition", func() {
 			cluster.Spec.ManagedSecurityGroups = &infrav1.ManagedSecurityGroups{}
-			Expect(create(cluster)).To(Succeed(), "OpenStackCluster creation should succeed")
+			Expect(createObj(cluster)).To(Succeed(), "OpenStackCluster creation should succeed")
 		})
 
 		It("should default enabled to true if APIServerLoadBalancer is specified without enabled=true", func() {
 			cluster.Spec.APIServerLoadBalancer = &infrav1.APIServerLoadBalancer{}
-			Expect(create(cluster)).To(Succeed(), "OpenStackCluster creation should succeed")
+			Expect(createObj(cluster)).To(Succeed(), "OpenStackCluster creation should succeed")
 
 			// Fetch the cluster and check the defaulting
 			fetchedCluster := &infrav1.OpenStackCluster{}
@@ -95,7 +86,7 @@ var _ = Describe("OpenStackCluster API validations", func() {
 		})
 
 		It("should not default APIServerLoadBalancer if it is not specifid", func() {
-			Expect(create(cluster)).To(Succeed(), "OpenStackCluster creation should succeed")
+			Expect(createObj(cluster)).To(Succeed(), "OpenStackCluster creation should succeed")
 
 			// Fetch the cluster and check the defaulting
 			fetchedCluster := &infrav1.OpenStackCluster{}
@@ -116,19 +107,19 @@ var _ = Describe("OpenStackCluster API validations", func() {
 					},
 				},
 			}
-			Expect(create(cluster)).To(Succeed(), "OpenStackCluster creation should succeed")
+			Expect(createObj(cluster)).To(Succeed(), "OpenStackCluster creation should succeed")
 		})
 
 		It("should not allow bastion.enabled=true without a spec", func() {
 			cluster.Spec.Bastion = &infrav1.Bastion{
 				Enabled: ptr.To(true),
 			}
-			Expect(create(cluster)).NotTo(Succeed(), "OpenStackCluster creation should not succeed")
+			Expect(createObj(cluster)).NotTo(Succeed(), "OpenStackCluster creation should not succeed")
 		})
 
 		It("should not allow an empty Bastion", func() {
 			cluster.Spec.Bastion = &infrav1.Bastion{}
-			Expect(create(cluster)).NotTo(Succeed(), "OpenStackCluster creation should not succeed")
+			Expect(createObj(cluster)).NotTo(Succeed(), "OpenStackCluster creation should not succeed")
 		})
 
 		It("should default bastion.enabled=true", func() {
@@ -141,7 +132,7 @@ var _ = Describe("OpenStackCluster API validations", func() {
 					},
 				},
 			}
-			Expect(create(cluster)).To(Succeed(), "OpenStackCluster creation should not succeed")
+			Expect(createObj(cluster)).To(Succeed(), "OpenStackCluster creation should not succeed")
 
 			// Fetch the cluster and check the defaulting
 			fetchedCluster := &infrav1.OpenStackCluster{}
@@ -162,7 +153,7 @@ var _ = Describe("OpenStackCluster API validations", func() {
 				},
 				FloatingIP: ptr.To("10.0.0.0"),
 			}
-			Expect(create(cluster)).To(Succeed(), "OpenStackCluster creation should succeed")
+			Expect(createObj(cluster)).To(Succeed(), "OpenStackCluster creation should succeed")
 		})
 
 		It("should not allow non-IPv4 as bastion floating IP", func() {
@@ -176,7 +167,7 @@ var _ = Describe("OpenStackCluster API validations", func() {
 				},
 				FloatingIP: ptr.To("foobar"),
 			}
-			Expect(create(cluster)).NotTo(Succeed(), "OpenStackCluster creation should not succeed")
+			Expect(createObj(cluster)).NotTo(Succeed(), "OpenStackCluster creation should not succeed")
 		})
 	})
 
@@ -196,7 +187,7 @@ var _ = Describe("OpenStackCluster API validations", func() {
 				Kind: "FakeKind",
 				Name: "identity-ref",
 			}
-			Expect(create(cluster)).To(Succeed(), "OpenStackCluster creation should succeed")
+			Expect(createObj(cluster)).To(Succeed(), "OpenStackCluster creation should succeed")
 
 			// Fetch the infrav1 version of the cluster
 			infrav1Cluster := &infrav1.OpenStackCluster{}
@@ -218,7 +209,7 @@ var _ = Describe("OpenStackCluster API validations", func() {
 
 		It("should not enable an explicitly disabled bastion when converting to v1beta1", func() {
 			cluster.Spec.Bastion = &infrav1alpha7.Bastion{Enabled: false}
-			Expect(create(cluster)).To(Succeed(), "OpenStackCluster creation should succeed")
+			Expect(createObj(cluster)).To(Succeed(), "OpenStackCluster creation should succeed")
 
 			// Fetch the infrav1 version of the cluster
 			infrav1Cluster := &infrav1.OpenStackCluster{}
@@ -232,6 +223,26 @@ var _ = Describe("OpenStackCluster API validations", func() {
 			// accordingly if we did that.
 			Expect(infrav1Bastion).ToNot(BeNil(), "Bastion should not have been removed")
 			Expect(infrav1Bastion.Enabled).To(Equal(ptr.To(false)), "Bastion should remain disabled")
+		})
+
+		It("should downgrade cleanly from infrav1", func() {
+			infrav1Cluster := &infrav1.OpenStackCluster{}
+			infrav1Cluster.Namespace = namespace.Name
+			infrav1Cluster.GenerateName = clusterNamePrefix
+			infrav1Cluster.Spec.IdentityRef.CloudName = "test-cloud"
+			infrav1Cluster.Spec.IdentityRef.Name = "test-credentials"
+			Expect(createObj(infrav1Cluster)).To(Succeed(), "infrav1 OpenStackCluster creation should succeed")
+
+			// Just fetching the object as v1alpha6 doesn't trigger
+			// validation failure, so we first fetch it and then
+			// patch the object with identical contents. The patch
+			// triggers a validation failure.
+			cluster := &infrav1alpha7.OpenStackCluster{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: infrav1Cluster.Name, Namespace: infrav1Cluster.Namespace}, cluster)).To(Succeed(), "OpenStackCluster fetch should succeed")
+
+			setObjectGVK(cluster)
+			cluster.ManagedFields = nil
+			Expect(k8sClient.Patch(ctx, cluster, client.Apply, client.FieldOwner("test"), client.ForceOwnership)).To(Succeed(), format.Object(cluster, 4))
 		})
 	})
 
@@ -251,7 +262,7 @@ var _ = Describe("OpenStackCluster API validations", func() {
 				Kind: "FakeKind",
 				Name: "identity-ref",
 			}
-			Expect(create(cluster)).To(Succeed(), "OpenStackCluster creation should succeed")
+			Expect(createObj(cluster)).To(Succeed(), "OpenStackCluster creation should succeed")
 
 			// Fetch the infrav1 version of the cluster
 			infrav1Cluster := &infrav1.OpenStackCluster{}
@@ -273,7 +284,7 @@ var _ = Describe("OpenStackCluster API validations", func() {
 
 		It("should not enable an explicitly disabled bastion when converting to v1beta1", func() {
 			cluster.Spec.Bastion = &infrav1alpha6.Bastion{Enabled: false}
-			Expect(create(cluster)).To(Succeed(), "OpenStackCluster creation should succeed")
+			Expect(createObj(cluster)).To(Succeed(), "OpenStackCluster creation should succeed")
 
 			// Fetch the infrav1 version of the cluster
 			infrav1Cluster := &infrav1.OpenStackCluster{}
@@ -287,6 +298,26 @@ var _ = Describe("OpenStackCluster API validations", func() {
 			// accordingly if we did that.
 			Expect(infrav1Bastion).ToNot(BeNil(), "Bastion should not have been removed")
 			Expect(infrav1Bastion.Enabled).To(Equal(ptr.To(false)), "Bastion should remain disabled")
+		})
+
+		It("should downgrade cleanly from infrav1", func() {
+			infrav1Cluster := &infrav1.OpenStackCluster{}
+			infrav1Cluster.Namespace = namespace.Name
+			infrav1Cluster.GenerateName = clusterNamePrefix
+			infrav1Cluster.Spec.IdentityRef.CloudName = "test-cloud"
+			infrav1Cluster.Spec.IdentityRef.Name = "test-credentials"
+			Expect(createObj(infrav1Cluster)).To(Succeed(), "infrav1 OpenStackCluster creation should succeed")
+
+			// Just fetching the object as v1alpha6 doesn't trigger
+			// validation failure, so we first fetch it and then
+			// patch the object with identical contents. The patch
+			// triggers a validation failure.
+			cluster := &infrav1alpha6.OpenStackCluster{} //nolint:staticcheck
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: infrav1Cluster.Name, Namespace: infrav1Cluster.Namespace}, cluster)).To(Succeed(), "OpenStackCluster fetch should succeed")
+
+			setObjectGVK(cluster)
+			cluster.ManagedFields = nil
+			Expect(k8sClient.Patch(ctx, cluster, client.Apply, client.FieldOwner("test"), client.ForceOwnership)).To(Succeed(), format.Object(cluster, 4))
 		})
 	})
 })

--- a/test/e2e/suites/apivalidations/suite_test.go
+++ b/test/e2e/suites/apivalidations/suite_test.go
@@ -165,3 +165,21 @@ func createNamespace() *corev1.Namespace {
 	By(fmt.Sprintf("Using namespace %s", namespace.Name))
 	return &namespace
 }
+
+func createObj(obj client.Object) error {
+	err := k8sClient.Create(ctx, obj)
+	if err == nil {
+		DeferCleanup(func() error {
+			return k8sClient.Delete(ctx, obj)
+		})
+	}
+	return err
+}
+
+func setObjectGVK(obj runtime.Object) {
+	gvk, unversioned, err := testScheme.ObjectKinds(obj)
+	Expect(unversioned).To(BeFalse(), "Object is considered unversioned")
+	Expect(err).ToNot(HaveOccurred(), "Error fetching gvk for Object")
+	Expect(gvk).To(HaveLen(1), "Object should have only one gvk")
+	obj.GetObjectKind().SetGroupVersionKind(gvk[0])
+}


### PR DESCRIPTION
We were not setting IdentityRef.Kind when down-converting an object with
no previous version annotation, which results in a validation error.

Fixes #2136

I developed this directly against the release-0.10 branch because main doesn't run v1alpha6 tests any more. However, we should merge it in main first.

TODO:
- [ ] Merge main first https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/2139
- [x] Confirm full-test is passing

/hold
