### PR TITLE
🐛 port: don't add any SGs when port security is disabled

### DIFF
--- a/pkg/webhooks/openstackmachine_webhook.go
+++ b/pkg/webhooks/openstackmachine_webhook.go
@@ -24,6 +24,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -59,6 +60,12 @@ func (*openStackMachineWebhook) ValidateCreate(_ context.Context, objRaw runtime
 			if device.Name == "root" {
 				allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "additionalBlockDevices"), "cannot contain a device named \"root\" when rootVolume is set"))
 			}
+		}
+	}
+
+	for _, port := range newObj.Spec.Ports {
+		if ptr.Deref(port.DisablePortSecurity, false) && len(port.SecurityGroups) > 0 {
+			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "ports"), "cannot have security groups when DisablePortSecurity is set to true"))
 		}
 	}
 

--- a/pkg/webhooks/openstackserver_webhook.go
+++ b/pkg/webhooks/openstackserver_webhook.go
@@ -24,6 +24,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api/util/topology"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -61,6 +62,12 @@ func (*openStackServerWebhook) ValidateCreate(_ context.Context, objRaw runtime.
 			if device.Name == "root" {
 				allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "additionalBlockDevices"), "cannot contain a device named \"root\" when rootVolume is set"))
 			}
+		}
+	}
+
+	for _, port := range newObj.Spec.Ports {
+		if ptr.Deref(port.DisablePortSecurity, false) && len(port.SecurityGroups) > 0 {
+			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "ports"), "cannot have security groups when DisablePortSecurity is set to true"))
 		}
 	}
 

--- a/test/e2e/suites/apivalidations/openstackmachine_test.go
+++ b/test/e2e/suites/apivalidations/openstackmachine_test.go
@@ -172,6 +172,23 @@ var _ = Describe("OpenStackMachine API validations", func() {
 			Expect(k8sClient.Create(ctx, machine)).NotTo(Succeed(), "OpenStackMachine creation with root device name in spec.AdditionalBlockDevices should not succeed")
 		})
 
+		It("should not allow to create machine with both SecurityGroups and DisablePortSecurity", func() {
+			machine := defaultMachine()
+			machine.Spec.Ports = []infrav1.PortOpts{
+				{
+					SecurityGroups: []infrav1.SecurityGroupParam{{
+						Filter: &infrav1.SecurityGroupFilter{Name: "test-security-group"},
+					}},
+					ResolvedPortSpecFields: infrav1.ResolvedPortSpecFields{
+						DisablePortSecurity: ptr.To(true),
+					},
+				},
+			}
+
+			By("Creating a machine with both SecurityGroups and DisablePortSecurity")
+			Expect(k8sClient.Create(ctx, machine)).NotTo(Succeed(), "OpenStackMachine creation with both SecurityGroups and DisablePortSecurity should not succeed")
+		})
+
 		/* FIXME: These tests are failing
 		It("should not allow additional volume with empty name", func() {
 			machine.Spec.AdditionalBlockDevices = []infrav1.AdditionalBlockDevice{

--- a/test/e2e/suites/apivalidations/openstackserver_test.go
+++ b/test/e2e/suites/apivalidations/openstackserver_test.go
@@ -150,6 +150,23 @@ var _ = Describe("OpenStackServer API validations", func() {
 			Expect(k8sClient.Create(ctx, server)).NotTo(Succeed(), "OpenStackserver creation with root device name in spec.AdditionalBlockDevices should not succeed")
 		})
 
+		It("should not allow to create server with both SecurityGroups and DisablePortSecurity", func() {
+			server := defaultServer()
+			server.Spec.Ports = []infrav1.PortOpts{
+				{
+					SecurityGroups: []infrav1.SecurityGroupParam{{
+						Filter: &infrav1.SecurityGroupFilter{Name: "test-security-group"},
+					}},
+					ResolvedPortSpecFields: infrav1.ResolvedPortSpecFields{
+						DisablePortSecurity: ptr.To(true),
+					},
+				},
+			}
+
+			By("Creating a server with both SecurityGroups and DisablePortSecurity")
+			Expect(k8sClient.Create(ctx, server)).NotTo(Succeed(), "OpenStackServer creation with both SecurityGroups and DisablePortSecurity should not succeed")
+		})
+
 		/* FIXME: These tests are failing
 		It("should not allow additional volume with empty name", func() {
 			server.Spec.AdditionalBlockDevices = []infrav1.AdditionalBlockDevice{


### PR DESCRIPTION
**What this PR does / why we need it**:

When port security is disabled on a port, don't add any security group
to the port options.

Skip the security groups when resolving the ports spec.
Report an error when a port tries to be created with both security
groups and disable port security to true.
Adds unit tests coverage for these scenarios.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2158
