### PR TITLE
feat(manager): :sparkles: add region to openStackMachineSpec.ProviderID field from crd identityRef

### DIFF
--- a/api/v1alpha6/conversion_test.go
+++ b/api/v1alpha6/conversion_test.go
@@ -91,6 +91,13 @@ func TestFuzzyConversion(t *testing.T) {
 				}
 			},
 
+			func(identityRef *infrav1.OpenStackIdentityReference, c fuzz.Continue) {
+				c.FuzzNoCustom(identityRef)
+
+				// None of the following identityRef fields have ever been set in v1alpha6
+				identityRef.Region = ""
+			},
+
 			func(spec *OpenStackMachineSpec, c fuzz.Continue) {
 				c.FuzzNoCustom(spec)
 

--- a/api/v1alpha6/zz_generated.conversion.go
+++ b/api/v1alpha6/zz_generated.conversion.go
@@ -1085,6 +1085,7 @@ func autoConvert_v1alpha6_OpenStackIdentityReference_To_v1beta1_OpenStackIdentit
 func autoConvert_v1beta1_OpenStackIdentityReference_To_v1alpha6_OpenStackIdentityReference(in *v1beta1.OpenStackIdentityReference, out *OpenStackIdentityReference, s conversion.Scope) error {
 	out.Name = in.Name
 	// WARNING: in.CloudName requires manual conversion: does not exist in peer-type
+	// WARNING: in.Region requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/api/v1alpha7/conversion_test.go
+++ b/api/v1alpha7/conversion_test.go
@@ -89,6 +89,13 @@ func TestFuzzyConversion(t *testing.T) {
 					}
 				}
 			},
+
+			func(identityRef *infrav1.OpenStackIdentityReference, c fuzz.Continue) {
+				c.FuzzNoCustom(identityRef)
+
+				// None of the following identityRef fields have ever been set in v1alpha7
+				identityRef.Region = ""
+			},
 		}
 
 		return slices.Concat(v1alpha7FuzzerFuncs, testhelpers.InfraV1FuzzerFuncs())

