### PR TITLE
feat(manager): :sparkles: add region to openStackMachineSpec.ProviderID field from annotation

### DIFF
--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -645,7 +645,7 @@ func (r *OpenStackMachineReconciler) reconcileNormal(ctx context.Context, scope 
 		conditions.MarkTrue(openStackMachine, infrav1.InstanceReadyCondition)
 
 		// Set properties required by CAPI machine controller
-		openStackMachine.Spec.ProviderID = ptr.To(fmt.Sprintf("openstack:///%s", instanceStatus.ID()))
+		openStackMachine.Spec.ProviderID = ptr.To(fmt.Sprintf("openstack://%s/%s", openStackMachine.ObjectMeta.Annotations["cluster.x-k8s.io/openstack.cloud"], instanceStatus.ID()))
 		openStackMachine.Status.Ready = true
 	case infrav1.InstanceStateError:
 		// If the machine has a NodeRef then it must have been working at some point,


### PR DESCRIPTION
**What this PR does / why we need it**:

To made CAPO compatible with OCCM multi-cloud deployment we need to manage providerID format with region code as introduced [here](https://github.com/kubernetes/cloud-provider-openstack/issues/1900) (`openstack://region/instance_uuid`). Use annotation from OpenstackMachine to define region in providerID field.

An empty or undefined annotation permit to be fully backward compatible. Moreover use annotation permit to manage some cluster with new OCCM provider-id string and other cluster with old format by same CAPO instance.

Fixes #2183

**Special notes for your reviewer**:

- As discussed in issue #2183 I first try to implement k8s secret call to get region name from config [here](https://github.com/MatthieuFin/cluster-api-provider-openstack/commit/04a4e609617d51249142d3328b3c017ed3d9c72a), it works well but it's not backward compatible. And if I setup a feature flag wiath a cli arg I loose the possibility to manage some k8s cluster with new providerID format beside of some k8s cluster with old providerID format managed by same CAPO instance.


