### PR TITLE
:sparkles: Support Flavor IDs

### DIFF
--- a/api/v1alpha1/openstackserver_types.go
+++ b/api/v1alpha1/openstackserver_types.go
@@ -32,6 +32,7 @@ const (
 )
 
 // OpenStackServerSpec defines the desired state of OpenStackServer.
+// +kubebuilder:validation:XValidation:message="at least one of flavor or flavorID must be set",rule=(has(self.flavor) || has(self.flavorID))
 type OpenStackServerSpec struct {
 	// AdditionalBlockDevices is a list of specifications for additional block devices to attach to the server instance.
 	// +listType=map
@@ -48,8 +49,15 @@ type OpenStackServerSpec struct {
 	ConfigDrive optional.Bool `json:"configDrive,omitempty"`
 
 	// The flavor reference for the flavor for the server instance.
-	// +required
-	Flavor string `json:"flavor"`
+	// +optional
+	// +kubebuilder:validation:MinLength=1
+	Flavor *string `json:"flavor,omitempty"`
+
+	// FlavorID allows flavors to be specified by ID.  This field takes precedence
+	// over Flavor.
+	// +optional
+	// +kubebuilder:validation:MinLength=1
+	FlavorID *string `json:"flavorID,omitempty"`
 
 	// FloatingIPPoolRef is a reference to a FloatingIPPool to allocate a floating IP from.
 	// +optional

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -30,6 +30,10 @@ type ResolvedServerSpec struct {
 	// +optional
 	ImageID string `json:"imageID,omitempty"`
 
+	// FlavorID is the ID of the flavor to use.
+	// +optional
+	FlavorID string `json:"flavorID,omitempty"`
+
 	// Ports is the fully resolved list of ports to create for the server.
 	// +optional
 	Ports []infrav1.ResolvedPortSpec `json:"ports,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -238,6 +238,16 @@ func (in *OpenStackServerSpec) DeepCopyInto(out *OpenStackServerSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Flavor != nil {
+		in, out := &in.Flavor, &out.Flavor
+		*out = new(string)
+		**out = **in
+	}
+	if in.FlavorID != nil {
+		in, out := &in.FlavorID, &out.FlavorID
+		*out = new(string)
+		**out = **in
+	}
 	if in.FloatingIPPoolRef != nil {
 		in, out := &in.FloatingIPPoolRef, &out.FloatingIPPoolRef
 		*out = new(v1.TypedLocalObjectReference)

--- a/api/v1alpha6/conversion_test.go
+++ b/api/v1alpha6/conversion_test.go
@@ -582,10 +582,10 @@ func TestMachineConversionControllerSpecFields(t *testing.T) {
 		{
 			name: "Non-ignored change",
 			modifyUp: func(up *infrav1.OpenStackMachine) {
-				up.Spec.Flavor = "new-flavor"
+				up.Spec.Flavor = ptr.To("new-flavor")
 			},
 			testAfter: func(g gomega.Gomega, after *OpenStackMachine) {
-				g.Expect(after.Spec.Flavor).To(gomega.Equal("new-flavor"))
+				g.Expect(after.Spec.Flavor).To(gomega.Equal(ptr.To("new-flavor")))
 			},
 			expectNetworkDiff: true,
 		},
@@ -613,11 +613,11 @@ func TestMachineConversionControllerSpecFields(t *testing.T) {
 			name: "Set ProviderID and non-ignored change",
 			modifyUp: func(up *infrav1.OpenStackMachine) {
 				up.Spec.ProviderID = ptr.To("new-provider-id")
-				up.Spec.Flavor = "new-flavor"
+				up.Spec.Flavor = ptr.To("new-flavor")
 			},
 			testAfter: func(g gomega.Gomega, after *OpenStackMachine) {
 				g.Expect(after.Spec.ProviderID).To(gomega.Equal(ptr.To("new-provider-id")))
-				g.Expect(after.Spec.Flavor).To(gomega.Equal("new-flavor"))
+				g.Expect(after.Spec.Flavor).To(gomega.Equal(ptr.To("new-flavor")))
 			},
 			expectNetworkDiff: true,
 		},

--- a/api/v1alpha6/openstackmachine_types.go
+++ b/api/v1alpha6/openstackmachine_types.go
@@ -43,7 +43,13 @@ type OpenStackMachineSpec struct {
 	CloudName string `json:"cloudName"`
 
 	// The flavor reference for the flavor for your server instance.
-	Flavor string `json:"flavor"`
+	// +kubebuilder:validation:MinLength=1
+	Flavor *string `json:"flavor,omitempty"`
+
+	// FlavorID allows flavors to be specified by ID.  This field takes precedence
+	// over Flavor.
+	// +kubebuilder:validation:MinLength=1
+	FlavorID *string `json:"flavorID,omitempty"`
 
 	// The name of the image to use for your server instance.
 	// If the RootVolume is specified, this will be ignored and use rootVolume directly.

--- a/api/v1alpha6/zz_generated.conversion.go
+++ b/api/v1alpha6/zz_generated.conversion.go
@@ -1160,7 +1160,8 @@ func autoConvert_v1alpha6_OpenStackMachineSpec_To_v1beta1_OpenStackMachineSpec(i
 	out.ProviderID = (*string)(unsafe.Pointer(in.ProviderID))
 	// WARNING: in.InstanceID requires manual conversion: does not exist in peer-type
 	// WARNING: in.CloudName requires manual conversion: does not exist in peer-type
-	out.Flavor = in.Flavor
+	out.Flavor = (*string)(unsafe.Pointer(in.Flavor))
+	out.FlavorID = (*string)(unsafe.Pointer(in.FlavorID))
 	// WARNING: in.Image requires manual conversion: inconvertible types (string vs sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1.ImageParam)
 	// WARNING: in.ImageUUID requires manual conversion: does not exist in peer-type
 	out.SSHKeyName = in.SSHKeyName
@@ -1217,7 +1218,8 @@ func autoConvert_v1alpha6_OpenStackMachineSpec_To_v1beta1_OpenStackMachineSpec(i
 
 func autoConvert_v1beta1_OpenStackMachineSpec_To_v1alpha6_OpenStackMachineSpec(in *v1beta1.OpenStackMachineSpec, out *OpenStackMachineSpec, s conversion.Scope) error {
 	out.ProviderID = (*string)(unsafe.Pointer(in.ProviderID))
-	out.Flavor = in.Flavor
+	out.Flavor = (*string)(unsafe.Pointer(in.Flavor))
+	out.FlavorID = (*string)(unsafe.Pointer(in.FlavorID))
 	// WARNING: in.Image requires manual conversion: inconvertible types (sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1.ImageParam vs string)
 	out.SSHKeyName = in.SSHKeyName
 	if in.Ports != nil {

--- a/api/v1alpha6/zz_generated.deepcopy.go
+++ b/api/v1alpha6/zz_generated.deepcopy.go
@@ -616,6 +616,16 @@ func (in *OpenStackMachineSpec) DeepCopyInto(out *OpenStackMachineSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Flavor != nil {
+		in, out := &in.Flavor, &out.Flavor
+		*out = new(string)
+		**out = **in
+	}
+	if in.FlavorID != nil {
+		in, out := &in.FlavorID, &out.FlavorID
+		*out = new(string)
+		**out = **in
+	}
 	if in.Networks != nil {
 		in, out := &in.Networks, &out.Networks
 		*out = make([]NetworkParam, len(*in))

--- a/api/v1alpha7/conversion_test.go
+++ b/api/v1alpha7/conversion_test.go
@@ -191,10 +191,10 @@ func TestMachineConversionControllerSpecFields(t *testing.T) {
 		{
 			name: "Non-ignored change",
 			modifyUp: func(up *infrav1.OpenStackMachine) {
-				up.Spec.Flavor = "new-flavor"
+				up.Spec.Flavor = ptr.To("new-flavor")
 			},
 			testAfter: func(g gomega.Gomega, after *OpenStackMachine) {
-				g.Expect(after.Spec.Flavor).To(gomega.Equal("new-flavor"))
+				g.Expect(after.Spec.Flavor).To(gomega.Equal(ptr.To("new-flavor")))
 			},
 			expectIdentityRefDiff: true,
 		},
@@ -222,11 +222,11 @@ func TestMachineConversionControllerSpecFields(t *testing.T) {
 			name: "Set ProviderID and non-ignored change",
 			modifyUp: func(up *infrav1.OpenStackMachine) {
 				up.Spec.ProviderID = ptr.To("new-provider-id")
-				up.Spec.Flavor = "new-flavor"
+				up.Spec.Flavor = ptr.To("new-flavor")
 			},
 			testAfter: func(g gomega.Gomega, after *OpenStackMachine) {
 				g.Expect(after.Spec.ProviderID).To(gomega.Equal(ptr.To("new-provider-id")))
-				g.Expect(after.Spec.Flavor).To(gomega.Equal("new-flavor"))
+				g.Expect(after.Spec.Flavor).To(gomega.Equal(ptr.To("new-flavor")))
 			},
 			expectIdentityRefDiff: true,
 		},

--- a/api/v1alpha7/openstackmachine_types.go
+++ b/api/v1alpha7/openstackmachine_types.go
@@ -43,7 +43,13 @@ type OpenStackMachineSpec struct {
 	CloudName string `json:"cloudName"`
 
 	// The flavor reference for the flavor for your server instance.
-	Flavor string `json:"flavor"`
+	// +kubebuilder:validation:MinLength=1
+	Flavor *string `json:"flavor,omitempty"`
+
+	// FlavorID allows flavors to be specified by ID.  This field takes precedence
+	// over Flavor.
+	// +kubebuilder:validation:MinLength=1
+	FlavorID *string `json:"flavorID,omitempty"`
 
 	// The name of the image to use for your server instance.
 	// If the RootVolume is specified, this will be ignored and use rootVolume directly.

--- a/api/v1alpha7/zz_generated.conversion.go
+++ b/api/v1alpha7/zz_generated.conversion.go
@@ -1394,7 +1394,8 @@ func autoConvert_v1alpha7_OpenStackMachineSpec_To_v1beta1_OpenStackMachineSpec(i
 	out.ProviderID = (*string)(unsafe.Pointer(in.ProviderID))
 	// WARNING: in.InstanceID requires manual conversion: does not exist in peer-type
 	// WARNING: in.CloudName requires manual conversion: does not exist in peer-type
-	out.Flavor = in.Flavor
+	out.Flavor = (*string)(unsafe.Pointer(in.Flavor))
+	out.FlavorID = (*string)(unsafe.Pointer(in.FlavorID))
 	// WARNING: in.Image requires manual conversion: inconvertible types (string vs sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1.ImageParam)
 	// WARNING: in.ImageUUID requires manual conversion: does not exist in peer-type
 	out.SSHKeyName = in.SSHKeyName
@@ -1460,7 +1461,8 @@ func autoConvert_v1alpha7_OpenStackMachineSpec_To_v1beta1_OpenStackMachineSpec(i
 
 func autoConvert_v1beta1_OpenStackMachineSpec_To_v1alpha7_OpenStackMachineSpec(in *v1beta1.OpenStackMachineSpec, out *OpenStackMachineSpec, s conversion.Scope) error {
 	out.ProviderID = (*string)(unsafe.Pointer(in.ProviderID))
-	out.Flavor = in.Flavor
+	out.Flavor = (*string)(unsafe.Pointer(in.Flavor))
+	out.FlavorID = (*string)(unsafe.Pointer(in.FlavorID))
 	// WARNING: in.Image requires manual conversion: inconvertible types (sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1.ImageParam vs string)
 	out.SSHKeyName = in.SSHKeyName
 	if in.Ports != nil {

--- a/api/v1alpha7/zz_generated.deepcopy.go
+++ b/api/v1alpha7/zz_generated.deepcopy.go
@@ -645,6 +645,16 @@ func (in *OpenStackMachineSpec) DeepCopyInto(out *OpenStackMachineSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Flavor != nil {
+		in, out := &in.Flavor, &out.Flavor
+		*out = new(string)
+		**out = **in
+	}
+	if in.FlavorID != nil {
+		in, out := &in.FlavorID, &out.FlavorID
+		*out = new(string)
+		**out = **in
+	}
 	if in.Ports != nil {
 		in, out := &in.Ports, &out.Ports
 		*out = make([]PortOpts, len(*in))

--- a/api/v1beta1/openstackmachine_types.go
+++ b/api/v1beta1/openstackmachine_types.go
@@ -92,12 +92,19 @@ type SchedulerHintAdditionalProperty struct {
 }
 
 // OpenStackMachineSpec defines the desired state of OpenStackMachine.
+// +kubebuilder:validation:XValidation:message="at least one of flavor or flavorID must be set",rule=(has(self.flavor) || has(self.flavorID))
 type OpenStackMachineSpec struct {
 	// ProviderID is the unique identifier as specified by the cloud provider.
 	ProviderID *string `json:"providerID,omitempty"`
 
 	// The flavor reference for the flavor for your server instance.
-	Flavor string `json:"flavor"`
+	// +kubebuilder:validation:MinLength=1
+	Flavor *string `json:"flavor,omitempty"`
+
+	// FlavorID allows flavors to be specified by ID.  This field takes precedence
+	// over Flavor.
+	// +kubebuilder:validation:MinLength=1
+	FlavorID *string `json:"flavorID,omitempty"`
 
 	// The image to use for your server instance.
 	// If the rootVolume is specified, this will be used when creating the root volume.

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -900,6 +900,10 @@ type ResolvedMachineSpec struct {
 	// +optional
 	ImageID string `json:"imageID,omitempty"`
 
+	// FlavorID is the ID of the flavor to use.
+	// +optional
+	FlavorID string `json:"flavorID,omitempty"`
+
 	// Ports is the fully resolved list of ports to create for the machine.
 	// +optional
 	Ports []ResolvedPortSpec `json:"ports,omitempty"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -972,6 +972,16 @@ func (in *OpenStackMachineSpec) DeepCopyInto(out *OpenStackMachineSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Flavor != nil {
+		in, out := &in.Flavor, &out.Flavor
+		*out = new(string)
+		**out = **in
+	}
+	if in.FlavorID != nil {
+		in, out := &in.FlavorID, &out.FlavorID
+		*out = new(string)
+		**out = **in
+	}
 	in.Image.DeepCopyInto(&out.Image)
 	if in.Ports != nil {
 		in, out := &in.Ports, &out.Ports

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -161,6 +161,13 @@ spec:
                       flavor:
                         description: The flavor reference for the flavor for your
                           server instance.
+                        minLength: 1
+                        type: string
+                      flavorID:
+                        description: |-
+                          FlavorID allows flavors to be specified by ID.  This field takes precedence
+                          over Flavor.
+                        minLength: 1
                         type: string
                       floatingIP:
                         description: |-
@@ -577,8 +584,6 @@ spec:
                         description: Whether the server instance is created on a trunk
                           port or not.
                         type: boolean
-                    required:
-                    - flavor
                     type: object
                 type: object
               cloudName:
@@ -2142,6 +2147,13 @@ spec:
                       flavor:
                         description: The flavor reference for the flavor for your
                           server instance.
+                        minLength: 1
+                        type: string
+                      flavorID:
+                        description: |-
+                          FlavorID allows flavors to be specified by ID.  This field takes precedence
+                          over Flavor.
+                        minLength: 1
                         type: string
                       floatingIP:
                         description: |-
@@ -2435,8 +2447,6 @@ spec:
                         description: Whether the server instance is created on a trunk
                           port or not.
                         type: boolean
-                    required:
-                    - flavor
                     type: object
                 type: object
               cloudName:
@@ -3440,6 +3450,13 @@ spec:
                       flavor:
                         description: The flavor reference for the flavor for your
                           server instance.
+                        minLength: 1
+                        type: string
+                      flavorID:
+                        description: |-
+                          FlavorID allows flavors to be specified by ID.  This field takes precedence
+                          over Flavor.
+                        minLength: 1
                         type: string
                       floatingIPPoolRef:
                         description: |-
@@ -4204,9 +4221,11 @@ spec:
                           port or not.
                         type: boolean
                     required:
-                    - flavor
                     - image
                     type: object
+                    x-kubernetes-validations:
+                    - message: at least one of flavor or flavorID must be set
+                      rule: (has(self.flavor) || has(self.flavorID))
                 type: object
                 x-kubernetes-validations:
                 - message: spec is required if bastion is enabled
@@ -4980,6 +4999,9 @@ spec:
                       Resolved contains parts of the bastion's machine spec with all
                       external references fully resolved.
                     properties:
+                      flavorID:
+                        description: FlavorID is the ID of the flavor to use.
+                        type: string
                       imageID:
                         description: ImageID is the ID of the image to use for the
                           machine and is calculated based on ImageFilter.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
@@ -140,6 +140,13 @@ spec:
                               flavor:
                                 description: The flavor reference for the flavor for
                                   your server instance.
+                                minLength: 1
+                                type: string
+                              flavorID:
+                                description: |-
+                                  FlavorID allows flavors to be specified by ID.  This field takes precedence
+                                  over Flavor.
+                                minLength: 1
                                 type: string
                               floatingIP:
                                 description: |-
@@ -563,8 +570,6 @@ spec:
                                 description: Whether the server instance is created
                                   on a trunk port or not.
                                 type: boolean
-                            required:
-                            - flavor
                             type: object
                         type: object
                       cloudName:
@@ -972,6 +977,13 @@ spec:
                               flavor:
                                 description: The flavor reference for the flavor for
                                   your server instance.
+                                minLength: 1
+                                type: string
+                              flavorID:
+                                description: |-
+                                  FlavorID allows flavors to be specified by ID.  This field takes precedence
+                                  over Flavor.
+                                minLength: 1
                                 type: string
                               floatingIP:
                                 description: |-
@@ -1271,8 +1283,6 @@ spec:
                                 description: Whether the server instance is created
                                   on a trunk port or not.
                                 type: boolean
-                            required:
-                            - flavor
                             type: object
                         type: object
                       cloudName:
@@ -1923,6 +1933,13 @@ spec:
                               flavor:
                                 description: The flavor reference for the flavor for
                                   your server instance.
+                                minLength: 1
+                                type: string
+                              flavorID:
+                                description: |-
+                                  FlavorID allows flavors to be specified by ID.  This field takes precedence
+                                  over Flavor.
+                                minLength: 1
                                 type: string
                               floatingIPPoolRef:
                                 description: |-
@@ -2703,9 +2720,12 @@ spec:
                                   on a trunk port or not.
                                 type: boolean
                             required:
-                            - flavor
                             - image
                             type: object
+                            x-kubernetes-validations:
+                            - message: at least one of flavor or flavorID must be
+                                set
+                              rule: (has(self.flavor) || has(self.flavorID))
                         type: object
                         x-kubernetes-validations:
                         - message: spec is required if bastion is enabled

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
@@ -83,6 +83,13 @@ spec:
                 type: boolean
               flavor:
                 description: The flavor reference for the flavor for your server instance.
+                minLength: 1
+                type: string
+              flavorID:
+                description: |-
+                  FlavorID allows flavors to be specified by ID.  This field takes precedence
+                  over Flavor.
+                minLength: 1
                 type: string
               floatingIP:
                 description: |-
@@ -493,8 +500,6 @@ spec:
                 description: Whether the server instance is created on a trunk port
                   or not.
                 type: boolean
-            required:
-            - flavor
             type: object
           status:
             description: OpenStackMachineStatus defines the observed state of OpenStackMachine.
@@ -727,6 +732,13 @@ spec:
                 type: boolean
               flavor:
                 description: The flavor reference for the flavor for your server instance.
+                minLength: 1
+                type: string
+              flavorID:
+                description: |-
+                  FlavorID allows flavors to be specified by ID.  This field takes precedence
+                  over Flavor.
+                minLength: 1
                 type: string
               floatingIP:
                 description: |-
@@ -1015,8 +1027,6 @@ spec:
                 description: Whether the server instance is created on a trunk port
                   or not.
                 type: boolean
-            required:
-            - flavor
             type: object
           status:
             description: OpenStackMachineStatus defines the observed state of OpenStackMachine.
@@ -1264,6 +1274,13 @@ spec:
                 type: boolean
               flavor:
                 description: The flavor reference for the flavor for your server instance.
+                minLength: 1
+                type: string
+              flavorID:
+                description: |-
+                  FlavorID allows flavors to be specified by ID.  This field takes precedence
+                  over Flavor.
+                minLength: 1
                 type: string
               floatingIPPoolRef:
                 description: |-
@@ -2020,9 +2037,11 @@ spec:
                   or not.
                 type: boolean
             required:
-            - flavor
             - image
             type: object
+            x-kubernetes-validations:
+            - message: at least one of flavor or flavorID must be set
+              rule: (has(self.flavor) || has(self.flavorID))
           status:
             description: OpenStackMachineStatus defines the observed state of OpenStackMachine.
             properties:
@@ -2130,6 +2149,9 @@ spec:
                   Resolved contains parts of the machine spec with all external
                   references fully resolved.
                 properties:
+                  flavorID:
+                    description: FlavorID is the ID of the flavor to use.
+                    type: string
                   imageID:
                     description: ImageID is the ID of the image to use for the machine
                       and is calculated based on ImageFilter.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
@@ -69,6 +69,13 @@ spec:
                       flavor:
                         description: The flavor reference for the flavor for your
                           server instance.
+                        minLength: 1
+                        type: string
+                      flavorID:
+                        description: |-
+                          FlavorID allows flavors to be specified by ID.  This field takes precedence
+                          over Flavor.
+                        minLength: 1
                         type: string
                       floatingIP:
                         description: |-
@@ -485,8 +492,6 @@ spec:
                         description: Whether the server instance is created on a trunk
                           port or not.
                         type: boolean
-                    required:
-                    - flavor
                     type: object
                 required:
                 - spec
@@ -609,6 +614,13 @@ spec:
                       flavor:
                         description: The flavor reference for the flavor for your
                           server instance.
+                        minLength: 1
+                        type: string
+                      flavorID:
+                        description: |-
+                          FlavorID allows flavors to be specified by ID.  This field takes precedence
+                          over Flavor.
+                        minLength: 1
                         type: string
                       floatingIP:
                         description: |-
@@ -902,8 +914,6 @@ spec:
                         description: Whether the server instance is created on a trunk
                           port or not.
                         type: boolean
-                    required:
-                    - flavor
                     type: object
                 required:
                 - spec
@@ -1042,6 +1052,13 @@ spec:
                       flavor:
                         description: The flavor reference for the flavor for your
                           server instance.
+                        minLength: 1
+                        type: string
+                      flavorID:
+                        description: |-
+                          FlavorID allows flavors to be specified by ID.  This field takes precedence
+                          over Flavor.
+                        minLength: 1
                         type: string
                       floatingIPPoolRef:
                         description: |-
@@ -1806,9 +1823,11 @@ spec:
                           port or not.
                         type: boolean
                     required:
-                    - flavor
                     - image
                     type: object
+                    x-kubernetes-validations:
+                    - message: at least one of flavor or flavorID must be set
+                      rule: (has(self.flavor) || has(self.flavorID))
                 required:
                 - spec
                 type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackservers.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackservers.yaml
@@ -156,6 +156,13 @@ spec:
                 type: boolean
               flavor:
                 description: The flavor reference for the flavor for the server instance.
+                minLength: 1
+                type: string
+              flavorID:
+                description: |-
+                  FlavorID allows flavors to be specified by ID.  This field takes precedence
+                  over Flavor.
+                minLength: 1
                 type: string
               floatingIPPoolRef:
                 description: FloatingIPPoolRef is a reference to a FloatingIPPool
@@ -922,12 +929,14 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
             required:
-            - flavor
             - identityRef
             - image
             - ports
             - sshKeyName
             type: object
+            x-kubernetes-validations:
+            - message: at least one of flavor or flavorID must be set
+              rule: (has(self.flavor) || has(self.flavorID))
           status:
             description: OpenStackServerStatus defines the observed state of OpenStackServer.
             properties:
@@ -1008,6 +1017,9 @@ spec:
                   Resolved contains parts of the machine spec with all external
                   references fully resolved.
                 properties:
+                  flavorID:
+                    description: FlavorID is the ID of the flavor to use.
+                    type: string
                   imageID:
                     description: ImageID is the ID of the image to use for the server
                       and is calculated based on ImageFilter.

--- a/controllers/openstackcluster_controller_test.go
+++ b/controllers/openstackcluster_controller_test.go
@@ -56,6 +56,7 @@ var _ = Describe("OpenStackCluster controller", func() {
 	testClusterName := "test-cluster"
 	testNum := 0
 	bastionSpec := infrav1.OpenStackMachineSpec{
+		Flavor: ptr.To("flavor-name"),
 		Image: infrav1.ImageParam{
 			Filter: &infrav1.ImageFilter{
 				Name: ptr.To("fake-name"),

--- a/controllers/openstackmachine_controller_test.go
+++ b/controllers/openstackmachine_controller_test.go
@@ -35,6 +35,7 @@ const (
 	workerSecurityGroupUUID       = "9c6c0d28-03c9-436c-815d-58440ac2c1c8"
 	serverGroupUUID               = "7b940d62-68ef-4e42-a76a-1a62e290509c"
 	imageUUID                     = "ce96e584-7ebc-46d6-9e55-987d72e3806c"
+	flavorUUID                    = "43b1c962-53ba-4690-b210-14e5a7651dbe"
 
 	openStackMachineName = "test-openstack-machine"
 	namespace            = "test-namespace"
@@ -86,12 +87,12 @@ func TestOpenStackMachineSpecToOpenStackServerSpec(t *testing.T) {
 		{
 			name: "Test a minimum OpenStackMachineSpec to OpenStackServerSpec conversion",
 			spec: &infrav1.OpenStackMachineSpec{
-				Flavor:     flavorName,
+				Flavor:     ptr.To(flavorName),
 				Image:      image,
 				SSHKeyName: sshKeyName,
 			},
 			want: &infrav1alpha1.OpenStackServerSpec{
-				Flavor:      flavorName,
+				Flavor:      ptr.To(flavorName),
 				IdentityRef: identityRef,
 				Image:       image,
 				SSHKeyName:  sshKeyName,

--- a/controllers/openstackserver_controller.go
+++ b/controllers/openstackserver_controller.go
@@ -534,7 +534,7 @@ func (r *OpenStackServerReconciler) serverToInstanceSpec(ctx context.Context, op
 	instanceSpec := &compute.InstanceSpec{
 		AdditionalBlockDevices:        openStackServer.Spec.AdditionalBlockDevices,
 		ConfigDrive:                   openStackServer.Spec.ConfigDrive != nil && *openStackServer.Spec.ConfigDrive,
-		Flavor:                        openStackServer.Spec.Flavor,
+		FlavorID:                      resolved.FlavorID,
 		ImageID:                       resolved.ImageID,
 		Metadata:                      serverMetadata,
 		Name:                          openStackServer.Name,

--- a/docs/book/src/api/v1alpha1/api.md
+++ b/docs/book/src/api/v1alpha1/api.md
@@ -107,7 +107,21 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>The flavor reference for the flavor for the server instance.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>flavorID</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>FlavorID allows flavors to be specified by ID.  This field takes precedence
+over Flavor.</p>
 </td>
 </tr>
 <tr>
@@ -646,7 +660,21 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>The flavor reference for the flavor for the server instance.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>flavorID</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>FlavorID allows flavors to be specified by ID.  This field takes precedence
+over Flavor.</p>
 </td>
 </tr>
 <tr>
@@ -998,6 +1026,18 @@ string
 <td>
 <em>(Optional)</em>
 <p>ImageID is the ID of the image to use for the server and is calculated based on ImageFilter.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>flavorID</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>FlavorID is the ID of the flavor to use.</p>
 </td>
 </tr>
 <tr>

--- a/docs/book/src/api/v1alpha6/api.md
+++ b/docs/book/src/api/v1alpha6/api.md
@@ -556,6 +556,18 @@ string
 </tr>
 <tr>
 <td>
+<code>flavorID</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>FlavorID allows flavors to be specified by ID.  This field takes precedence
+over Flavor.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>image</code><br/>
 <em>
 string
@@ -2610,6 +2622,18 @@ string
 </tr>
 <tr>
 <td>
+<code>flavorID</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>FlavorID allows flavors to be specified by ID.  This field takes precedence
+over Flavor.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>image</code><br/>
 <em>
 string
@@ -2971,6 +2995,18 @@ string
 </td>
 <td>
 <p>The flavor reference for the flavor for your server instance.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>flavorID</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>FlavorID allows flavors to be specified by ID.  This field takes precedence
+over Flavor.</p>
 </td>
 </tr>
 <tr>

--- a/docs/book/src/api/v1alpha7/api.md
+++ b/docs/book/src/api/v1alpha7/api.md
@@ -586,6 +586,18 @@ string
 </tr>
 <tr>
 <td>
+<code>flavorID</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>FlavorID allows flavors to be specified by ID.  This field takes precedence
+over Flavor.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>image</code><br/>
 <em>
 string
@@ -2720,6 +2732,18 @@ string
 </tr>
 <tr>
 <td>
+<code>flavorID</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>FlavorID allows flavors to be specified by ID.  This field takes precedence
+over Flavor.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>image</code><br/>
 <em>
 string
@@ -3071,6 +3095,18 @@ string
 </td>
 <td>
 <p>The flavor reference for the flavor for your server instance.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>flavorID</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>FlavorID allows flavors to be specified by ID.  This field takes precedence
+over Flavor.</p>
 </td>
 </tr>
 <tr>

--- a/docs/book/src/api/v1beta1/api.md
+++ b/docs/book/src/api/v1beta1/api.md
@@ -574,6 +574,18 @@ string
 </tr>
 <tr>
 <td>
+<code>flavorID</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>FlavorID allows flavors to be specified by ID.  This field takes precedence
+over Flavor.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>image</code><br/>
 <em>
 <a href="#infrastructure.cluster.x-k8s.io/v1beta1.ImageParam">
@@ -3233,6 +3245,18 @@ string
 </tr>
 <tr>
 <td>
+<code>flavorID</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>FlavorID allows flavors to be specified by ID.  This field takes precedence
+over Flavor.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>image</code><br/>
 <em>
 <a href="#infrastructure.cluster.x-k8s.io/v1beta1.ImageParam">
@@ -3618,6 +3642,18 @@ string
 </td>
 <td>
 <p>The flavor reference for the flavor for your server instance.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>flavorID</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>FlavorID allows flavors to be specified by ID.  This field takes precedence
+over Flavor.</p>
 </td>
 </tr>
 <tr>
@@ -4086,6 +4122,18 @@ string
 <td>
 <em>(Optional)</em>
 <p>ImageID is the ID of the image to use for the machine and is calculated based on ImageFilter.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>flavorID</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>FlavorID is the ID of the flavor to use.</p>
 </td>
 </tr>
 <tr>

--- a/hack/codegen/openapi/zz_generated.openapi.go
+++ b/hack/codegen/openapi/zz_generated.openapi.go
@@ -16585,7 +16585,13 @@ func schema_sigsk8sio_cluster_api_provider_openstack_api_v1alpha1_OpenStackServe
 					"flavor": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The flavor reference for the flavor for the server instance.",
-							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"flavorID": {
+						SchemaProps: spec.SchemaProps{
+							Description: "FlavorID allows flavors to be specified by ID.  This field takes precedence over Flavor.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -16736,7 +16742,7 @@ func schema_sigsk8sio_cluster_api_provider_openstack_api_v1alpha1_OpenStackServe
 						},
 					},
 				},
-				Required: []string{"flavor", "identityRef", "image", "ports", "sshKeyName"},
+				Required: []string{"identityRef", "image", "ports", "sshKeyName"},
 			},
 		},
 		Dependencies: []string{
@@ -16839,6 +16845,13 @@ func schema_sigsk8sio_cluster_api_provider_openstack_api_v1alpha1_ResolvedServer
 					"imageID": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ImageID is the ID of the image to use for the server and is calculated based on ImageFilter.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"flavorID": {
+						SchemaProps: spec.SchemaProps{
+							Description: "FlavorID is the ID of the flavor to use.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -18158,7 +18171,13 @@ func schema_sigsk8sio_cluster_api_provider_openstack_api_v1alpha6_OpenStackMachi
 					"flavor": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The flavor reference for the flavor for your server instance.",
-							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"flavorID": {
+						SchemaProps: spec.SchemaProps{
+							Description: "FlavorID allows flavors to be specified by ID.  This field takes precedence over Flavor.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -18310,7 +18329,6 @@ func schema_sigsk8sio_cluster_api_provider_openstack_api_v1alpha6_OpenStackMachi
 						},
 					},
 				},
-				Required: []string{"flavor"},
 			},
 		},
 		Dependencies: []string{
@@ -20562,7 +20580,13 @@ func schema_sigsk8sio_cluster_api_provider_openstack_api_v1alpha7_OpenStackMachi
 					"flavor": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The flavor reference for the flavor for your server instance.",
-							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"flavorID": {
+						SchemaProps: spec.SchemaProps{
+							Description: "FlavorID allows flavors to be specified by ID.  This field takes precedence over Flavor.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -20715,7 +20739,6 @@ func schema_sigsk8sio_cluster_api_provider_openstack_api_v1alpha7_OpenStackMachi
 						},
 					},
 				},
-				Required: []string{"flavor"},
 			},
 		},
 		Dependencies: []string{
@@ -23319,7 +23342,13 @@ func schema_sigsk8sio_cluster_api_provider_openstack_api_v1beta1_OpenStackMachin
 					"flavor": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The flavor reference for the flavor for your server instance.",
-							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"flavorID": {
+						SchemaProps: spec.SchemaProps{
+							Description: "FlavorID allows flavors to be specified by ID.  This field takes precedence over Flavor.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -23491,7 +23520,7 @@ func schema_sigsk8sio_cluster_api_provider_openstack_api_v1beta1_OpenStackMachin
 						},
 					},
 				},
-				Required: []string{"flavor", "image"},
+				Required: []string{"image"},
 			},
 		},
 		Dependencies: []string{
@@ -23971,6 +24000,13 @@ func schema_sigsk8sio_cluster_api_provider_openstack_api_v1beta1_ResolvedMachine
 					"imageID": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ImageID is the ID of the image to use for the machine and is calculated based on ImageFilter.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"flavorID": {
+						SchemaProps: spec.SchemaProps{
+							Description: "FlavorID is the ID of the flavor to use.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/clients/mock/compute.go
+++ b/pkg/clients/mock/compute.go
@@ -101,21 +101,6 @@ func (mr *MockComputeClientMockRecorder) DeleteServer(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteServer", reflect.TypeOf((*MockComputeClient)(nil).DeleteServer), arg0)
 }
 
-// GetFlavorFromName mocks base method.
-func (m *MockComputeClient) GetFlavorFromName(arg0 string) (*flavors.Flavor, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetFlavorFromName", arg0)
-	ret0, _ := ret[0].(*flavors.Flavor)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetFlavorFromName indicates an expected call of GetFlavorFromName.
-func (mr *MockComputeClientMockRecorder) GetFlavorFromName(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFlavorFromName", reflect.TypeOf((*MockComputeClient)(nil).GetFlavorFromName), arg0)
-}
-
 // GetServer mocks base method.
 func (m *MockComputeClient) GetServer(arg0 string) (*servers.Server, error) {
 	m.ctrl.T.Helper()
@@ -159,6 +144,21 @@ func (m *MockComputeClient) ListAvailabilityZones() ([]availabilityzones.Availab
 func (mr *MockComputeClientMockRecorder) ListAvailabilityZones() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAvailabilityZones", reflect.TypeOf((*MockComputeClient)(nil).ListAvailabilityZones))
+}
+
+// ListFlavors mocks base method.
+func (m *MockComputeClient) ListFlavors() ([]flavors.Flavor, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListFlavors")
+	ret0, _ := ret[0].([]flavors.Flavor)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListFlavors indicates an expected call of ListFlavors.
+func (mr *MockComputeClientMockRecorder) ListFlavors() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListFlavors", reflect.TypeOf((*MockComputeClient)(nil).ListFlavors))
 }
 
 // ListServerGroups mocks base method.

--- a/pkg/cloud/services/compute/instance_types.go
+++ b/pkg/cloud/services/compute/instance_types.go
@@ -32,7 +32,7 @@ import (
 type InstanceSpec struct {
 	Name                          string
 	ImageID                       string
-	Flavor                        string
+	FlavorID                      string
 	SSHKeyName                    string
 	UserData                      string
 	Metadata                      map[string]string

--- a/pkg/cloud/services/compute/referenced_resources.go
+++ b/pkg/cloud/services/compute/referenced_resources.go
@@ -105,6 +105,20 @@ func ResolveServerSpec(ctx context.Context, scope *scope.WithLogger, k8sClient c
 		return true, true, nil
 	}
 
+	flavorID := func() (bool, bool, error) {
+		if resolved.FlavorID != "" {
+			return true, false, nil
+		}
+
+		flavorID, err := computeService.GetFlavorID(spec.FlavorID, spec.Flavor)
+		if err != nil {
+			return false, false, err
+		}
+
+		resolved.FlavorID = flavorID
+		return true, true, nil
+	}
+
 	ports := func() (bool, bool, error) {
 		if len(resolved.Ports) > 0 {
 			return true, false, nil
@@ -135,7 +149,7 @@ func ResolveServerSpec(ctx context.Context, scope *scope.WithLogger, k8sClient c
 	var errs []error
 	changed := false
 	done := true
-	for _, setter := range []setterFn{serverGroup, imageID, ports} {
+	for _, setter := range []setterFn{serverGroup, imageID, flavorID, ports} {
 		thisDone, thisChanged, err := setter()
 		changed = changed || thisChanged
 		done = done && thisDone

--- a/pkg/generated/applyconfiguration/api/v1alpha1/openstackserverspec.go
+++ b/pkg/generated/applyconfiguration/api/v1alpha1/openstackserverspec.go
@@ -30,6 +30,7 @@ type OpenStackServerSpecApplyConfiguration struct {
 	AvailabilityZone                  *string                                                     `json:"availabilityZone,omitempty"`
 	ConfigDrive                       *bool                                                       `json:"configDrive,omitempty"`
 	Flavor                            *string                                                     `json:"flavor,omitempty"`
+	FlavorID                          *string                                                     `json:"flavorID,omitempty"`
 	FloatingIPPoolRef                 *v1.TypedLocalObjectReference                               `json:"floatingIPPoolRef,omitempty"`
 	IdentityRef                       *v1beta1.OpenStackIdentityReferenceApplyConfiguration       `json:"identityRef,omitempty"`
 	Image                             *v1beta1.ImageParamApplyConfiguration                       `json:"image,omitempty"`
@@ -85,6 +86,14 @@ func (b *OpenStackServerSpecApplyConfiguration) WithConfigDrive(value bool) *Ope
 // If called multiple times, the Flavor field is set to the value of the last call.
 func (b *OpenStackServerSpecApplyConfiguration) WithFlavor(value string) *OpenStackServerSpecApplyConfiguration {
 	b.Flavor = &value
+	return b
+}
+
+// WithFlavorID sets the FlavorID field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the FlavorID field is set to the value of the last call.
+func (b *OpenStackServerSpecApplyConfiguration) WithFlavorID(value string) *OpenStackServerSpecApplyConfiguration {
+	b.FlavorID = &value
 	return b
 }
 

--- a/pkg/generated/applyconfiguration/api/v1alpha1/resolvedserverspec.go
+++ b/pkg/generated/applyconfiguration/api/v1alpha1/resolvedserverspec.go
@@ -27,6 +27,7 @@ import (
 type ResolvedServerSpecApplyConfiguration struct {
 	ServerGroupID *string                                      `json:"serverGroupID,omitempty"`
 	ImageID       *string                                      `json:"imageID,omitempty"`
+	FlavorID      *string                                      `json:"flavorID,omitempty"`
 	Ports         []v1beta1.ResolvedPortSpecApplyConfiguration `json:"ports,omitempty"`
 }
 
@@ -49,6 +50,14 @@ func (b *ResolvedServerSpecApplyConfiguration) WithServerGroupID(value string) *
 // If called multiple times, the ImageID field is set to the value of the last call.
 func (b *ResolvedServerSpecApplyConfiguration) WithImageID(value string) *ResolvedServerSpecApplyConfiguration {
 	b.ImageID = &value
+	return b
+}
+
+// WithFlavorID sets the FlavorID field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the FlavorID field is set to the value of the last call.
+func (b *ResolvedServerSpecApplyConfiguration) WithFlavorID(value string) *ResolvedServerSpecApplyConfiguration {
+	b.FlavorID = &value
 	return b
 }
 

--- a/pkg/generated/applyconfiguration/api/v1alpha6/openstackmachinespec.go
+++ b/pkg/generated/applyconfiguration/api/v1alpha6/openstackmachinespec.go
@@ -25,6 +25,7 @@ type OpenStackMachineSpecApplyConfiguration struct {
 	InstanceID     *string                                       `json:"instanceID,omitempty"`
 	CloudName      *string                                       `json:"cloudName,omitempty"`
 	Flavor         *string                                       `json:"flavor,omitempty"`
+	FlavorID       *string                                       `json:"flavorID,omitempty"`
 	Image          *string                                       `json:"image,omitempty"`
 	ImageUUID      *string                                       `json:"imageUUID,omitempty"`
 	SSHKeyName     *string                                       `json:"sshKeyName,omitempty"`
@@ -77,6 +78,14 @@ func (b *OpenStackMachineSpecApplyConfiguration) WithCloudName(value string) *Op
 // If called multiple times, the Flavor field is set to the value of the last call.
 func (b *OpenStackMachineSpecApplyConfiguration) WithFlavor(value string) *OpenStackMachineSpecApplyConfiguration {
 	b.Flavor = &value
+	return b
+}
+
+// WithFlavorID sets the FlavorID field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the FlavorID field is set to the value of the last call.
+func (b *OpenStackMachineSpecApplyConfiguration) WithFlavorID(value string) *OpenStackMachineSpecApplyConfiguration {
+	b.FlavorID = &value
 	return b
 }
 

--- a/pkg/generated/applyconfiguration/api/v1alpha7/openstackmachinespec.go
+++ b/pkg/generated/applyconfiguration/api/v1alpha7/openstackmachinespec.go
@@ -25,6 +25,7 @@ type OpenStackMachineSpecApplyConfiguration struct {
 	InstanceID             *string                                       `json:"instanceID,omitempty"`
 	CloudName              *string                                       `json:"cloudName,omitempty"`
 	Flavor                 *string                                       `json:"flavor,omitempty"`
+	FlavorID               *string                                       `json:"flavorID,omitempty"`
 	Image                  *string                                       `json:"image,omitempty"`
 	ImageUUID              *string                                       `json:"imageUUID,omitempty"`
 	SSHKeyName             *string                                       `json:"sshKeyName,omitempty"`
@@ -76,6 +77,14 @@ func (b *OpenStackMachineSpecApplyConfiguration) WithCloudName(value string) *Op
 // If called multiple times, the Flavor field is set to the value of the last call.
 func (b *OpenStackMachineSpecApplyConfiguration) WithFlavor(value string) *OpenStackMachineSpecApplyConfiguration {
 	b.Flavor = &value
+	return b
+}
+
+// WithFlavorID sets the FlavorID field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the FlavorID field is set to the value of the last call.
+func (b *OpenStackMachineSpecApplyConfiguration) WithFlavorID(value string) *OpenStackMachineSpecApplyConfiguration {
+	b.FlavorID = &value
 	return b
 }
 

--- a/pkg/generated/applyconfiguration/api/v1beta1/openstackmachinespec.go
+++ b/pkg/generated/applyconfiguration/api/v1beta1/openstackmachinespec.go
@@ -27,6 +27,7 @@ import (
 type OpenStackMachineSpecApplyConfiguration struct {
 	ProviderID                        *string                                             `json:"providerID,omitempty"`
 	Flavor                            *string                                             `json:"flavor,omitempty"`
+	FlavorID                          *string                                             `json:"flavorID,omitempty"`
 	Image                             *ImageParamApplyConfiguration                       `json:"image,omitempty"`
 	SSHKeyName                        *string                                             `json:"sshKeyName,omitempty"`
 	Ports                             []PortOptsApplyConfiguration                        `json:"ports,omitempty"`
@@ -62,6 +63,14 @@ func (b *OpenStackMachineSpecApplyConfiguration) WithProviderID(value string) *O
 // If called multiple times, the Flavor field is set to the value of the last call.
 func (b *OpenStackMachineSpecApplyConfiguration) WithFlavor(value string) *OpenStackMachineSpecApplyConfiguration {
 	b.Flavor = &value
+	return b
+}
+
+// WithFlavorID sets the FlavorID field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the FlavorID field is set to the value of the last call.
+func (b *OpenStackMachineSpecApplyConfiguration) WithFlavorID(value string) *OpenStackMachineSpecApplyConfiguration {
+	b.FlavorID = &value
 	return b
 }
 

--- a/pkg/generated/applyconfiguration/api/v1beta1/resolvedmachinespec.go
+++ b/pkg/generated/applyconfiguration/api/v1beta1/resolvedmachinespec.go
@@ -23,6 +23,7 @@ package v1beta1
 type ResolvedMachineSpecApplyConfiguration struct {
 	ServerGroupID *string                              `json:"serverGroupID,omitempty"`
 	ImageID       *string                              `json:"imageID,omitempty"`
+	FlavorID      *string                              `json:"flavorID,omitempty"`
 	Ports         []ResolvedPortSpecApplyConfiguration `json:"ports,omitempty"`
 }
 
@@ -45,6 +46,14 @@ func (b *ResolvedMachineSpecApplyConfiguration) WithServerGroupID(value string) 
 // If called multiple times, the ImageID field is set to the value of the last call.
 func (b *ResolvedMachineSpecApplyConfiguration) WithImageID(value string) *ResolvedMachineSpecApplyConfiguration {
 	b.ImageID = &value
+	return b
+}
+
+// WithFlavorID sets the FlavorID field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the FlavorID field is set to the value of the last call.
+func (b *ResolvedMachineSpecApplyConfiguration) WithFlavorID(value string) *ResolvedMachineSpecApplyConfiguration {
+	b.FlavorID = &value
 	return b
 }
 

--- a/pkg/generated/applyconfiguration/internal/internal.go
+++ b/pkg/generated/applyconfiguration/internal/internal.go
@@ -241,7 +241,9 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: flavor
       type:
         scalar: string
-      default: ""
+    - name: flavorID
+      type:
+        scalar: string
     - name: floatingIPPoolRef
       type:
         namedType: io.k8s.api.core.v1.TypedLocalObjectReference
@@ -337,6 +339,9 @@ var schemaYAML = typed.YAMLObject(`types:
 - name: io.k8s.sigs.cluster-api-provider-openstack.api.v1alpha1.ResolvedServerSpec
   map:
     fields:
+    - name: flavorID
+      type:
+        scalar: string
     - name: imageID
       type:
         scalar: string
@@ -820,7 +825,9 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: flavor
       type:
         scalar: string
-      default: ""
+    - name: flavorID
+      type:
+        scalar: string
     - name: floatingIP
       type:
         scalar: string
@@ -1728,7 +1735,9 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: flavor
       type:
         scalar: string
-      default: ""
+    - name: flavorID
+      type:
+        scalar: string
     - name: floatingIP
       type:
         scalar: string
@@ -2695,7 +2704,9 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: flavor
       type:
         scalar: string
-      default: ""
+    - name: flavorID
+      type:
+        scalar: string
     - name: floatingIPPoolRef
       type:
         namedType: io.k8s.api.core.v1.TypedLocalObjectReference
@@ -2910,6 +2921,9 @@ var schemaYAML = typed.YAMLObject(`types:
 - name: io.k8s.sigs.cluster-api-provider-openstack.api.v1beta1.ResolvedMachineSpec
   map:
     fields:
+    - name: flavorID
+      type:
+        scalar: string
     - name: imageID
       type:
         scalar: string

--- a/pkg/webhooks/openstackcluster_webhook_test.go
+++ b/pkg/webhooks/openstackcluster_webhook_test.go
@@ -88,7 +88,7 @@ func TestOpenStackCluster_ValidateUpdate(t *testing.T) {
 									Name: ptr.To("foobar"),
 								},
 							},
-							Flavor: "minimal",
+							Flavor: ptr.To("minimal"),
 						},
 						Enabled: ptr.To(true),
 					},
@@ -112,7 +112,7 @@ func TestOpenStackCluster_ValidateUpdate(t *testing.T) {
 									Name: ptr.To("foobarbaz"),
 								},
 							},
-							Flavor: "medium",
+							Flavor: ptr.To("medium"),
 						},
 						Enabled: ptr.To(true),
 					},
@@ -459,7 +459,7 @@ func TestOpenStackCluster_ValidateUpdate(t *testing.T) {
 					Bastion: &infrav1.Bastion{
 						Enabled: ptr.To(true),
 						Spec: &infrav1.OpenStackMachineSpec{
-							Flavor: "m1.small",
+							Flavor: ptr.To("m1.small"),
 							Image: infrav1.ImageParam{
 								Filter: &infrav1.ImageFilter{
 									Name: ptr.To("ubuntu"),
@@ -490,7 +490,7 @@ func TestOpenStackCluster_ValidateUpdate(t *testing.T) {
 					Bastion: &infrav1.Bastion{
 						Enabled: ptr.To(false),
 						Spec: &infrav1.OpenStackMachineSpec{
-							Flavor: "m1.small",
+							Flavor: ptr.To("m1.small"),
 							Image: infrav1.ImageParam{
 								Filter: &infrav1.ImageFilter{
 									Name: ptr.To("ubuntu"),

--- a/pkg/webhooks/openstackmachinetemplate_webhook_test.go
+++ b/pkg/webhooks/openstackmachinetemplate_webhook_test.go
@@ -46,7 +46,7 @@ func TestOpenStackMachineTemplate_ValidateUpdate(t *testing.T) {
 				Spec: infrav1.OpenStackMachineTemplateSpec{
 					Template: infrav1.OpenStackMachineTemplateResource{
 						Spec: infrav1.OpenStackMachineSpec{
-							Flavor: "foo",
+							Flavor: ptr.To("foo"),
 							Image: infrav1.ImageParam{
 								Filter: &infrav1.ImageFilter{
 									Name: ptr.To("bar"),
@@ -60,7 +60,7 @@ func TestOpenStackMachineTemplate_ValidateUpdate(t *testing.T) {
 				Spec: infrav1.OpenStackMachineTemplateSpec{
 					Template: infrav1.OpenStackMachineTemplateResource{
 						Spec: infrav1.OpenStackMachineSpec{
-							Flavor: "foo",
+							Flavor: ptr.To("foo"),
 							Image: infrav1.ImageParam{
 								Filter: &infrav1.ImageFilter{
 									Name: ptr.To("NewImage"),
@@ -79,7 +79,7 @@ func TestOpenStackMachineTemplate_ValidateUpdate(t *testing.T) {
 				Spec: infrav1.OpenStackMachineTemplateSpec{
 					Template: infrav1.OpenStackMachineTemplateResource{
 						Spec: infrav1.OpenStackMachineSpec{
-							Flavor: "foo",
+							Flavor: ptr.To("foo"),
 							Image: infrav1.ImageParam{
 								Filter: &infrav1.ImageFilter{
 									Name: ptr.To("bar"),
@@ -96,7 +96,7 @@ func TestOpenStackMachineTemplate_ValidateUpdate(t *testing.T) {
 				Spec: infrav1.OpenStackMachineTemplateSpec{
 					Template: infrav1.OpenStackMachineTemplateResource{
 						Spec: infrav1.OpenStackMachineSpec{
-							Flavor: "foo",
+							Flavor: ptr.To("foo"),
 							Image: infrav1.ImageParam{
 								Filter: &infrav1.ImageFilter{
 									Name: ptr.To("bar"),
@@ -117,7 +117,7 @@ func TestOpenStackMachineTemplate_ValidateUpdate(t *testing.T) {
 				Spec: infrav1.OpenStackMachineTemplateSpec{
 					Template: infrav1.OpenStackMachineTemplateResource{
 						Spec: infrav1.OpenStackMachineSpec{
-							Flavor: "foo",
+							Flavor: ptr.To("foo"),
 							Image: infrav1.ImageParam{
 								Filter: &infrav1.ImageFilter{
 									Name: ptr.To("bar"),
@@ -131,7 +131,7 @@ func TestOpenStackMachineTemplate_ValidateUpdate(t *testing.T) {
 				Spec: infrav1.OpenStackMachineTemplateSpec{
 					Template: infrav1.OpenStackMachineTemplateResource{
 						Spec: infrav1.OpenStackMachineSpec{
-							Flavor: "foo",
+							Flavor: ptr.To("foo"),
 							Image: infrav1.ImageParam{
 								Filter: &infrav1.ImageFilter{
 									Name: ptr.To("NewImage"),
@@ -150,7 +150,7 @@ func TestOpenStackMachineTemplate_ValidateUpdate(t *testing.T) {
 				Spec: infrav1.OpenStackMachineTemplateSpec{
 					Template: infrav1.OpenStackMachineTemplateResource{
 						Spec: infrav1.OpenStackMachineSpec{
-							Flavor: "foo",
+							Flavor: ptr.To("foo"),
 							Image: infrav1.ImageParam{
 								Filter: &infrav1.ImageFilter{
 									Name: ptr.To("bar"),
@@ -169,7 +169,7 @@ func TestOpenStackMachineTemplate_ValidateUpdate(t *testing.T) {
 				Spec: infrav1.OpenStackMachineTemplateSpec{
 					Template: infrav1.OpenStackMachineTemplateResource{
 						Spec: infrav1.OpenStackMachineSpec{
-							Flavor: "foo",
+							Flavor: ptr.To("foo"),
 							Image: infrav1.ImageParam{
 								Filter: &infrav1.ImageFilter{
 									Name: ptr.To("NewImage"),

--- a/pkg/webhooks/openstackserver_webhook_test.go
+++ b/pkg/webhooks/openstackserver_webhook_test.go
@@ -44,12 +44,12 @@ func TestOpenStackServer_ValidateUpdate(t *testing.T) {
 			name: "OpenStackServer with immutable spec",
 			old: &infrav1alpha1.OpenStackServer{
 				Spec: infrav1alpha1.OpenStackServerSpec{
-					Flavor: "foo",
+					Flavor: ptr.To("foo"),
 				},
 			},
 			new: &infrav1alpha1.OpenStackServer{
 				Spec: infrav1alpha1.OpenStackServerSpec{
-					Flavor: "new",
+					Flavor: ptr.To("new"),
 				},
 			},
 			req:     &admission.Request{},
@@ -59,7 +59,7 @@ func TestOpenStackServer_ValidateUpdate(t *testing.T) {
 			name: "OpenStackServer with mutable metadata",
 			old: &infrav1alpha1.OpenStackServer{
 				Spec: infrav1alpha1.OpenStackServerSpec{
-					Flavor: "foo",
+					Flavor: ptr.To("foo"),
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
@@ -67,7 +67,7 @@ func TestOpenStackServer_ValidateUpdate(t *testing.T) {
 			},
 			new: &infrav1alpha1.OpenStackServer{
 				Spec: infrav1alpha1.OpenStackServerSpec{
-					Flavor: "foo",
+					Flavor: ptr.To("foo"),
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "bar",
@@ -79,12 +79,12 @@ func TestOpenStackServer_ValidateUpdate(t *testing.T) {
 			name: "don't allow modification, dry run, no skip immutability annotation set",
 			old: &infrav1alpha1.OpenStackServer{
 				Spec: infrav1alpha1.OpenStackServerSpec{
-					Flavor: "foo",
+					Flavor: ptr.To("foo"),
 				},
 			},
 			new: &infrav1alpha1.OpenStackServer{
 				Spec: infrav1alpha1.OpenStackServerSpec{
-					Flavor: "new",
+					Flavor: ptr.To("new"),
 				},
 			},
 			req:     &admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{DryRun: ptr.To(true)}},
@@ -94,7 +94,7 @@ func TestOpenStackServer_ValidateUpdate(t *testing.T) {
 			name: "allow modification, dry run, skip immutability annotation set",
 			old: &infrav1alpha1.OpenStackServer{
 				Spec: infrav1alpha1.OpenStackServerSpec{
-					Flavor: "foo",
+					Flavor: ptr.To("foo"),
 				},
 			},
 			new: &infrav1alpha1.OpenStackServer{
@@ -104,7 +104,7 @@ func TestOpenStackServer_ValidateUpdate(t *testing.T) {
 					},
 				},
 				Spec: infrav1alpha1.OpenStackServerSpec{
-					Flavor: "new",
+					Flavor: ptr.To("new"),
 				},
 			},
 			req: &admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{DryRun: ptr.To(true)}},

--- a/test/e2e/shared/openstack.go
+++ b/test/e2e/shared/openstack.go
@@ -880,7 +880,11 @@ func GetOpenStackVolume(e2eCtx *E2EContext, name string) (*volumes.Volume, error
 	return volume, nil
 }
 
-func GetFlavorFromName(e2eCtx *E2EContext, name string) (*flavors.Flavor, error) {
+func GetFlavorFromName(e2eCtx *E2EContext, name *string) (*flavors.Flavor, error) {
+	if name == nil {
+		return nil, fmt.Errorf("flavor name not set")
+	}
+
 	providerClient, clientOpts, _, err := GetTenantProviderClient(e2eCtx)
 	if err != nil {
 		_, _ = fmt.Fprintf(GinkgoWriter, "error creating provider client: %s\n", err)
@@ -890,7 +894,7 @@ func GetFlavorFromName(e2eCtx *E2EContext, name string) (*flavors.Flavor, error)
 	computeClient, err := openstack.NewComputeV2(providerClient, gophercloud.EndpointOpts{Region: clientOpts.RegionName})
 	Expect(err).NotTo(HaveOccurred())
 
-	flavorID, err := uflavors.IDFromName(context.TODO(), computeClient, name)
+	flavorID, err := uflavors.IDFromName(context.TODO(), computeClient, *name)
 	Expect(err).NotTo(HaveOccurred())
 
 	return flavors.Get(context.TODO(), computeClient, flavorID).Extract()

--- a/test/e2e/suites/apivalidations/filters_test.go
+++ b/test/e2e/suites/apivalidations/filters_test.go
@@ -38,7 +38,8 @@ var _ = Describe("Filter API validations", func() {
 		// Initialise a basic machine object in the correct namespace
 		machine = &infrav1.OpenStackMachine{
 			Spec: infrav1.OpenStackMachineSpec{
-				Image: infrav1.ImageParam{Filter: &infrav1.ImageFilter{Name: ptr.To("test-image")}},
+				Flavor: ptr.To("flavor-name"),
+				Image:  infrav1.ImageParam{Filter: &infrav1.ImageFilter{Name: ptr.To("test-image")}},
 			},
 		}
 		machine.Namespace = namespace.Name

--- a/test/e2e/suites/apivalidations/openstackcluster_test.go
+++ b/test/e2e/suites/apivalidations/openstackcluster_test.go
@@ -99,6 +99,7 @@ var _ = Describe("OpenStackCluster API validations", func() {
 			cluster.Spec.Bastion = &infrav1.Bastion{
 				Enabled: ptr.To(true),
 				Spec: &infrav1.OpenStackMachineSpec{
+					Flavor: ptr.To("flavor-name"),
 					Image: infrav1.ImageParam{
 						Filter: &infrav1.ImageFilter{
 							Name: ptr.To("fake-image"),
@@ -124,6 +125,7 @@ var _ = Describe("OpenStackCluster API validations", func() {
 		It("should default bastion.enabled=true", func() {
 			cluster.Spec.Bastion = &infrav1.Bastion{
 				Spec: &infrav1.OpenStackMachineSpec{
+					Flavor: ptr.To("flavor-name"),
 					Image: infrav1.ImageParam{
 						Filter: &infrav1.ImageFilter{
 							Name: ptr.To("fake-image"),
@@ -144,6 +146,7 @@ var _ = Describe("OpenStackCluster API validations", func() {
 			cluster.Spec.Bastion = &infrav1.Bastion{
 				Enabled: ptr.To(true),
 				Spec: &infrav1.OpenStackMachineSpec{
+					Flavor: ptr.To("flavor-name"),
 					Image: infrav1.ImageParam{
 						Filter: &infrav1.ImageFilter{
 							Name: ptr.To("fake-image"),
@@ -158,6 +161,7 @@ var _ = Describe("OpenStackCluster API validations", func() {
 		It("should not allow non-IPv4 as bastion floating IP", func() {
 			cluster.Spec.Bastion = &infrav1.Bastion{
 				Spec: &infrav1.OpenStackMachineSpec{
+					Flavor: ptr.To("flavor-name"),
 					Image: infrav1.ImageParam{
 						Filter: &infrav1.ImageFilter{
 							Name: ptr.To("fake-image"),

--- a/test/e2e/suites/apivalidations/openstackmachine_test.go
+++ b/test/e2e/suites/apivalidations/openstackmachine_test.go
@@ -38,7 +38,8 @@ var _ = Describe("OpenStackMachine API validations", func() {
 		// Initialise a basic machine object in the correct namespace
 		machine := &infrav1.OpenStackMachine{
 			Spec: infrav1.OpenStackMachineSpec{
-				Image: infrav1.ImageParam{Filter: &infrav1.ImageFilter{Name: ptr.To("test-image")}},
+				Image:  infrav1.ImageParam{Filter: &infrav1.ImageFilter{Name: ptr.To("test-image")}},
+				Flavor: ptr.To("flavor-name"),
 			},
 		}
 		machine.Namespace = namespace.Name
@@ -130,6 +131,20 @@ var _ = Describe("OpenStackMachine API validations", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, machine)).To(Succeed(), "Creating a machine with max metadata key and value should succeed")
+	})
+
+	Context("flavors", func() {
+		It("should require either a flavor or flavorID", func() {
+			machine := defaultMachine()
+
+			By("Creating a machine with no flavor or flavor id")
+			machine.Spec.Flavor = nil
+			Expect(k8sClient.Create(ctx, machine)).NotTo(Succeed(), "Creating a machine with no flavor name or id should fail")
+
+			By("Creating a machine with a flavor id")
+			machine.Spec.FlavorID = ptr.To("6aa02f56-c595-4d2f-9f8e-3c6296a4bed9")
+			Expect(k8sClient.Create(ctx, machine)).To(Succeed(), "Creating a machine with a flavor id should succeed")
+		})
 	})
 
 	Context("volumes", func() {
@@ -516,6 +531,7 @@ var _ = Describe("OpenStackMachine API validations", func() {
 				Name:      "test-credentials",
 			}
 			infrav1Machine.Spec.Image.ID = ptr.To("de9872ee-0c2c-44ed-9414-90163c8b0e0d")
+			infrav1Machine.Spec.Flavor = ptr.To("flavor-name")
 			Expect(createObj(infrav1Machine)).To(Succeed(), "infrav1 OpenStackMachine creation should succeed")
 
 			// Just fetching the object as v1alpha7 doesn't trigger

--- a/test/e2e/suites/apivalidations/openstackserver_test.go
+++ b/test/e2e/suites/apivalidations/openstackserver_test.go
@@ -35,7 +35,7 @@ var _ = Describe("OpenStackServer API validations", func() {
 		// Initialise a basic server object in the correct namespace
 		server := &infrav1alpha1.OpenStackServer{
 			Spec: infrav1alpha1.OpenStackServerSpec{
-				Flavor: "test-flavor",
+				Flavor: ptr.To("test-flavor"),
 				IdentityRef: infrav1.OpenStackIdentityReference{
 					Name:      "test-identity",
 					CloudName: "test-cloud",
@@ -108,6 +108,20 @@ var _ = Describe("OpenStackServer API validations", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, server)).To(Succeed(), "Creating a server with max metadata key and value should succeed")
+	})
+
+	Context("flavors", func() {
+		It("should require either a flavor or flavorID", func() {
+			server := defaultServer()
+
+			By("Creating a server with no flavor or flavor id")
+			server.Spec.Flavor = nil
+			Expect(k8sClient.Create(ctx, server)).NotTo(Succeed(), "Creating a server with no flavor name or id should fail")
+
+			By("Creating a server with a flavor id")
+			server.Spec.FlavorID = ptr.To("6aa02f56-c595-4d2f-9f8e-3c6296a4bed9")
+			Expect(k8sClient.Create(ctx, server)).To(Succeed(), "Creating a server with a flavor id should succeed")
+		})
 	})
 
 	Context("volumes", func() {

--- a/test/e2e/suites/e2e/e2e_test.go
+++ b/test/e2e/suites/e2e/e2e_test.go
@@ -275,7 +275,7 @@ var _ = Describe("e2e tests [PR-Blocking]", func() {
 			).Should(BeTrue())
 
 			shared.Logf("Create the bastion with a new flavor")
-			bastionNewFlavorName := e2eCtx.E2EConfig.GetVariable(shared.OpenStackBastionFlavorAlt)
+			bastionNewFlavorName := ptr.To(e2eCtx.E2EConfig.GetVariable(shared.OpenStackBastionFlavorAlt))
 			bastionNewFlavor, err := shared.GetFlavorFromName(e2eCtx, bastionNewFlavorName)
 			Expect(err).NotTo(HaveOccurred())
 			openStackCluster, err = shared.ClusterForSpec(ctx, e2eCtx, namespace)
@@ -1081,7 +1081,7 @@ func makeOpenStackMachineTemplate(namespace, clusterName, name string) *infrav1.
 		Spec: infrav1.OpenStackMachineTemplateSpec{
 			Template: infrav1.OpenStackMachineTemplateResource{
 				Spec: infrav1.OpenStackMachineSpec{
-					Flavor: e2eCtx.E2EConfig.GetVariable(shared.OpenStackNodeMachineFlavor),
+					Flavor: ptr.To(e2eCtx.E2EConfig.GetVariable(shared.OpenStackNodeMachineFlavor)),
 					Image: infrav1.ImageParam{
 						Filter: &infrav1.ImageFilter{
 							Name: ptr.To(e2eCtx.E2EConfig.GetVariable(shared.OpenStackImageName)),
@@ -1107,7 +1107,7 @@ func makeOpenStackMachineTemplateWithPortOptions(namespace, clusterName, name st
 		Spec: infrav1.OpenStackMachineTemplateSpec{
 			Template: infrav1.OpenStackMachineTemplateResource{
 				Spec: infrav1.OpenStackMachineSpec{
-					Flavor: e2eCtx.E2EConfig.GetVariable(shared.OpenStackNodeMachineFlavor),
+					Flavor: ptr.To(e2eCtx.E2EConfig.GetVariable(shared.OpenStackNodeMachineFlavor)),
 					Image: infrav1.ImageParam{
 						Filter: &infrav1.ImageFilter{
 							Name: ptr.To(e2eCtx.E2EConfig.GetVariable(shared.OpenStackImageName)),


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

If I have a system that uses flavor IDs, beacuse it's unambiguous, I then need to translate it into a flavor name before passing it to CAPO that will then translate it back into an ID using a list API call. Check whether the "name" looks like a UUID, and use it directly for the flavor lookup if you can.  Ideally, we'd make API changes like how images are handled, where you can be explicit about it, but I guess all OpenStack clients do this anyway!

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

As per usual, this is just a feeler to get feedback for whether my approach, simple and naive as it is, is going to fly!

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
