### PR TITLE
openstackserver: create before delete if adoption fields are empty

### DIFF
--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -309,16 +309,6 @@ func (r *OpenStackClusterReconciler) reconcileNormal(ctx context.Context, scope 
 		return reconcile.Result{}, err
 	}
 
-	// TODO(emilien) we should do that separately but the reconcileBastion
-	// should happen after the cluster Ready is true
-	result, err := r.reconcileBastion(ctx, scope, cluster, openStackCluster)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-	if result != nil {
-		return *result, nil
-	}
-
 	availabilityZones, err := computeService.GetAvailabilityZones()
 	if err != nil {
 		return ctrl.Result{}, err
@@ -343,6 +333,16 @@ func (r *OpenStackClusterReconciler) reconcileNormal(ctx context.Context, scope 
 	openStackCluster.Status.FailureMessage = nil
 	openStackCluster.Status.FailureReason = nil
 	scope.Logger().Info("Reconciled Cluster created successfully")
+
+	result, err := r.reconcileBastion(ctx, scope, cluster, openStackCluster)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if result != nil {
+		return *result, nil
+	}
+	scope.Logger().Info("Reconciled Bastion created successfully")
+
 	return reconcile.Result{}, nil
 }
 

--- a/controllers/openstackserver_controller.go
+++ b/controllers/openstackserver_controller.go
@@ -127,6 +127,14 @@ func (r *OpenStackServerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}()
 
 	if !openStackServer.ObjectMeta.DeletionTimestamp.IsZero() {
+		// When moving a cluster, we need to populate the server status with the resources
+		// that were in another object's status.
+		// This is because the status is not persisted across CAPI resources moves.
+		if openStackServer.Status.Resolved == nil || openStackServer.Status.Resources == nil {
+			if _, err := r.reconcileNormal(ctx, scope, openStackServer); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
 		return reconcile.Result{}, r.reconcileDelete(scope, openStackServer)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

To handle cluster move, we now do two things:

* Re-populate OpenStackServer.Status fields before a server is deleted, otherwise the Status is empty and we don't know what resources need cleanup (server ID, port ID, etc).
* Mark the Cluster as Ready as early as possible, even before the bastion is not ready yet. The bastion isn't a CAPI-managed type of resource, so it's ok to mark the cluster ready when the bastion is not. We have a reconciler to make sure the bastion exists (or not) right after. This helps when a cluster is moved.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2155

/hold
