### PR TITLE
CI: update OpenStack to 2024.1 (Caracal)

### DIFF
--- a/hack/ci/create_devstack.sh
+++ b/hack/ci/create_devstack.sh
@@ -31,7 +31,7 @@ source "${scriptdir}/${RESOURCE_TYPE}.sh"
 
 CLUSTER_NAME=${CLUSTER_NAME:-"capo-e2e"}
 
-OPENSTACK_RELEASE=${OPENSTACK_RELEASE:-"2023.2"}
+OPENSTACK_RELEASE=${OPENSTACK_RELEASE:-"2024.1"}
 OPENSTACK_ENABLE_HORIZON=${OPENSTACK_ENABLE_HORIZON:-"false"}
 
 # Devstack will create a provider network using this range

--- a/scripts/ci-conformance.sh
+++ b/scripts/ci-conformance.sh
@@ -47,7 +47,7 @@ trap cleanup EXIT
 
 apt-get update -y
 # Install requests module explicitly for HTTP calls.
-# libffi required for pip install cffi (bobcat dependency)
+# libffi required for pip install cffi (caracal dependency)
 apt-get install -y python3-requests libffi-dev
 rm -rf /var/lib/apt/lists/*
 

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -48,7 +48,7 @@ trap cleanup EXIT
 
 apt-get update -y
 # Install requests module explicitly for HTTP calls.
-# libffi required for pip install cffi (bobcat dependency)
+# libffi required for pip install cffi (caracal dependency)
 apt-get install -y python3-requests libffi-dev
 rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Update CI to use the latest stable version of OpenStack: Caracal.
