### PR TITLE
:seedling: test/e2e: bump Flatcar image to latest Stable

### DIFF
--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -186,7 +186,7 @@ variables:
   SSH_USER_MACHINE: "ubuntu"
   EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION: "true"
   # The Flatcar image produced by the image-builder
-  OPENSTACK_FLATCAR_IMAGE_NAME: "flatcar-stable-3975.2.0-kube-v1.30.1"
+  OPENSTACK_FLATCAR_IMAGE_NAME: "flatcar-stable-4081.2.0-kube-v1.30.1"
   # A plain Flatcar from the Flatcar releases server
   FLATCAR_IMAGE_NAME: "flatcar_production_openstack_image"
 


### PR DESCRIPTION
**What this PR does / why we need it**: This PR bumps Flatcar tested version to latest Stable

**Special notes for your reviewer**:
* With the new orc approach, I can't update the image here for testing, so one maintainer needs to upload this image to the CAPO GCS: https://wfwfg.s3.pl-waw.scw.cloud/flatcar-stable-4081.2.0-kube-v1.30.1.img
* We need to think about "deprecating" the current `flatcar` template in favor of `flatcar-sysext` to have only one Flatcar template that does not need images from the image-builder

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
