### PR TITLE
Do not delete bastion floating ip if set in spec

### DIFF
--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -252,14 +252,14 @@ func (r *OpenStackClusterReconciler) deleteBastion(ctx context.Context, scope *s
 	var statusFloatingIP *string
 	var specFloatingIP *string
 	if openStackCluster.Status.Bastion != nil && openStackCluster.Status.Bastion.FloatingIP != "" {
-		// Floating IP set in status
 		statusFloatingIP = &openStackCluster.Status.Bastion.FloatingIP
 	}
 	if openStackCluster.Spec.Bastion.FloatingIP != nil {
-		// Floating IP from the spec
 		specFloatingIP = openStackCluster.Spec.Bastion.FloatingIP
 	}
 
+	// We only remove the bastion's floating IP if it exists and if it's not the same value defined both in the spec and in status.
+	// This decision was made so if a user specifies a pre-created floating IP that is intended to only be used for the bastion, the floating IP won't get removed once the bastion is destroyed.
 	if statusFloatingIP != nil && (specFloatingIP == nil || *statusFloatingIP != *specFloatingIP) {
 		if err = networkingService.DeleteFloatingIP(openStackCluster, openStackCluster.Status.Bastion.FloatingIP); err != nil {
 			handleUpdateOSCError(openStackCluster, fmt.Errorf("failed to delete floating IP: %w", err), false)
@@ -286,7 +286,8 @@ func (r *OpenStackClusterReconciler) deleteBastion(ctx context.Context, scope *s
 
 		for _, address := range addresses {
 			if address.Type == corev1.NodeExternalIP {
-				// If a floating IP is set for the bastion spec, skip deleting it
+				// If a floating IP retrieved is the same as what is set in the bastion spec, skip deleting it.
+				// This decision was made so if a user specifies a pre-created floating IP that is intended to only be used for the bastion, the floating IP won't get removed once the bastion is destroyed.
 				if specFloatingIP != nil && address.Address == *specFloatingIP {
 					continue
 				}

--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -249,7 +249,18 @@ func (r *OpenStackClusterReconciler) deleteBastion(ctx context.Context, scope *s
 		return err
 	}
 
+	var statusFloatingIP *string
+	var specFloatingIP *string
 	if openStackCluster.Status.Bastion != nil && openStackCluster.Status.Bastion.FloatingIP != "" {
+		// Floating IP set in status
+		statusFloatingIP = &openStackCluster.Status.Bastion.FloatingIP
+	}
+	if openStackCluster.Spec.Bastion.FloatingIP != nil {
+		// Floating IP from the spec
+		specFloatingIP = openStackCluster.Spec.Bastion.FloatingIP
+	}
+
+	if statusFloatingIP != nil && (specFloatingIP == nil || *statusFloatingIP != *specFloatingIP) {
 		if err = networkingService.DeleteFloatingIP(openStackCluster, openStackCluster.Status.Bastion.FloatingIP); err != nil {
 			handleUpdateOSCError(openStackCluster, fmt.Errorf("failed to delete floating IP: %w", err), false)
 			return fmt.Errorf("failed to delete floating IP: %w", err)
@@ -275,6 +286,10 @@ func (r *OpenStackClusterReconciler) deleteBastion(ctx context.Context, scope *s
 
 		for _, address := range addresses {
 			if address.Type == corev1.NodeExternalIP {
+				// If a floating IP is set for the bastion spec, skip deleting it
+				if specFloatingIP != nil && address.Address == *specFloatingIP {
+					continue
+				}
 				// Floating IP may not have properly saved in bastion status (thus not deleted above), delete any remaining floating IP
 				if err = networkingService.DeleteFloatingIP(openStackCluster, address.Address); err != nil {
 					handleUpdateOSCError(openStackCluster, fmt.Errorf("failed to delete floating IP: %w", err), false)

--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -254,7 +254,7 @@ func (r *OpenStackClusterReconciler) deleteBastion(ctx context.Context, scope *s
 	if openStackCluster.Status.Bastion != nil && openStackCluster.Status.Bastion.FloatingIP != "" {
 		statusFloatingIP = &openStackCluster.Status.Bastion.FloatingIP
 	}
-	if openStackCluster.Spec.Bastion.FloatingIP != nil {
+	if openStackCluster.Spec.Bastion != nil && openStackCluster.Spec.Bastion.FloatingIP != nil {
 		specFloatingIP = openStackCluster.Spec.Bastion.FloatingIP
 	}
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR makes it so that if an floatingIP is set in the `openstackcluster.spec.bastion.floatingIP`, and it is the same as set in the `status` of the `openstackcluster` resource, it will not be deleted when deleting the cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2157 

**Special notes for your reviewer**:

My issue got stale so I am creating this PR so that hopefully this feature does not get forgotten.

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