--- a/api/v1alpha7/zz_generated.conversion.go
+++ b/api/v1alpha7/zz_generated.conversion.go
@@ -1319,6 +1319,7 @@ func autoConvert_v1alpha7_OpenStackIdentityReference_To_v1beta1_OpenStackIdentit
 func autoConvert_v1beta1_OpenStackIdentityReference_To_v1alpha7_OpenStackIdentityReference(in *v1beta1.OpenStackIdentityReference, out *OpenStackIdentityReference, s conversion.Scope) error {
 	out.Name = in.Name
 	// WARNING: in.CloudName requires manual conversion: does not exist in peer-type
+	// WARNING: in.Region requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/api/v1beta1/identity_types.go
+++ b/api/v1beta1/identity_types.go
@@ -18,6 +18,7 @@ package v1beta1
 
 // OpenStackIdentityReference is a reference to an infrastructure
 // provider identity to be used to provision cluster resources.
+// +kubebuilder:validation:XValidation:rule="(!has(self.region) && !has(oldSelf.region)) || self.region == oldSelf.region",message="region is immutable"
 type OpenStackIdentityReference struct {
 	// Name is the name of a secret in the same namespace as the resource being provisioned.
 	// The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
@@ -28,6 +29,12 @@ type OpenStackIdentityReference struct {
 	// CloudName specifies the name of the entry in the clouds.yaml file to use.
 	// +kubebuilder:validation:Required
 	CloudName string `json:"cloudName"`
+
+	// Region specifies an OpenStack region to use. If specified, it overrides
+	// any value in clouds.yaml. If specified for an OpenStackMachine, its
+	// value will be included in providerID.
+	// +optional
+	Region string `json:"region,omitempty"`
 }
 
 // IdentityRefProvider is an interface for obtaining OpenStack credentials from an API object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -3482,10 +3482,20 @@ spec:
                               The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
                               The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
                             type: string
+                          region:
+                            description: |-
+                              Region specifies an OpenStack region to use. If specified, it overrides
+                              any value in clouds.yaml. If specified for an OpenStackMachine, its
+                              value will be included in providerID.
+                            type: string
                         required:
                         - cloudName
                         - name
                         type: object
+                        x-kubernetes-validations:
+                        - message: region is immutable
+                          rule: (!has(self.region) && !has(oldSelf.region)) || self.region
+                            == oldSelf.region
                       image:
                         description: |-
                           The image to use for your server instance.
@@ -4481,10 +4491,20 @@ spec:
                       The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
                       The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
                     type: string
+                  region:
+                    description: |-
+                      Region specifies an OpenStack region to use. If specified, it overrides
+                      any value in clouds.yaml. If specified for an OpenStackMachine, its
+                      value will be included in providerID.
+                    type: string
                 required:
                 - cloudName
                 - name
                 type: object
+                x-kubernetes-validations:
+                - message: region is immutable
+                  rule: (!has(self.region) && !has(oldSelf.region)) || self.region
+                    == oldSelf.region
               managedSecurityGroups:
                 description: |-
                   ManagedSecurityGroups determines whether OpenStack security groups for the cluster

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
@@ -1977,10 +1977,20 @@ spec:
                                       The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
                                       The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
                                     type: string
+                                  region:
+                                    description: |-
+                                      Region specifies an OpenStack region to use. If specified, it overrides
+                                      any value in clouds.yaml. If specified for an OpenStackMachine, its
+                                      value will be included in providerID.
+                                    type: string
                                 required:
                                 - cloudName
                                 - name
                                 type: object
+                                x-kubernetes-validations:
+                                - message: region is immutable
+                                  rule: (!has(self.region) && !has(oldSelf.region))
+                                    || self.region == oldSelf.region
                               image:
                                 description: |-
                                   The image to use for your server instance.
@@ -2992,10 +3002,20 @@ spec:
                               The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
                               The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
                             type: string
+                          region:
+                            description: |-
+                              Region specifies an OpenStack region to use. If specified, it overrides
+                              any value in clouds.yaml. If specified for an OpenStackMachine, its
+                              value will be included in providerID.
+                            type: string
                         required:
                         - cloudName
                         - name
                         type: object
+                        x-kubernetes-validations:
+                        - message: region is immutable
+                          rule: (!has(self.region) && !has(oldSelf.region)) || self.region
+                            == oldSelf.region
                       managedSecurityGroups:
                         description: |-
                           ManagedSecurityGroups determines whether OpenStack security groups for the cluster

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackfloatingippools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackfloatingippools.yaml
@@ -133,10 +133,20 @@ spec:
                       The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
                       The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
                     type: string
+                  region:
+                    description: |-
+                      Region specifies an OpenStack region to use. If specified, it overrides
+                      any value in clouds.yaml. If specified for an OpenStackMachine, its
+                      value will be included in providerID.
+                    type: string
                 required:
                 - cloudName
                 - name
                 type: object
+                x-kubernetes-validations:
+                - message: region is immutable
+                  rule: (!has(self.region) && !has(oldSelf.region)) || self.region
+                    == oldSelf.region
               maxIPs:
                 description: |-
                   MaxIPs is the maximum number of floating ips that can be allocated from this pool, if nil there is no limit.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
@@ -1315,10 +1315,20 @@ spec:
                       The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
                       The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
                     type: string
+                  region:
+                    description: |-
+                      Region specifies an OpenStack region to use. If specified, it overrides
+                      any value in clouds.yaml. If specified for an OpenStackMachine, its
+                      value will be included in providerID.
+                    type: string
                 required:
                 - cloudName
                 - name
                 type: object
+                x-kubernetes-validations:
+                - message: region is immutable
+                  rule: (!has(self.region) && !has(oldSelf.region)) || self.region
+                    == oldSelf.region
               image:
                 description: |-
                   The image to use for your server instance.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
@@ -1097,10 +1097,20 @@ spec:
                               The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
                               The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
                             type: string
+                          region:
+                            description: |-
+                              Region specifies an OpenStack region to use. If specified, it overrides
+                              any value in clouds.yaml. If specified for an OpenStackMachine, its
+                              value will be included in providerID.
+                            type: string
                         required:
                         - cloudName
                         - name
                         type: object
+                        x-kubernetes-validations:
+                        - message: region is immutable
+                          rule: (!has(self.region) && !has(oldSelf.region)) || self.region
+                            == oldSelf.region
                       image:
                         description: |-
                           The image to use for your server instance.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackservers.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackservers.yaml
@@ -199,10 +199,20 @@ spec:
                       The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
                       The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
                     type: string
+                  region:
+                    description: |-
+                      Region specifies an OpenStack region to use. If specified, it overrides
+                      any value in clouds.yaml. If specified for an OpenStackMachine, its
+                      value will be included in providerID.
+                    type: string
                 required:
                 - cloudName
                 - name
                 type: object
+                x-kubernetes-validations:
+                - message: region is immutable
+                  rule: (!has(self.region) && !has(oldSelf.region)) || self.region
+                    == oldSelf.region
               image:
                 description: The image to use for the server instance.
                 maxProperties: 1

--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -422,7 +422,11 @@ func (r *OpenStackMachineReconciler) reconcileMachineState(scope *scope.WithLogg
 		conditions.MarkTrue(openStackMachine, infrav1.InstanceReadyCondition)
 
 		// Set properties required by CAPI machine controller
-		openStackMachine.Spec.ProviderID = ptr.To(fmt.Sprintf("openstack:///%s", *openStackServer.Status.InstanceID))
+		var region string
+		if openStackMachine.Spec.IdentityRef != nil {
+			region = openStackMachine.Spec.IdentityRef.Region
+		}
+		openStackMachine.Spec.ProviderID = ptr.To(fmt.Sprintf("openstack://%s/%s", region, *openStackServer.Status.InstanceID))
 		openStackMachine.Status.InstanceID = openStackServer.Status.InstanceID
 		openStackMachine.Status.Ready = true
 	case infrav1.InstanceStateError:

--- a/docs/book/src/api/v1beta1/api.md
+++ b/docs/book/src/api/v1beta1/api.md
@@ -3200,6 +3200,20 @@ string
 <p>CloudName specifies the name of the entry in the clouds.yaml file to use.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>region</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Region specifies an OpenStack region to use. If specified, it overrides
+any value in clouds.yaml. If specified for an OpenStackMachine, its
+value will be included in providerID.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="infrastructure.cluster.x-k8s.io/v1beta1.OpenStackMachineSpec">OpenStackMachineSpec

--- a/hack/codegen/openapi/zz_generated.openapi.go
+++ b/hack/codegen/openapi/zz_generated.openapi.go
@@ -23222,6 +23222,13 @@ func schema_sigsk8sio_cluster_api_provider_openstack_api_v1beta1_OpenStackIdenti
 							Format:      "",
 						},
 					},
+					"region": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Region specifies an OpenStack region to use. If specified, it overrides any value in clouds.yaml. If specified for an OpenStackMachine, its value will be included in providerID.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"name", "cloudName"},
 			},

