### PR TITLE
🐛 Fix support for `OpenStackMachine.Spec.SecurityGroups`

### DIFF
--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -527,6 +527,9 @@ func openStackMachineSpecToOpenStackServerSpec(openStackMachineSpec *infrav1.Ope
 				},
 			}
 		}
+		if len(openStackMachineSpec.SecurityGroups) > 0 {
+			serverPorts[i].SecurityGroups = append(serverPorts[i].SecurityGroups, openStackMachineSpec.SecurityGroups...)
+		}
 	}
 	openStackServerSpec.Ports = serverPorts
 

--- a/controllers/openstackmachine_controller_test.go
+++ b/controllers/openstackmachine_controller_test.go
@@ -76,6 +76,21 @@ func TestOpenStackMachineSpecToOpenStackServerSpec(t *testing.T) {
 			},
 		},
 	}
+	portOptsWithAdditionalSecurityGroup := []infrav1.PortOpts{
+		{
+			Network: &infrav1.NetworkParam{
+				ID: ptr.To(openStackCluster.Status.Network.ID),
+			},
+			SecurityGroups: []infrav1.SecurityGroupParam{
+				{
+					ID: ptr.To(openStackCluster.Status.WorkerSecurityGroup.ID),
+				},
+				{
+					ID: ptr.To(extraSecurityGroupUUID),
+				},
+			},
+		},
+	}
 	image := infrav1.ImageParam{Filter: &infrav1.ImageFilter{Name: ptr.To("my-image")}}
 	tags := []string{"tag1", "tag2"}
 	userData := &corev1.LocalObjectReference{Name: "server-data-secret"}
@@ -97,6 +112,28 @@ func TestOpenStackMachineSpecToOpenStackServerSpec(t *testing.T) {
 				Image:       image,
 				SSHKeyName:  sshKeyName,
 				Ports:       portOpts,
+				Tags:        tags,
+				UserDataRef: userData,
+			},
+		},
+		{
+			name: "Test a OpenStackMachineSpec to OpenStackServerSpec conversion with an additional security group",
+			spec: &infrav1.OpenStackMachineSpec{
+				Flavor:     ptr.To(flavorName),
+				Image:      image,
+				SSHKeyName: sshKeyName,
+				SecurityGroups: []infrav1.SecurityGroupParam{
+					{
+						ID: ptr.To(extraSecurityGroupUUID),
+					},
+				},
+			},
+			want: &infrav1alpha1.OpenStackServerSpec{
+				Flavor:      ptr.To(flavorName),
+				IdentityRef: identityRef,
+				Image:       image,
+				SSHKeyName:  sshKeyName,
+				Ports:       portOptsWithAdditionalSecurityGroup,
 				Tags:        tags,
 				UserDataRef: userData,
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:

Somehow we broke that feature, probably when converting to
`OpenStackServer` and our CI missed that due to the lack of tests.

Now we add it back and we have tests.
This patch will add the security groups part of
`OpenStackMachine.Spec.SecurityGroups` in each Port that is in
`OpenStackServer.Spec.Ports`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2236
