### PR TITLE
🐛 Re-allow `OpenStackMachine` to use their own `IdentityRef`

### DIFF
--- a/pkg/scope/provider.go
+++ b/pkg/scope/provider.go
@@ -58,6 +58,9 @@ func (f *providerScopeFactory) NewClientScopeFromObject(ctx context.Context, ctr
 
 	for _, o := range objects {
 		namespace, identityRef = o.GetIdentityRef()
+		if namespace != nil || identityRef != nil {
+			break
+		}
 	}
 
 	if namespace == nil || identityRef == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This patch fixes a regression where the last `IdentityRef` from a given list where used instead of the first one that was found valid.
In the case of the OpenStackMachine, we pass two refs, one for the Machine and one for the Cluster. Now the provider will return the ref from the Machine if it exists.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2190
