### PR TITLE
🐛 Drop caBundle from CRDs to support Kubernetes 1.31

### DIFF
--- a/config/crd/patches/webhook_in_openstackclusters.yaml
+++ b/config/crd/patches/webhook_in_openstackclusters.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_openstackclustertemplates.yaml
+++ b/config/crd/patches/webhook_in_openstackclustertemplates.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_openstackfloatingippools.yaml
+++ b/config/crd/patches/webhook_in_openstackfloatingippools.yaml
@@ -8,9 +8,6 @@ spec:
   conversion:
     strategy: Webhook
     webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
       service:
         namespace: system
         name: webhook-service

--- a/config/crd/patches/webhook_in_openstackmachines.yaml
+++ b/config/crd/patches/webhook_in_openstackmachines.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_openstackmachinetemplates.yaml
+++ b/config/crd/patches/webhook_in_openstackmachinetemplates.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service


### PR DESCRIPTION
**What this PR does / why we need it:**

Starting with Kubernetes 1.31 it won't be possible anymore to continuously apply CRDs that are setting caBundle to an invalid value (in our case Cg==). The solution is to simply drop the caBundle field (it was never actually required by kube-apiserver).
For more details see: https://kubernetes.slack.com/archives/C0EG7JC6T/p1722441161968339

Let me know if you have any questions.

We'll want to backport this into all supported releases. It's never great to set the caBundle to an invalid value, even before Kubernetes 1.31.

This is an effort driven by CAPI: https://github.com/kubernetes-sigs/cluster-api/pull/10972