### PR TITLE
:bug: Fix down-conversion of IdentityRef

### DIFF
--- a/api/v1alpha6/openstackcluster_conversion.go
+++ b/api/v1alpha6/openstackcluster_conversion.go
@@ -365,7 +365,10 @@ func Convert_v1beta1_OpenStackClusterSpec_To_v1alpha6_OpenStackClusterSpec(in *i
 	}
 
 	out.CloudName = in.IdentityRef.CloudName
-	out.IdentityRef = &OpenStackIdentityReference{Name: in.IdentityRef.Name}
+	out.IdentityRef = &OpenStackIdentityReference{}
+	if err := Convert_v1beta1_OpenStackIdentityReference_To_v1alpha6_OpenStackIdentityReference(&in.IdentityRef, out.IdentityRef, s); err != nil {
+		return err
+	}
 
 	if in.APIServerLoadBalancer != nil {
 		if err := Convert_v1beta1_APIServerLoadBalancer_To_v1alpha6_APIServerLoadBalancer(in.APIServerLoadBalancer, &out.APIServerLoadBalancer, s); err != nil {

--- a/api/v1alpha6/openstackmachine_conversion.go
+++ b/api/v1alpha6/openstackmachine_conversion.go
@@ -373,7 +373,6 @@ func Convert_v1beta1_OpenStackMachineSpec_To_v1alpha6_OpenStackMachineSpec(in *i
 	}
 
 	if in.IdentityRef != nil {
-		out.IdentityRef = &OpenStackIdentityReference{Name: in.IdentityRef.Name}
 		out.CloudName = in.IdentityRef.CloudName
 	}
 

--- a/api/v1alpha6/types_conversion.go
+++ b/api/v1alpha6/types_conversion.go
@@ -534,6 +534,8 @@ func Convert_v1alpha6_OpenStackIdentityReference_To_v1beta1_OpenStackIdentityRef
 
 func Convert_v1beta1_OpenStackIdentityReference_To_v1alpha6_OpenStackIdentityReference(in *infrav1.OpenStackIdentityReference, out *OpenStackIdentityReference, _ apiconversion.Scope) error {
 	out.Name = in.Name
+	// Kind will be overwritten during restore if it was previously set to some other value, but if not then some value is still required
+	out.Kind = "Secret"
 	return nil
 }
 

--- a/api/v1alpha7/openstackcluster_conversion.go
+++ b/api/v1alpha7/openstackcluster_conversion.go
@@ -362,7 +362,10 @@ func Convert_v1beta1_OpenStackClusterSpec_To_v1alpha7_OpenStackClusterSpec(in *i
 	}
 
 	out.CloudName = in.IdentityRef.CloudName
-	out.IdentityRef = &OpenStackIdentityReference{Name: in.IdentityRef.Name}
+	out.IdentityRef = &OpenStackIdentityReference{}
+	if err := Convert_v1beta1_OpenStackIdentityReference_To_v1alpha7_OpenStackIdentityReference(&in.IdentityRef, out.IdentityRef, s); err != nil {
+		return err
+	}
 
 	if in.APIServerLoadBalancer != nil {
 		if err := Convert_v1beta1_APIServerLoadBalancer_To_v1alpha7_APIServerLoadBalancer(in.APIServerLoadBalancer, &out.APIServerLoadBalancer, s); err != nil {

--- a/api/v1alpha7/types_conversion.go
+++ b/api/v1alpha7/types_conversion.go
@@ -536,6 +536,8 @@ func Convert_v1alpha7_OpenStackIdentityReference_To_v1beta1_OpenStackIdentityRef
 
 func Convert_v1beta1_OpenStackIdentityReference_To_v1alpha7_OpenStackIdentityReference(in *infrav1.OpenStackIdentityReference, out *OpenStackIdentityReference, _ apiconversion.Scope) error {
 	out.Name = in.Name
+	// Kind will be overwritten during restore if it was previously set to some other value, but if not then some value is still required
+	out.Kind = "Secret"
 	return nil
 }
 

--- a/test/e2e/suites/apivalidations/openstackmachine_test.go
+++ b/test/e2e/suites/apivalidations/openstackmachine_test.go
@@ -21,9 +21,13 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	infrav1alpha7 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha7"
 	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1"
 )
 
@@ -330,6 +334,31 @@ var _ = Describe("OpenStackMachine API validations", func() {
 
 			machine = defaultMachineWithAdditionBlockDeviceAZ(&az)
 			Expect(k8sClient.Create(ctx, machine)).NotTo(Succeed(), "Creating a machine with an additional block device with an empty name availability zone should fail")
+		})
+	})
+
+	Context("v1alpha7", func() {
+		It("should downgrade cleanly from infrav1", func() {
+			infrav1Machine := &infrav1.OpenStackMachine{}
+			infrav1Machine.Namespace = namespace.Name
+			infrav1Machine.GenerateName = clusterNamePrefix
+			infrav1Machine.Spec.IdentityRef = &infrav1.OpenStackIdentityReference{
+				CloudName: "test-cloud",
+				Name:      "test-credentials",
+			}
+			infrav1Machine.Spec.Image.ID = ptr.To("de9872ee-0c2c-44ed-9414-90163c8b0e0d")
+			Expect(createObj(infrav1Machine)).To(Succeed(), "infrav1 OpenStackMachine creation should succeed")
+
+			// Just fetching the object as v1alpha7 doesn't trigger
+			// validation failure, so we first fetch it and then
+			// patch the object with identical contents. The patch
+			// triggers a validation failure.
+			machine := &infrav1alpha7.OpenStackMachine{} //nolint: staticcheck
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: infrav1Machine.Name, Namespace: infrav1Machine.Namespace}, machine)).To(Succeed(), "OpenStackMachine fetch should succeed")
+
+			setObjectGVK(machine)
+			machine.ManagedFields = nil
+			Expect(k8sClient.Patch(ctx, machine, client.Apply, client.FieldOwner("test"), client.ForceOwnership)).To(Succeed(), format.Object(machine, 4))
 		})
 	})
 })

--- a/test/e2e/suites/apivalidations/suite_test.go
+++ b/test/e2e/suites/apivalidations/suite_test.go
@@ -161,3 +161,21 @@ func createNamespace() *corev1.Namespace {
 	By(fmt.Sprintf("Using namespace %s", namespace.Name))
 	return &namespace
 }
+
+func createObj(obj client.Object) error {
+	err := k8sClient.Create(ctx, obj)
+	if err == nil {
+		DeferCleanup(func() error {
+			return k8sClient.Delete(ctx, obj)
+		})
+	}
+	return err
+}
+
+func setObjectGVK(obj runtime.Object) {
+	gvk, unversioned, err := testScheme.ObjectKinds(obj)
+	Expect(unversioned).To(BeFalse(), "Object is considered unversioned")
+	Expect(err).ToNot(HaveOccurred(), "Error fetching gvk for Object")
+	Expect(gvk).To(HaveLen(1), "Object should have only one gvk")
+	obj.GetObjectKind().SetGroupVersionKind(gvk[0])
+}


### PR DESCRIPTION
We were not setting IdentityRef.Kind when down-converting an object with
no previous version annotation, which results in a validation error.

**Which issue(s) this PR fixes**:
Fixes #2136

TODO:
- [x] Confirm full-test is passing

/hold
