### PR TITLE
🌱 Add Image templates and update dev docs

### DIFF
--- a/docs/book/src/development/development.md
+++ b/docs/book/src/development/development.md
@@ -61,6 +61,15 @@ make docker-build docker-push
 
 After generating `infrastructure-components.yaml`, replace the `us.gcr.io/k8s-artifacts-prod/capi-openstack/capi-openstack-controller:v0.3.4` with your image.
 
+## Automatically Adding Images to OpenStack
+
+Before you can create a Cluster, you will need a suitable image in OpenStack.
+There is a convenient template available in `templates/images-template.yaml` for this purpose.
+
+```bash
+clusterctl generate yaml  --from templates/images-template.yaml | kubectl apply -f -
+```
+
 ## Testing Cluster Creation using the 'dev-test' ClusterClass with Tilt
 
 This guide demonstrates how to create a Kubernetes cluster using a ClusterClass, specifically designed for a development environment. It includes configuring secrets, applying the ClusterClass, and creating a cluster with Tilt.
@@ -196,7 +205,7 @@ kubectl create secret generic dev-test-cloud-config --from-file=clouds.yaml
 You can use `clusterctl` to render the ClusterClass:
 
 ```bash
-clusterctl generate yaml  --from templates/clusterclass-dev-test.yaml
+clusterctl generate yaml  --from templates/clusterclass-dev-test.yaml | kubectl apply -f -
 ```
 
 Create a cluster using the development template, that makes use of the ClusterClass:

--- a/templates/cluster-template-development.yaml
+++ b/templates/cluster-template-development.yaml
@@ -11,3 +11,10 @@ spec:
       - class: default-worker
         name: md-0
         replicas: 1
+    variables:
+    - name: identityRef
+      value:
+        name: ${CLOUD_CONFIG_SECRET:=dev-test-cloud-config}
+        cloudName: ${OPENSTACK_CLOUD:=capo-e2e}
+    - name: imageBaseName
+      value: ${IMAGE_BASE_NAME:=ubuntu-2404-kube}

--- a/templates/clusterclass-dev-test.yaml
+++ b/templates/clusterclass-dev-test.yaml
@@ -20,20 +20,52 @@ spec:
       name: dev-test-openstackcluster
   workers:
     machineDeployments:
-      - class: default-worker
-        template:
-          bootstrap:
-            ref:
-              apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
-              kind: KubeadmConfigTemplate
-              name: dev-test-default-worker-bootstraptemplate
-          infrastructure:
-            ref:
-              apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-              kind: OpenStackMachineTemplate
-              name: dev-test-default-worker-machine
+    - class: default-worker
+      template:
+        bootstrap:
+          ref:
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+            kind: KubeadmConfigTemplate
+            name: dev-test-default-worker-bootstraptemplate
+        infrastructure:
+          ref:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: OpenStackMachineTemplate
+            name: dev-test-default-worker-machine
+  variables:
+  - name: identityRef
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          name:
+            type: string
+            description: "The name of the OpenStackCloudConfigSecret."
+            default: dev-test-cloud-config
+          cloudName:
+            type: string
+            description: "The name of the cloud in the OpenStackCloudConfigSecret."
+            default: capo-e2e
+  - name: imageBaseName
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: string
+        description: |
+          The base name of the OpenStack image that is used for creating the servers.
+          This will be combined with the k8s version to create the full name. E.g. imageBaseName-v1.31.2.
+        default: "ubuntu-2404-kube"
+  - name: imageOverride
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: string
+        description: |
+          The image that is used for creating the servers.
+          This overrides the imageBaseName + k8s version that is normally used.
   patches:
-  - name: controlPlaneImage
+  - name: image
     description: "Sets the OpenStack image that is used for creating the servers."
     definitions:
     - selector:
@@ -46,10 +78,7 @@ spec:
         path: /spec/template/spec/image/filter/name
         valueFrom:
           template: |
-            ubuntu-2204-kube-{{ .builtin.controlPlane.version }}
-  - name: workerImage
-    description: "Sets the OpenStack image that is used for creating the servers."
-    definitions:
+            {{ if .imageOverride }}{{ .imageOverride }}{{ else }}{{ .imageBaseName }}-{{ .builtin.controlPlane.version }}{{ end }}
     - selector:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: OpenStackMachineTemplate
@@ -62,7 +91,20 @@ spec:
         path: /spec/template/spec/image/filter/name
         valueFrom:
           template: |
-            ubuntu-2204-kube-{{ .builtin.machineDeployment.version }}
+            {{ if .imageOverride }}{{ .imageOverride }}{{ else }}{{ .imageBaseName }}-{{ .builtin.machineDeployment.version }}{{ end }}
+  - name: identityRef
+    description: "Sets the OpenStack identity reference."
+    definitions:
+    - selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: OpenStackClusterTemplate
+        matchResources:
+          infrastructureCluster: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/identityRef
+        valueFrom:
+          variable: identityRef
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/templates/images-template.yaml
+++ b/templates/images-template.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Image
+metadata:
+  name: node-image
+spec:
+  managementPolicy: managed
+  resource:
+    name: ubuntu-2404-kube-v1.31.2
+    content:
+      diskFormat: qcow2
+      download:
+        url: ${NODE_IMAGE_URL:="https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/ubuntu/2024-11-21/ubuntu-2404-kube-v1.31.2.img"}
+  cloudCredentialsRef:
+    secretName: dev-test-cloud-config
+    cloudName: capo-e2e
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Image
+metadata:
+  name: bastion-image
+spec:
+  managementPolicy: managed
+  resource:
+    name: ubuntu-22.04
+    content:
+      diskFormat: qcow2
+      download:
+        url: ${BASTION_IMAGE_URL:="https://cloud-images.ubuntu.com/releases/jammy/release/ubuntu-22.04-server-cloudimg-amd64.img"}
+  cloudCredentialsRef:
+    secretName: dev-test-cloud-config
+    cloudName: capo-e2e


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds a template for ORC managed Images. The template is meant as a simple way for developers to get a bastion and node image loaded into their openstack environment. Docs are also updated to reflect this.

The ClusterClass template is also updated to make it more useful. Most notably, this adds variables for identityRef and for specifying the image name.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