--- a/pkg/generated/applyconfiguration/api/v1beta1/openstackidentityreference.go
+++ b/pkg/generated/applyconfiguration/api/v1beta1/openstackidentityreference.go
@@ -23,6 +23,7 @@ package v1beta1
 type OpenStackIdentityReferenceApplyConfiguration struct {
 	Name      *string `json:"name,omitempty"`
 	CloudName *string `json:"cloudName,omitempty"`
+	Region    *string `json:"region,omitempty"`
 }
 
 // OpenStackIdentityReferenceApplyConfiguration constructs an declarative configuration of the OpenStackIdentityReference type for use with
@@ -44,5 +45,13 @@ func (b *OpenStackIdentityReferenceApplyConfiguration) WithName(value string) *O
 // If called multiple times, the CloudName field is set to the value of the last call.
 func (b *OpenStackIdentityReferenceApplyConfiguration) WithCloudName(value string) *OpenStackIdentityReferenceApplyConfiguration {
 	b.CloudName = &value
+	return b
+}
+
+// WithRegion sets the Region field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Region field is set to the value of the last call.
+func (b *OpenStackIdentityReferenceApplyConfiguration) WithRegion(value string) *OpenStackIdentityReferenceApplyConfiguration {
+	b.Region = &value
 	return b
 }

