### PR TITLE
⚠️ Convert APIServerPort to uint16

### DIFF
--- a/api/v1alpha6/zz_generated.conversion.go
+++ b/api/v1alpha6/zz_generated.conversion.go
@@ -756,9 +756,7 @@ func autoConvert_v1alpha6_OpenStackClusterSpec_To_v1beta1_OpenStackClusterSpec(i
 	if err := optional.Convert_string_To_optional_String(&in.APIServerFixedIP, &out.APIServerFixedIP, s); err != nil {
 		return err
 	}
-	if err := optional.Convert_int_To_optional_Int(&in.APIServerPort, &out.APIServerPort, s); err != nil {
-		return err
-	}
+	// WARNING: in.APIServerPort requires manual conversion: inconvertible types (int vs sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/optional.UInt16)
 	// WARNING: in.ManagedSecurityGroups requires manual conversion: inconvertible types (bool vs *sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1.ManagedSecurityGroups)
 	// WARNING: in.AllowAllInClusterTraffic requires manual conversion: does not exist in peer-type
 	if err := optional.Convert_bool_To_optional_Bool(&in.DisablePortSecurity, &out.DisablePortSecurity, s); err != nil {
@@ -812,9 +810,7 @@ func autoConvert_v1beta1_OpenStackClusterSpec_To_v1alpha6_OpenStackClusterSpec(i
 	if err := optional.Convert_optional_String_To_string(&in.APIServerFixedIP, &out.APIServerFixedIP, s); err != nil {
 		return err
 	}
-	if err := optional.Convert_optional_Int_To_int(&in.APIServerPort, &out.APIServerPort, s); err != nil {
-		return err
-	}
+	// WARNING: in.APIServerPort requires manual conversion: inconvertible types (sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/optional.UInt16 vs int)
 	// WARNING: in.ManagedSecurityGroups requires manual conversion: inconvertible types (*sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1.ManagedSecurityGroups vs bool)
 	if err := optional.Convert_optional_Bool_To_bool(&in.DisablePortSecurity, &out.DisablePortSecurity, s); err != nil {
 		return err

--- a/api/v1alpha7/openstackcluster_conversion.go
+++ b/api/v1alpha7/openstackcluster_conversion.go
@@ -17,9 +17,11 @@ limitations under the License.
 package v1alpha7
 
 import (
+	"math"
 	"reflect"
 
 	apiconversion "k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrlconversion "sigs.k8s.io/controller-runtime/pkg/conversion"
 
@@ -168,6 +170,11 @@ func restorev1alpha7ClusterSpec(previous *OpenStackClusterSpec, dst *OpenStackCl
 	}
 
 	restorev1alpha7NetworkFilter(&previous.Network, &dst.Network)
+
+	// APIServerPort is not uint16
+	if previous.APIServerPort > math.MaxUint16 {
+		dst.APIServerPort = previous.APIServerPort
+	}
 }
 
 func restorev1beta1ClusterSpec(previous *infrav1.OpenStackClusterSpec, dst *infrav1.OpenStackClusterSpec) {
@@ -238,7 +245,7 @@ func restorev1beta1ClusterSpec(previous *infrav1.OpenStackClusterSpec, dst *infr
 
 	optional.RestoreString(&previous.APIServerFloatingIP, &dst.APIServerFloatingIP)
 	optional.RestoreString(&previous.APIServerFixedIP, &dst.APIServerFixedIP)
-	optional.RestoreInt(&previous.APIServerPort, &dst.APIServerPort)
+	optional.RestoreUInt16(&previous.APIServerPort, &dst.APIServerPort)
 	optional.RestoreBool(&previous.DisableAPIServerFloatingIP, &dst.DisableAPIServerFloatingIP)
 	optional.RestoreBool(&previous.ControlPlaneOmitAvailabilityZone, &dst.ControlPlaneOmitAvailabilityZone)
 	optional.RestoreBool(&previous.DisablePortSecurity, &dst.DisablePortSecurity)
@@ -310,6 +317,10 @@ func Convert_v1alpha7_OpenStackClusterSpec_To_v1beta1_OpenStackClusterSpec(in *O
 		out.APIServerLoadBalancer = apiServerLoadBalancer
 	}
 
+	if in.APIServerPort > 0 && in.APIServerPort < math.MaxUint16 {
+		out.APIServerPort = ptr.To(uint16(in.APIServerPort)) //nolint:gosec
+	}
+
 	return nil
 }
 
@@ -372,6 +383,8 @@ func Convert_v1beta1_OpenStackClusterSpec_To_v1alpha7_OpenStackClusterSpec(in *i
 			return err
 		}
 	}
+
+	out.APIServerPort = int(ptr.Deref(in.APIServerPort, 0))
 
 	return nil
 }

--- a/api/v1alpha7/zz_generated.conversion.go
+++ b/api/v1alpha7/zz_generated.conversion.go
@@ -989,9 +989,7 @@ func autoConvert_v1alpha7_OpenStackClusterSpec_To_v1beta1_OpenStackClusterSpec(i
 	if err := optional.Convert_string_To_optional_String(&in.APIServerFixedIP, &out.APIServerFixedIP, s); err != nil {
 		return err
 	}
-	if err := optional.Convert_int_To_optional_Int(&in.APIServerPort, &out.APIServerPort, s); err != nil {
-		return err
-	}
+	// WARNING: in.APIServerPort requires manual conversion: inconvertible types (int vs sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/optional.UInt16)
 	// WARNING: in.ManagedSecurityGroups requires manual conversion: inconvertible types (bool vs *sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1.ManagedSecurityGroups)
 	// WARNING: in.AllowAllInClusterTraffic requires manual conversion: does not exist in peer-type
 	if err := optional.Convert_bool_To_optional_Bool(&in.DisablePortSecurity, &out.DisablePortSecurity, s); err != nil {
@@ -1055,9 +1053,7 @@ func autoConvert_v1beta1_OpenStackClusterSpec_To_v1alpha7_OpenStackClusterSpec(i
 	if err := optional.Convert_optional_String_To_string(&in.APIServerFixedIP, &out.APIServerFixedIP, s); err != nil {
 		return err
 	}
-	if err := optional.Convert_optional_Int_To_int(&in.APIServerPort, &out.APIServerPort, s); err != nil {
-		return err
-	}
+	// WARNING: in.APIServerPort requires manual conversion: inconvertible types (sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/optional.UInt16 vs int)
 	// WARNING: in.ManagedSecurityGroups requires manual conversion: inconvertible types (*sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1.ManagedSecurityGroups vs bool)
 	if err := optional.Convert_optional_Bool_To_bool(&in.DisablePortSecurity, &out.DisablePortSecurity, s); err != nil {
 		return err

--- a/api/v1beta1/openstackcluster_types.go
+++ b/api/v1beta1/openstackcluster_types.go
@@ -133,9 +133,9 @@ type OpenStackClusterSpec struct {
 	APIServerFixedIP optional.String `json:"apiServerFixedIP,omitempty"`
 
 	// APIServerPort is the port on which the listener on the APIServer
-	// will be created
+	// will be created. If specified, it must be an integer between 0 and 65535.
 	// +optional
-	APIServerPort optional.Int `json:"apiServerPort,omitempty"`
+	APIServerPort optional.UInt16 `json:"apiServerPort,omitempty"`
 
 	// ManagedSecurityGroups determines whether OpenStack security groups for the cluster
 	// will be managed by the OpenStack provider or whether pre-existing security groups will

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -677,7 +677,7 @@ func (in *OpenStackClusterSpec) DeepCopyInto(out *OpenStackClusterSpec) {
 	}
 	if in.APIServerPort != nil {
 		in, out := &in.APIServerPort, &out.APIServerPort
-		*out = new(int)
+		*out = new(uint16)
 		**out = **in
 	}
 	if in.ManagedSecurityGroups != nil {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -3310,7 +3310,9 @@ spec:
               apiServerPort:
                 description: |-
                   APIServerPort is the port on which the listener on the APIServer
-                  will be created
+                  will be created. If specified, it must be an integer between 0 and 65535.
+                maximum: 65535
+                minimum: 0
                 type: integer
               bastion:
                 description: |-

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
@@ -1792,7 +1792,9 @@ spec:
                       apiServerPort:
                         description: |-
                           APIServerPort is the port on which the listener on the APIServer
-                          will be created
+                          will be created. If specified, it must be an integer between 0 and 65535.
+                        maximum: 65535
+                        minimum: 0
                         type: integer
                       bastion:
                         description: |-

--- a/controllers/openstackcluster_controller_test.go
+++ b/controllers/openstackcluster_controller_test.go
@@ -490,7 +490,7 @@ func Test_getAPIServerPort(t *testing.T) {
 			name: "with API server port",
 			openStackCluster: &infrav1.OpenStackCluster{
 				Spec: infrav1.OpenStackClusterSpec{
-					APIServerPort: ptr.To(6445),
+					APIServerPort: ptr.To(uint16(6445)),
 				},
 			},
 			want: 6445,
@@ -498,7 +498,7 @@ func Test_getAPIServerPort(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got, _ := getAPIServerPort(tt.openStackCluster); got != tt.want {
+			if got := getAPIServerPort(tt.openStackCluster); got != tt.want {
 				t.Errorf("getAPIServerPort() = %v, want %v", got, tt.want)
 			}
 		})

--- a/docs/book/src/api/v1beta1/api.md
+++ b/docs/book/src/api/v1beta1/api.md
@@ -273,13 +273,13 @@ holds the fixed IP to be used as a VIP.</p>
 <td>
 <code>apiServerPort</code><br/>
 <em>
-int
+uint16
 </em>
 </td>
 <td>
 <em>(Optional)</em>
 <p>APIServerPort is the port on which the listener on the APIServer
-will be created</p>
+will be created. If specified, it must be an integer between 0 and 65535.</p>
 </td>
 </tr>
 <tr>
@@ -2378,13 +2378,13 @@ holds the fixed IP to be used as a VIP.</p>
 <td>
 <code>apiServerPort</code><br/>
 <em>
-int
+uint16
 </em>
 </td>
 <td>
 <em>(Optional)</em>
 <p>APIServerPort is the port on which the listener on the APIServer
-will be created</p>
+will be created. If specified, it must be an integer between 0 and 65535.</p>
 </td>
 </tr>
 <tr>
@@ -2960,13 +2960,13 @@ holds the fixed IP to be used as a VIP.</p>
 <td>
 <code>apiServerPort</code><br/>
 <em>
-int
+uint16
 </em>
 </td>
 <td>
 <em>(Optional)</em>
 <p>APIServerPort is the port on which the listener on the APIServer
-will be created</p>
+will be created. If specified, it must be an integer between 0 and 65535.</p>
 </td>
 </tr>
 <tr>

--- a/hack/codegen/openapi/zz_generated.openapi.go
+++ b/hack/codegen/openapi/zz_generated.openapi.go
@@ -22824,7 +22824,7 @@ func schema_sigsk8sio_cluster_api_provider_openstack_api_v1beta1_OpenStackCluste
 					},
 					"apiServerPort": {
 						SchemaProps: spec.SchemaProps{
-							Description: "APIServerPort is the port on which the listener on the APIServer will be created",
+							Description: "APIServerPort is the port on which the listener on the APIServer will be created. If specified, it must be an integer between 0 and 65535.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},

--- a/pkg/generated/applyconfiguration/api/v1beta1/openstackclusterspec.go
+++ b/pkg/generated/applyconfiguration/api/v1beta1/openstackclusterspec.go
@@ -37,7 +37,7 @@ type OpenStackClusterSpecApplyConfiguration struct {
 	DisableAPIServerFloatingIP       *bool                                         `json:"disableAPIServerFloatingIP,omitempty"`
 	APIServerFloatingIP              *string                                       `json:"apiServerFloatingIP,omitempty"`
 	APIServerFixedIP                 *string                                       `json:"apiServerFixedIP,omitempty"`
-	APIServerPort                    *int                                          `json:"apiServerPort,omitempty"`
+	APIServerPort                    *uint16                                       `json:"apiServerPort,omitempty"`
 	ManagedSecurityGroups            *ManagedSecurityGroupsApplyConfiguration      `json:"managedSecurityGroups,omitempty"`
 	DisablePortSecurity              *bool                                         `json:"disablePortSecurity,omitempty"`
 	Tags                             []string                                      `json:"tags,omitempty"`
@@ -168,7 +168,7 @@ func (b *OpenStackClusterSpecApplyConfiguration) WithAPIServerFixedIP(value stri
 // WithAPIServerPort sets the APIServerPort field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the APIServerPort field is set to the value of the last call.
-func (b *OpenStackClusterSpecApplyConfiguration) WithAPIServerPort(value int) *OpenStackClusterSpecApplyConfiguration {
+func (b *OpenStackClusterSpecApplyConfiguration) WithAPIServerPort(value uint16) *OpenStackClusterSpecApplyConfiguration {
 	b.APIServerPort = &value
 	return b
 }

--- a/pkg/utils/optional/conversion.go
+++ b/pkg/utils/optional/conversion.go
@@ -32,6 +32,12 @@ func RestoreInt(previous, dst *Int) {
 	}
 }
 
+func RestoreUInt16(previous, dst *UInt16) {
+	if *dst == nil || **dst == 0 {
+		*dst = *previous
+	}
+}
+
 func RestoreBool(previous, dst *Bool) {
 	if *dst == nil || !**dst {
 		*dst = *previous
@@ -70,6 +76,24 @@ func Convert_int_To_optional_Int(in *int, out *Int, _ conversion.Scope) error {
 }
 
 func Convert_optional_Int_To_int(in *Int, out *int, _ conversion.Scope) error {
+	if *in == nil {
+		*out = 0
+	} else {
+		*out = **in
+	}
+	return nil
+}
+
+func Convert_uint16_To_optional_UInt16(in *uint16, out *UInt16, _ conversion.Scope) error {
+	if *in == 0 {
+		*out = nil
+	} else {
+		*out = in
+	}
+	return nil
+}
+
+func Convert_optional_UInt16_To_uint16(in *UInt16, out *uint16, _ conversion.Scope) error {
 	if *in == nil {
 		*out = 0
 	} else {

--- a/pkg/utils/optional/types.go
+++ b/pkg/utils/optional/types.go
@@ -28,6 +28,14 @@ type String *string
 // +optional.
 type Int *int
 
+// UInt16 is a uint16 that can be unspecified. uint16s which are converted to
+// optional.UInt16 during API conversion will be converted to nil if the value
+// was previously 0.
+// +kubebuilder:validation:Minimum:=0
+// +kubebuilder:validation:Maximum:=65535
+// +optional.
+type UInt16 *uint16
+
 // Bool is a bool that can be unspecified. bools which are converted to
 // optional.Bool during API conversion will be converted to nil if the value
 // was previously false.

--- a/pkg/webhooks/openstackcluster_webhook_test.go
+++ b/pkg/webhooks/openstackcluster_webhook_test.go
@@ -358,7 +358,7 @@ func TestOpenStackCluster_ValidateUpdate(t *testing.T) {
 			newTemplate: &infrav1.OpenStackCluster{
 				Spec: infrav1.OpenStackClusterSpec{
 					DisableAPIServerFloatingIP: ptr.To(true),
-					APIServerPort:              ptr.To(8443),
+					APIServerPort:              ptr.To(uint16(8443)),
 				},
 			},
 			wantErr: false,
@@ -381,7 +381,7 @@ func TestOpenStackCluster_ValidateUpdate(t *testing.T) {
 						CloudName: "foobar",
 					},
 					DisableAPIServerFloatingIP: ptr.To(false),
-					APIServerPort:              ptr.To(8443),
+					APIServerPort:              ptr.To(uint16(8443)),
 				},
 			},
 			wantErr: true,


### PR DESCRIPTION
This problem was highlighted by the updated gosec linter brought in by https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/2173, which pointed out the unsafe conversion from int to int32. CAPI's control plane endpoint port is an int32. We were using int, which can be larger. We also weren't validating it.

APIServerPort is a TCP port, which is an unsigned 16 bit integer. We were
previously allowing it to be any integer.

This is a breaking change, but as any working configuration would have
to have a value which passes the new validation it should not break any
working configuration.