### PR TITLE
🌱 release-0.10: Pin GOTOOLCHAIN to go1.22.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ include $(ROOT_DIR_RELATIVE)/common.mk
 # If you update this file, please follow
 # https://www.thapaliya.com/en/writings/well-documented-makefiles/
 
+export GOTOOLCHAIN=go1.22.8
+
 # Active module mode, as we use go modules to manage dependencies
 export GO111MODULE=on
 unexport GOPATH


### PR DESCRIPTION
This fixes linting issues in the release-0.10 branch, which only manifest when the toolchain is bumped to 1.23, as in the current default kubekins-e2e image used in prow jobs.

/hold
