### PR TITLE
🐛 ci/devstack: host tuning

### DIFF
--- a/hack/ci/cloud-init/controller.yaml.tpl
+++ b/hack/ci/cloud-init/controller.yaml.tpl
@@ -12,6 +12,11 @@
     VERBOSE=True
     LOG_COLOR=True
 
+    # Host tuning
+    ENABLE_SYSCTL_MEM_TUNING="True"
+    ENABLE_SYSCTL_NET_TUNING="True"
+    ENABLE_ZSWAP="True"
+
     # Octavia
     enable_plugin octavia https://github.com/openstack/octavia stable/${OPENSTACK_RELEASE}
     enable_plugin octavia-dashboard https://github.com/openstack/octavia-dashboard stable/${OPENSTACK_RELEASE}

--- a/hack/ci/cloud-init/worker.yaml.tpl
+++ b/hack/ci/cloud-init/worker.yaml.tpl
@@ -11,6 +11,11 @@
     VERBOSE=True
     LOG_COLOR=True
 
+    # Host tuning
+    ENABLE_SYSCTL_MEM_TUNING="True"
+    ENABLE_SYSCTL_NET_TUNING="True"
+    ENABLE_ZSWAP="True"
+
     DATABASE_PASSWORD=secretdatabase
     RABBIT_PASSWORD=secretrabbit
     ADMIN_PASSWORD=secretadmin


### PR DESCRIPTION
**What this PR does / why we need it**:

Configuring the following in devstack:

```
ENABLE_SYSCTL_MEM_TUNING="True"
ENABLE_SYSCTL_NET_TUNING="True"
ENABLE_ZSWAP="True"
```

That tuning is what is done in the `devstack-platform-ubuntu-noble`
job.
Example:
https://storage.gra.cloud.ovh.net/v1/AUTH_dcaab5e32b234d56b626f72581e3644c/zuul_opendev_logs_d17/936669/2/check/devstack-platform-ubuntu-noble/d178dad/controller/logs/local_conf.txt
