### PR TITLE
test: bump Flatcar Stable version

### DIFF
--- a/hack/ci/cloud-init/controller.yaml.tpl
+++ b/hack/ci/cloud-init/controller.yaml.tpl
@@ -70,7 +70,7 @@
     IMAGE_URLS+="https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/cirros/2022-12-05/cirros-0.6.1-x86_64-disk.img,"
     IMAGE_URLS+="https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/ubuntu/2024-05-28/ubuntu-2204-kube-v1.29.5.img,"
     IMAGE_URLS+="https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/ubuntu/2024-05-28/ubuntu-2204-kube-v1.30.1.img,"
-    IMAGE_URLS+="https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/flatcar/flatcar-stable-3815.2.2-kube-v1.30.1.img,"
+    IMAGE_URLS+="https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/flatcar/flatcar-stable-3975.2.0-kube-v1.30.1.img,"
     IMAGE_URLS+="https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_openstack_image.img"
 
     [[post-config|$NOVA_CONF]]

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -187,7 +187,7 @@ variables:
   SSH_USER_MACHINE: "ubuntu"
   EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION: "true"
   # The Flatcar image produced by the image-builder
-  OPENSTACK_FLATCAR_IMAGE_NAME: "flatcar-stable-3815.2.2-kube-v1.30.1"
+  OPENSTACK_FLATCAR_IMAGE_NAME: "flatcar-stable-3975.2.0-kube-v1.30.1"
   # A plain Flatcar from the Flatcar releases server
   FLATCAR_IMAGE_NAME: "flatcar_production_openstack_image"
 


### PR DESCRIPTION
**What this PR does / why we need it**: When there is a new Flatcar Stable major release, we update the tested image on CAPO. (https://github.com/flatcar/Flatcar/issues/1509)

**Special notes for your reviewer**: 
* As usual, a CAPO maintainer will need to upload the image (https://wfwfg.s3.pl-waw.scw.cloud/flatcar-stable-3975.2.0-kube-v1.30.1.img) on CAPO GCS Bucket :ballot_box_with_check: 
* Image built with: `sudo podman run -it --privileged -v "${PWD}/docker-output:/output" -v /dev:/dev --net host --rm -e PACKER_LOG=1 -e OEM_ID=openstack -e PACKER_FLAGS="--var 'kubernetes_semver=v1.30.1' --var 'kubernetes_series=v1.30'" image-builder build-qemu-flatcar`
* `flatcar-sysext` test is already using the latest Flatcar version by default - no need to update. 

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
