### PR TITLE
🐛  Fix ServerMetadata Not Applied to Bastion in OpenStackCluster

### DIFF
--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -564,6 +564,12 @@ func bastionToInstanceSpec(openStackCluster *infrav1.OpenStackCluster, cluster *
 	}
 
 	machineSpec := bastion.Spec
+
+	// Create metadata map from ServerMetadata
+	metadata := make(map[string]string)
+	for _, item := range bastion.Spec.ServerMetadata {
+		metadata[item.Key] = item.Value
+	}
 	instanceSpec := &compute.InstanceSpec{
 		Name:          bastionName(cluster.Name),
 		Flavor:        machineSpec.Flavor,
@@ -572,6 +578,7 @@ func bastionToInstanceSpec(openStackCluster *infrav1.OpenStackCluster, cluster *
 		RootVolume:    machineSpec.RootVolume,
 		ServerGroupID: resolved.ServerGroupID,
 		Tags:          compute.InstanceTags(machineSpec, openStackCluster),
+		Metadata:      metadata,
 	}
 	if bastion.AvailabilityZone != nil {
 		instanceSpec.FailureDomain = *bastion.AvailabilityZone


### PR DESCRIPTION
- Fixed issue where spec.bastion.spec.serverMetadata was not set in bastion.
- Updated bastionToInstanceSpec to apply serverMetadata in InstanceSpec.

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Fixes an issue where `spec.bastion.spec.serverMetadata` in `OpenStackCluster` was not applied as `metadata` to OpenStack instances. This change ensures that server metadata is set during bastion creation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2177 

**Special notes for your reviewer**:
1. Please check if any other parts of the repository require updates to serverMetadata outside of this change.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits

/hold
