### PR TITLE
🌱 Remove pkg/utils/hash

### DIFF
--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -39,7 +39,6 @@ import (
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/record"
 	capoerrors "sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/errors"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/filterconvert"
-	"sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/hash"
 )
 
 const (
@@ -591,12 +590,4 @@ func getTimeout(name string, timeout int) time.Duration {
 		}
 	}
 	return time.Duration(timeout)
-}
-
-func HashInstanceSpec(computeInstance *InstanceSpec) (string, error) {
-	instanceHash, err := hash.ComputeSpewHash(computeInstance)
-	if err != nil {
-		return "", err
-	}
-	return strconv.Itoa(int(instanceHash)), nil
 }

--- a/pkg/scope/hash.go
+++ b/pkg/scope/hash.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package hash
+package scope
 
 import (
 	"fmt"
@@ -22,13 +22,12 @@ import (
 	"hash/fnv"
 
 	"github.com/davecgh/go-spew/spew"
-	"k8s.io/apimachinery/pkg/util/dump"
 )
 
-// SpewHashObject writes specified object to hash using the spew library
+// spewHashObject writes specified object to hash using the spew library
 // which follows pointers and prints actual values of the nested objects
 // ensuring the hash does not change when a pointer changes.
-func SpewHashObject(hasher hash.Hash, objectToWrite interface{}) error {
+func spewHashObject(hasher hash.Hash, objectToWrite interface{}) error {
 	hasher.Reset()
 	printer := spew.ConfigState{
 		Indent:         " ",
@@ -43,20 +42,11 @@ func SpewHashObject(hasher hash.Hash, objectToWrite interface{}) error {
 	return nil
 }
 
-// ComputeSpewHash computes the hash of a InstanceSpec using the spew library.
-func ComputeSpewHash(objectToWrite interface{}) (uint32, error) {
+// computeSpewHash computes the hash of an object using the spew library.
+func computeSpewHash(objectToWrite interface{}) (uint32, error) {
 	instanceSpecHasher := fnv.New32a()
-	if err := SpewHashObject(instanceSpecHasher, objectToWrite); err != nil {
+	if err := spewHashObject(instanceSpecHasher, objectToWrite); err != nil {
 		return 0, err
 	}
 	return instanceSpecHasher.Sum32(), nil
-}
-
-// DeepHashObject writes specified object to hash using the spew library
-// which follows pointers and prints actual values of the nested objects
-// ensuring the hash does not change when a pointer changes.
-// This function is taken from https://github.com/kubernetes/kubernetes/blob/v1.29.2/pkg/util/hash/hash.go#L26-L32
-func DeepHashObject(hasher hash.Hash, objectToWrite interface{}) {
-	hasher.Reset()
-	fmt.Fprintf(hasher, "%v", dump.ForHash(objectToWrite))
 }

--- a/pkg/scope/provider.go
+++ b/pkg/scope/provider.go
@@ -39,7 +39,6 @@ import (
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients"
-	"sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/hash"
 	"sigs.k8s.io/cluster-api-provider-openstack/version"
 )
 
@@ -88,7 +87,7 @@ func (f *providerScopeFactory) NewClientScopeFromObject(ctx context.Context, ctr
 }
 
 func getScopeCacheKey(cloud clientconfig.Cloud) (string, error) {
-	key, err := hash.ComputeSpewHash(cloud)
+	key, err := computeSpewHash(cloud)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This package was hosting 2 exported functions that weren't sharing any code and each had only a single consumer. We instead move the methods to their respective points of use.

Also entirely removes the exported function HashInstanceSpec, which had no consumers.