### PR TITLE
🌱 E2E: Use CAPI production images and skip cert-manager pre-pull

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,12 +209,9 @@ e2e-image: docker-build
 
 # Pull all the images references in test/e2e/data/e2e_conf.yaml
 test-e2e-image-prerequisites:
-	docker pull gcr.io/k8s-staging-cluster-api/cluster-api-controller:v1.6.0
-	docker pull gcr.io/k8s-staging-cluster-api/kubeadm-bootstrap-controller:v1.6.0
-	docker pull gcr.io/k8s-staging-cluster-api/kubeadm-control-plane-controller:v1.6.0
-	docker pull quay.io/jetstack/cert-manager-cainjector:v1.12.1
-	docker pull quay.io/jetstack/cert-manager-webhook:v1.12.1
-	docker pull quay.io/jetstack/cert-manager-controller:v1.12.1
+	docker pull registry.k8s.io/cluster-api/cluster-api-controller:v1.8.5
+	docker pull registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.8.5
+	docker pull registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.8.5
 
 CONFORMANCE_E2E_ARGS ?= -kubetest.config-file=$(KUBETEST_CONF_PATH)
 CONFORMANCE_E2E_ARGS += $(E2E_ARGS)

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -1,8 +1,5 @@
 ---
 # E2E test scenario using local dev images and manifests built from the source tree for following providers:
-# - cluster-api
-# - bootstrap kubeadm
-# - control-plane kubeadm
 # - openstack
 
 # To run tests, run the following from the root of this repository.
@@ -12,21 +9,15 @@
 managementClusterName: capo-e2e
 
 images:
-- name: gcr.io/k8s-staging-cluster-api/cluster-api-controller:v1.8.5
+- name: registry.k8s.io/cluster-api/cluster-api-controller:v1.8.5
   loadBehavior: tryLoad
-- name: gcr.io/k8s-staging-cluster-api/kubeadm-bootstrap-controller:v1.8.5
+- name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.8.5
   loadBehavior: tryLoad
-- name: gcr.io/k8s-staging-cluster-api/kubeadm-control-plane-controller:v1.8.5
+- name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.8.5
   loadBehavior: tryLoad
 # Use local dev images built source tree;
 - name: gcr.io/k8s-staging-capi-openstack/capi-openstack-controller:e2e
   loadBehavior: mustLoad
-- name: quay.io/jetstack/cert-manager-cainjector:v1.14.5
-  loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-webhook:v1.14.5
-  loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-controller:v1.14.5
-  loadBehavior: tryLoad
 
 providers:
 - name: cluster-api


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Use CAPI production images instead of from GCR.

Don't pre-pull cert-manager. We always let these images get out of sync, causing us to pull double instead of saving anything. We end up with different tags in e2e_conf.yaml and in the Makefile. Additionally, CAPI may change what version is installed by clusterctl by default, causing us to pull *two* wrong versions and then install a third if we don't remember to check when bumping CAPI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