--- a/pkg/generated/applyconfiguration/internal/internal.go
+++ b/pkg/generated/applyconfiguration/internal/internal.go
@@ -2666,6 +2666,9 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         scalar: string
       default: ""
+    - name: region
+      type:
+        scalar: string
 - name: io.k8s.sigs.cluster-api-provider-openstack.api.v1beta1.OpenStackMachine
   map:
     fields:

--- a/test/e2e/shared/openstack.go
+++ b/test/e2e/shared/openstack.go
@@ -667,7 +667,7 @@ func getProviderClient(e2eCtx *E2EContext, openstackCloud string) (*gophercloud.
 	clouds := getParsedOpenStackCloudYAML(openStackCloudYAMLFile)
 	cloud := clouds.Clouds[openstackCloud]
 
-	providerClient, clientOpts, projectID, err := scope.NewProviderClient(cloud, nil, logr.Discard())
+	providerClient, clientOpts, projectID, err := scope.NewProviderClient(cloud, "", nil, logr.Discard())
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/test/e2e/suites/apivalidations/openstackmachine_test.go
+++ b/test/e2e/suites/apivalidations/openstackmachine_test.go
@@ -133,6 +133,34 @@ var _ = Describe("OpenStackMachine API validations", func() {
 		Expect(k8sClient.Create(ctx, machine)).To(Succeed(), "Creating a machine with max metadata key and value should succeed")
 	})
 
+	It("should allow server identityRef Region field or unset on creation", func() {
+		machine := defaultMachine()
+
+		By("Creating a machine with identityRef Region field set on creation")
+		machine.Spec.IdentityRef = &infrav1.OpenStackIdentityReference{
+			Name:      "secretName",
+			CloudName: "cloudName",
+			Region:    "regionName",
+		}
+		Expect(k8sClient.Create(ctx, machine)).To(Succeed(), "Creating a machine with a spec.identityRef.Region field should be allowed")
+
+		By("Updating the identityRef Region field")
+		machine.Spec.IdentityRef.Region = "anotherRegionName"
+		Expect(k8sClient.Update(ctx, machine)).NotTo(Succeed(), "Updating spec.identityRef.Region field should fail")
+
+		machine = defaultMachine()
+		By("Creating a machine with identityRef Region field not set on creation")
+		machine.Spec.IdentityRef = &infrav1.OpenStackIdentityReference{
+			Name:      "secretName",
+			CloudName: "cloudName",
+		}
+		Expect(k8sClient.Create(ctx, machine)).To(Succeed(), "Creating a machine without a spec.identityRef.Region field should be allowed")
+
+		By("Setting the identityRef Region field")
+		machine.Spec.IdentityRef.Region = "regionName"
+		Expect(k8sClient.Update(ctx, machine)).NotTo(Succeed(), "Setting spec.identityRef.Region field should fail")
+	})
+
 	Context("flavors", func() {
 		It("should require either a flavor or flavorID", func() {
 			machine := defaultMachine()


### PR DESCRIPTION
**What this PR does / why we need it**:

To made CAPO compatible with OCCM multi-cloud deployment we need to manage providerID format with region code as introduced [here](https://github.com/kubernetes/cloud-provider-openstack/issues/1900) (`openstack://region/instance_uuid`). Use annotation from OpenstackMachine to define region in providerID field.

An empty or undefined annotation permit to be fully backward compatible. Moreover use annotation permit to manage some cluster with new OCCM provider-id string and other cluster with old format by same CAPO instance.

Fixes #2183

**Special notes for your reviewer**:

- As discussed in issue #2183 I first try to implement k8s secret call to get region name from config [here](https://github.com/MatthieuFin/cluster-api-provider-openstack/commit/04a4e609617d51249142d3328b3c017ed3d9c72a), it works well but it's not backward compatible. And if I setup a feature flag wiath a cli arg I loose the possibility to manage some k8s cluster with new providerID format beside of some k8s cluster with old providerID format managed by same CAPO instance.
- This feature need https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/2191 merged to work correctly !

