### PR TITLE
🐛 Requeue when waiting for a server to be deleted

### DIFF
--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -66,6 +66,7 @@ const (
 	waitForClusterInfrastructureReadyDuration = 15 * time.Second
 	waitForInstanceBecomeActiveToReconcile    = 60 * time.Second
 	waitForBuildingInstanceToReconcile        = 10 * time.Second
+	deleteServerRequeueDelay                  = 10 * time.Second
 )
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=openstackmachines,verbs=get;list;watch;create;update;patch;delete
@@ -265,7 +266,7 @@ func (r *OpenStackMachineReconciler) reconcileDelete(ctx context.Context, scope 
 		// If the server was found, we need to wait for it to be deleted before
 		// removing the OpenStackMachine finalizer.
 		scope.Logger().Info("Waiting for server to be deleted before removing finalizer")
-		return ctrl.Result{}, nil
+		return ctrl.Result{RequeueAfter: deleteServerRequeueDelay}, nil
 	}
 
 	controllerutil.RemoveFinalizer(openStackMachine, infrav1.MachineFinalizer)


### PR DESCRIPTION
**What this PR does / why we need it**:

We did not add a requeue when waiting for a server to be deleted. This leads to unnecessary delays when deleting a cluster, since the controller will then wait for the next sync period (default 10m) before it checks again.
This PR adds a requeue similar to what we have in other situations where we expect progress to happen soon.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
