### PR TITLE
🌱 CI: bump devstack to 2024.2 (Dalmatian)

### DIFF
--- a/scripts/ci-conformance.sh
+++ b/scripts/ci-conformance.sh
@@ -47,7 +47,7 @@ trap cleanup EXIT
 
 apt-get update -y
 # Install requests module explicitly for HTTP calls.
-# libffi required for pip install cffi (caracal dependency)
+# libffi required for pip install cffi (openstack dependency)
 apt-get install -y python3-requests libffi-dev
 rm -rf /var/lib/apt/lists/*
 

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -48,7 +48,7 @@ trap cleanup EXIT
 
 apt-get update -y
 # Install requests module explicitly for HTTP calls.
-# libffi required for pip install cffi (caracal dependency)
+# libffi required for pip install cffi (openstack dependency)
 apt-get install -y python3-requests libffi-dev
 rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR bumps the version of OpenStack in our CI to test the latest maintained version.
