### PR TITLE
:seedling: Backport #2081 and #2141 to release-0.10

### DIFF
--- a/controllers/openstackmachine_controller_test.go
+++ b/controllers/openstackmachine_controller_test.go
@@ -265,6 +265,7 @@ func Test_reconcileDelete(t *testing.T) {
 		trunkExtension.Alias = "trunk"
 		r.network.ListExtensions().Return([]extensions.Extension{trunkExtension}, nil)
 		r.network.ListTrunk(trunks.ListOpts{PortID: portUUID}).Return([]trunks.Trunk{{ID: trunkUUID}}, nil)
+		r.network.ListTrunkSubports(trunkUUID).Return([]trunks.Subport{}, nil)
 		r.network.DeleteTrunk(trunkUUID).Return(nil)
 		r.network.DeletePort(portUUID).Return(nil)
 	}

--- a/pkg/clients/mock/network.go
+++ b/pkg/clients/mock/network.go
@@ -546,6 +546,21 @@ func (mr *MockNetworkClientMockRecorder) ListTrunk(arg0 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTrunk", reflect.TypeOf((*MockNetworkClient)(nil).ListTrunk), arg0)
 }
 
+// ListTrunkSubports mocks base method.
+func (m *MockNetworkClient) ListTrunkSubports(arg0 string) ([]trunks.Subport, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListTrunkSubports", arg0)
+	ret0, _ := ret[0].([]trunks.Subport)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListTrunkSubports indicates an expected call of ListTrunkSubports.
+func (mr *MockNetworkClientMockRecorder) ListTrunkSubports(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTrunkSubports", reflect.TypeOf((*MockNetworkClient)(nil).ListTrunkSubports), arg0)
+}
+
 // RemoveRouterInterface mocks base method.
 func (m *MockNetworkClient) RemoveRouterInterface(arg0 string, arg1 routers.RemoveInterfaceOptsBuilder) (*routers.InterfaceInfo, error) {
 	m.ctrl.T.Helper()
@@ -559,6 +574,20 @@ func (m *MockNetworkClient) RemoveRouterInterface(arg0 string, arg1 routers.Remo
 func (mr *MockNetworkClientMockRecorder) RemoveRouterInterface(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveRouterInterface", reflect.TypeOf((*MockNetworkClient)(nil).RemoveRouterInterface), arg0, arg1)
+}
+
+// RemoveSubports mocks base method.
+func (m *MockNetworkClient) RemoveSubports(arg0 string, arg1 trunks.RemoveSubportsOpts) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveSubports", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveSubports indicates an expected call of RemoveSubports.
+func (mr *MockNetworkClientMockRecorder) RemoveSubports(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveSubports", reflect.TypeOf((*MockNetworkClient)(nil).RemoveSubports), arg0, arg1)
 }
 
 // ReplaceAllAttributesTags mocks base method.

--- a/pkg/clients/networking.go
+++ b/pkg/clients/networking.go
@@ -53,6 +53,9 @@ type NetworkClient interface {
 	CreateTrunk(opts trunks.CreateOptsBuilder) (*trunks.Trunk, error)
 	DeleteTrunk(id string) error
 
+	ListTrunkSubports(trunkID string) ([]trunks.Subport, error)
+	RemoveSubports(id string, opts trunks.RemoveSubportsOpts) error
+
 	ListRouter(opts routers.ListOpts) ([]routers.Router, error)
 	CreateRouter(opts routers.CreateOptsBuilder) (*routers.Router, error)
 	DeleteRouter(id string) error
@@ -236,6 +239,24 @@ func (c networkClient) CreateTrunk(opts trunks.CreateOptsBuilder) (*trunks.Trunk
 func (c networkClient) DeleteTrunk(id string) error {
 	mc := metrics.NewMetricPrometheusContext("trunk", "delete")
 	return mc.ObserveRequestIgnoreNotFound(trunks.Delete(c.serviceClient, id).ExtractErr())
+}
+
+func (c networkClient) ListTrunkSubports(trunkID string) ([]trunks.Subport, error) {
+	mc := metrics.NewMetricPrometheusContext("trunk", "listsubports")
+	subports, err := trunks.GetSubports(c.serviceClient, trunkID).Extract()
+	if mc.ObserveRequest(err) != nil {
+		return nil, err
+	}
+	return subports, nil
+}
+
+func (c networkClient) RemoveSubports(id string, opts trunks.RemoveSubportsOpts) error {
+	mc := metrics.NewMetricPrometheusContext("trunk", "deletesubports")
+	_, err := trunks.RemoveSubports(c.serviceClient, id, opts).Extract()
+	if mc.ObserveRequest(err) != nil {
+		return err
+	}
+	return nil
 }
 
 func (c networkClient) ListTrunk(opts trunks.ListOptsBuilder) ([]trunks.Trunk, error) {

--- a/pkg/cloud/services/networking/trunk.go
+++ b/pkg/cloud/services/networking/trunk.go
@@ -31,8 +31,9 @@ import (
 )
 
 const (
-	timeoutTrunkDelete       = 3 * time.Minute
-	retryIntervalTrunkDelete = 5 * time.Second
+	timeoutTrunkDelete         = 3 * time.Minute
+	retryIntervalTrunkDelete   = 5 * time.Second
+	retryIntervalSubportDelete = 30 * time.Second
 )
 
 func (s *Service) GetTrunkSupport() (bool, error) {
@@ -77,6 +78,42 @@ func (s *Service) getOrCreateTrunkForPort(eventObject runtime.Object, port *port
 	return trunk, nil
 }
 
+func (s *Service) RemoveTrunkSubports(trunkID string) error {
+	subports, err := s.client.ListTrunkSubports(trunkID)
+	if err != nil {
+		return err
+	}
+
+	if len(subports) == 0 {
+		return nil
+	}
+
+	portList := make([]trunks.RemoveSubport, len(subports))
+	for i, subport := range subports {
+		portList[i] = trunks.RemoveSubport{
+			PortID: subport.PortID,
+		}
+	}
+
+	removeSubportsOpts := trunks.RemoveSubportsOpts{
+		Subports: portList,
+	}
+
+	err = s.client.RemoveSubports(trunkID, removeSubportsOpts)
+	if err != nil {
+		return err
+	}
+
+	for _, subPort := range subports {
+		err := s.client.DeletePort(subPort.PortID)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (s *Service) DeleteTrunk(eventObject runtime.Object, portID string) error {
 	listOpts := trunks.ListOpts{
 		PortID: portID,
@@ -88,6 +125,22 @@ func (s *Service) DeleteTrunk(eventObject runtime.Object, portID string) error {
 	if len(trunkInfo) != 1 {
 		return nil
 	}
+	// Delete sub-ports if trunk is associated with sub-ports
+	err = wait.PollUntilContextTimeout(context.TODO(), retryIntervalSubportDelete, timeoutTrunkDelete, true, func(_ context.Context) (bool, error) {
+		if err := s.RemoveTrunkSubports(trunkInfo[0].ID); err != nil {
+			if capoerrors.IsNotFound(err) || capoerrors.IsConflict(err) || capoerrors.IsRetryable(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+	if err != nil {
+		record.Warnf(eventObject, "FailedRemoveTrunkSubports", "Failed to delete sub ports trunk %s with id %s: %v", trunkInfo[0].Name, trunkInfo[0].ID, err)
+		return err
+	}
+
+	record.Eventf(eventObject, "SuccessfulRemoveTrunkSubports", "Removed trunk sub ports %s with id %s", trunkInfo[0].Name, trunkInfo[0].ID)
 
 	err = wait.PollUntilContextTimeout(context.TODO(), retryIntervalTrunkDelete, timeoutTrunkDelete, true, func(_ context.Context) (bool, error) {
 		if err := s.client.DeleteTrunk(trunkInfo[0].ID); err != nil {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR backports https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/2081 and https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/2141 into release-0.10

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
