### PR TITLE
:book: docs/configuration: fix security groups example

### DIFF
--- a/docs/book/src/clusteropenstack/configuration.md
+++ b/docs/book/src/clusteropenstack/configuration.md
@@ -598,7 +598,8 @@ spec:
   template:
     spec:
       securityGroups:
-      - name: allow-ssh
+      - filter:
+          name: allow-ssh
 ```
 
 ## Tagging


### PR DESCRIPTION
**What this PR does / why we need it**: it now uses a filter to get the security group by name

**TODOs**:

- [x] squashed commits
- if necessary:
  - [x] includes documentation
  - [ ] adds unit tests

/hold
