### PR TITLE
🌱 Use Dependabot for go.mod & GH workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,53 @@
+# Please see the documentation for all configuration options: https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+
+# github-actions
+- directory: "/"
+  package-ecosystem: "github-actions"
+  open-pull-requests-limit: 5
+  schedule:
+    interval: "weekly"
+    day: "monday"
+  groups:
+    all-github-actions:
+      patterns: [ "*" ]
+  commit-message:
+    prefix: ":seedling: chore(deps): bump"
+    include: scope
+  labels:
+    - "area/dependency"
+    - "ok-to-test"
+
+# Go directories
+- directories:
+    - "/"
+    - "/hack/tools"
+    - "/orc"
+  package-ecosystem: "gomod"
+  open-pull-requests-limit: 5
+  schedule:
+    interval: "weekly"
+    day: "monday"
+  ## group all dependencies with a k8s.io prefix into a single PR.
+  groups:
+    all-go-mod-patch-and-minor:
+      patterns: [ "*" ]
+      update-types: [ "patch", "minor" ]
+  commit-message:
+    prefix: ":seedling: chore(deps): bump"
+    include: scope
+  ignore:
+    # Ignore controller-runtime as its upgraded manually.
+    - dependency-name: "sigs.k8s.io/controller-runtime"
+      update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+    # Ignore k8s and its transitives modules as they are upgraded manually together with controller-runtime.
+    - dependency-name: "k8s.io/*"
+      update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+    - dependency-name: "github.com/prometheus/*"
+      update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+    - dependency-name: "sigs.k8s.io/cluster-api-provider-openstack"
+  labels:
+    - "area/dependency"
+    - "ok-to-test"

--- a/.github/workflows/pr-dependabot.yaml
+++ b/.github/workflows/pr-dependabot.yaml
@@ -1,0 +1,49 @@
+name: PR dependabot code generation and go modules fix
+
+# This action runs on other PRs opened by dependabot. It updates modules and generated code on PRs opened by dependabot.
+on:
+  pull_request:
+    branches:
+      - dependabot/**
+  push:
+    branches:
+      - dependabot/**
+  workflow_dispatch:
+
+permissions:
+  contents: write # Allow to update the PR.
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v4.2.2
+    - name: Calculate go version
+      id: vars
+      run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT
+    - name: Set up Go
+      uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # tag=v5.1.0
+      with:
+        go-version: ${{ steps.vars.outputs.go_version }}
+    - uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # tag=v4.1.2
+      name: Restore go cache
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Update all modules
+      run: make modules
+    - name: Update generated code
+      run: make generate
+    - uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # tag=v9.1.4
+      name: Commit changes
+      with:
+        author_name: dependabot[bot]
+        author_email: 49699333+dependabot[bot]@users.noreply.github.com
+        default_author: github_actor
+        message: 'Update generated code'


### PR DESCRIPTION
**What this PR does / why we need it**:

Maintaining our go.mod (we have 3 of them) up to date is a bit of work
and other cluster-api providers use dependabot to take care of it.

I took a look at the vsphere and azure providers and pretty much copy
pasted (with adjustments).
