### PR TITLE
🐛 Ensure SSA patch can't accidentally create a new object

### DIFF
--- a/internal/controllers/image/reconcile.go
+++ b/internal/controllers/image/reconcile.go
@@ -232,7 +232,7 @@ func (r *orcImageReconciler) reconcileDelete(ctx context.Context, orcImage *orcv
 	log.V(4).Info("Image is deleted")
 
 	// Clear owned fields on the base resource, including the finalizer
-	applyConfig := orcapplyconfigv1alpha1.Image(orcImage.Name, orcImage.Namespace)
+	applyConfig := orcapplyconfigv1alpha1.Image(orcImage.Name, orcImage.Namespace).WithUID(orcImage.UID)
 	return ctrl.Result{}, r.client.Patch(ctx, orcImage, ssa.ApplyConfigPatch(applyConfig), client.ForceOwnership, client.FieldOwner(orcv1alpha1.ImageControllerFieldOwner))
 }
 

--- a/internal/controllers/image/status.go
+++ b/internal/controllers/image/status.go
@@ -45,7 +45,7 @@ const (
 // updateObject writes to the Image root resource, i.e. everything except status.
 func (r *orcImageReconciler) updateObject(ctx context.Context, orcImage *orcv1alpha1.Image) error {
 	applyConfig := orcapplyconfigv1alpha1.Image(orcImage.Name, orcImage.Namespace).
-		WithFinalizers(orcv1alpha1.ImageControllerFinalizer)
+		WithFinalizers(orcv1alpha1.ImageControllerFinalizer).WithUID(orcImage.UID)
 
 	return r.client.Patch(ctx, orcImage, ssa.ApplyConfigPatch(applyConfig), client.ForceOwnership, client.FieldOwner(orcv1alpha1.ImageControllerFieldOwner))
 }


### PR DESCRIPTION
This fixes a race during image delete where we can get a second reconcile on a deleted object and accidentally create a new object when we only intended to remove the finalizer from the old object. With this change, the second patch will throw an error instead.

/hold
