### PR TITLE
:bug: Ensure tags and trunks for existing ports

### DIFF
--- a/pkg/cloud/services/compute/instance_test.go
+++ b/pkg/cloud/services/compute/instance_test.go
@@ -366,7 +366,6 @@ func TestService_ReconcileInstance(t *testing.T) {
 				Description: portOpts["description"].(string),
 			}, nil
 		})
-		networkRecorder.ReplaceAllAttributesTags("ports", portUUID, attributestags.ReplaceAllOpts{Tags: []string{"test-tag"}}).Return(nil, nil)
 	}
 
 	// Expected calls if we delete the network port
@@ -460,6 +459,7 @@ func TestService_ReconcileInstance(t *testing.T) {
 				expectDefaultImageAndFlavor(r.compute, r.image)
 
 				expectCreateServer(r.compute, getDefaultServerMap(), false)
+				r.network.ReplaceAllAttributesTags("ports", portUUID, attributestags.ReplaceAllOpts{Tags: []string{"test-tag"}}).Return(nil, nil)
 				expectServerPollSuccess(r.compute)
 			},
 			wantErr: false,
@@ -472,6 +472,7 @@ func TestService_ReconcileInstance(t *testing.T) {
 				expectDefaultImageAndFlavor(r.compute, r.image)
 
 				expectCreateServer(r.compute, getDefaultServerMap(), true)
+				r.network.ReplaceAllAttributesTags("ports", portUUID, attributestags.ReplaceAllOpts{Tags: []string{"test-tag"}}).Return(nil, nil)
 
 				// Make sure we delete ports
 				expectCleanupDefaultPort(r.network)
@@ -491,6 +492,7 @@ func TestService_ReconcileInstance(t *testing.T) {
 			expect: func(r *recorders) {
 				expectDefaultImageAndFlavor(r.compute, r.image)
 				expectUseExistingDefaultPort(r.network)
+				r.network.ReplaceAllAttributesTags("ports", portUUID, attributestags.ReplaceAllOpts{Tags: []string{"test-tag"}}).Return(nil, nil)
 
 				// Looking up the second port fails
 				r.network.ListPort(ports.ListOpts{
@@ -511,6 +513,7 @@ func TestService_ReconcileInstance(t *testing.T) {
 				expectDefaultImageAndFlavor(r.compute, r.image)
 
 				expectCreateServer(r.compute, getDefaultServerMap(), false)
+				r.network.ReplaceAllAttributesTags("ports", portUUID, attributestags.ReplaceAllOpts{Tags: []string{"test-tag"}}).Return(nil, nil)
 				expectServerPoll(r.compute, []string{"BUILDING", "ACTIVE"})
 			},
 			wantErr: false,
@@ -523,6 +526,7 @@ func TestService_ReconcileInstance(t *testing.T) {
 				expectDefaultImageAndFlavor(r.compute, r.image)
 
 				expectCreateServer(r.compute, getDefaultServerMap(), false)
+				r.network.ReplaceAllAttributesTags("ports", portUUID, attributestags.ReplaceAllOpts{Tags: []string{"test-tag"}}).Return(nil, nil)
 				expectServerPoll(r.compute, []string{"BUILDING", "ERROR"})
 
 				// Don't delete ports because the server is created: DeleteInstance will do it
@@ -567,6 +571,7 @@ func TestService_ReconcileInstance(t *testing.T) {
 					},
 				}
 				expectCreateServer(r.compute, createMap, false)
+				r.network.ReplaceAllAttributesTags("ports", portUUID, attributestags.ReplaceAllOpts{Tags: []string{"test-tag"}}).Return(nil, nil)
 				expectServerPollSuccess(r.compute)
 
 				// Don't delete ports because the server is created: DeleteInstance will do it
@@ -614,6 +619,7 @@ func TestService_ReconcileInstance(t *testing.T) {
 					},
 				}
 				expectCreateServer(r.compute, createMap, false)
+				r.network.ReplaceAllAttributesTags("ports", portUUID, attributestags.ReplaceAllOpts{Tags: []string{"test-tag"}}).Return(nil, nil)
 				expectServerPollSuccess(r.compute)
 
 				// Don't delete ports because the server is created: DeleteInstance will do it
@@ -631,6 +637,7 @@ func TestService_ReconcileInstance(t *testing.T) {
 			},
 			expect: func(r *recorders) {
 				expectUseExistingDefaultPort(r.network)
+				r.network.ReplaceAllAttributesTags("ports", portUUID, attributestags.ReplaceAllOpts{Tags: []string{"test-tag"}}).Return(nil, nil)
 				expectDefaultImageAndFlavor(r.compute, r.image)
 
 				r.volume.ListVolumes(volumes.ListOpts{Name: fmt.Sprintf("%s-root", openStackMachineName)}).
@@ -679,6 +686,7 @@ func TestService_ReconcileInstance(t *testing.T) {
 			},
 			expect: func(r *recorders) {
 				expectUseExistingDefaultPort(r.network)
+				r.network.ReplaceAllAttributesTags("ports", portUUID, attributestags.ReplaceAllOpts{Tags: []string{"test-tag"}}).Return(nil, nil)
 				expectDefaultImageAndFlavor(r.compute, r.image)
 
 				r.volume.ListVolumes(volumes.ListOpts{Name: fmt.Sprintf("%s-root", openStackMachineName)}).
@@ -767,6 +775,7 @@ func TestService_ReconcileInstance(t *testing.T) {
 			},
 			expect: func(r *recorders) {
 				expectUseExistingDefaultPort(r.network)
+				r.network.ReplaceAllAttributesTags("ports", portUUID, attributestags.ReplaceAllOpts{Tags: []string{"test-tag"}}).Return(nil, nil)
 				expectDefaultImageAndFlavor(r.compute, r.image)
 
 				r.volume.ListVolumes(volumes.ListOpts{Name: fmt.Sprintf("%s-etcd", openStackMachineName)}).
@@ -836,6 +845,7 @@ func TestService_ReconcileInstance(t *testing.T) {
 			},
 			expect: func(r *recorders) {
 				expectUseExistingDefaultPort(r.network)
+				r.network.ReplaceAllAttributesTags("ports", portUUID, attributestags.ReplaceAllOpts{Tags: []string{"test-tag"}}).Return(nil, nil)
 				expectDefaultImageAndFlavor(r.compute, r.image)
 
 				r.volume.ListVolumes(volumes.ListOpts{Name: fmt.Sprintf("%s-etcd", openStackMachineName)}).
@@ -893,6 +903,7 @@ func TestService_ReconcileInstance(t *testing.T) {
 			},
 			expect: func(r *recorders) {
 				expectUseExistingDefaultPort(r.network)
+				r.network.ReplaceAllAttributesTags("ports", portUUID, attributestags.ReplaceAllOpts{Tags: []string{"test-tag"}}).Return(nil, nil)
 				expectDefaultImageAndFlavor(r.compute, r.image)
 
 				// Make sure we delete ports
@@ -918,6 +929,7 @@ func TestService_ReconcileInstance(t *testing.T) {
 				r.network.ListExtensions().Return(extensions, nil)
 
 				expectCreatePort(r.network, portName, networkUUID)
+				r.network.ReplaceAllAttributesTags("ports", portUUID, attributestags.ReplaceAllOpts{Tags: []string{"test-tag"}}).Return(nil, nil)
 
 				// Check for existing trunk
 				r.network.ListTrunk(newGomegaMockMatcher(


### PR DESCRIPTION
**What this PR does / why we need it**:
When a port is created, it is tagged and explicitly checked if it needs a trunk, but if the port already exists for some reason, it is taken without any of those checking. This PR fixes that by adding a similar check for the existing ports, similar to the check in new ports.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Technically this rarely happens, as a failure in VM creation will clean up all ports, hence we don't normally have existing ports with same name and network ID as the one we need. Still, if that happens that there exists such a port, a problem may arise.

This is an issue with release-0.9. I'm not sure if other releases may behave in the same manner.

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
