### PR TITLE
🌱 devstack: build OVN from source

### DIFF
--- a/hack/ci/cloud-init/controller.yaml.tpl
+++ b/hack/ci/cloud-init/controller.yaml.tpl
@@ -48,6 +48,14 @@
     OVN_L3_CREATE_PUBLIC_NETWORK="True"
     Q_AGENT="ovn"
 
+    # WORKAROUND:
+    # 	https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/2320
+    # 	OVN built from source using LTS versions. Should be removed once OVS is more stable without the pin.
+    # 	https://opendev.org/openstack/neutron/src/commit/83de306105f9329e24c97c4af6c3886de20e7d70/zuul.d/tempest-multinode.yaml#L603-L604
+    OVN_BUILD_FROM_SOURCE=True
+    OVN_BRANCH=branch-24.03
+    OVS_BRANCH=branch-3.3
+
     # Octavia
     ENABLED_SERVICES+=,octavia,o-api,o-cw,o-hm,o-hk,o-da
 

--- a/hack/ci/cloud-init/worker.yaml.tpl
+++ b/hack/ci/cloud-init/worker.yaml.tpl
@@ -44,6 +44,14 @@
     Q_ML2_PLUGIN_MECHANISM_DRIVERS="ovn,logger"
     Q_AGENT="ovn"
 
+    # WORKAROUND:
+    # 	https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/2320
+    # 	OVN built from source using LTS versions. Should be removed once OVS is more stable without the pin.
+    # 	https://opendev.org/openstack/neutron/src/commit/83de306105f9329e24c97c4af6c3886de20e7d70/zuul.d/tempest-multinode.yaml#L603-L604
+    OVN_BUILD_FROM_SOURCE=True
+    OVN_BRANCH=branch-24.03
+    OVS_BRANCH=branch-3.3
+
     # Additional services
     ENABLED_SERVICES+=${OPENSTACK_ADDITIONAL_SERVICES}
     DISABLED_SERVICES+=${OPENSTACK_DISABLED_SERVICES}


### PR DESCRIPTION
**What this PR does / why we need it**:

In this PR we'll control the version of OVN to align with the upstream
devstack jobs building OVN and OVS from LTS versions.
This is largely a workaround to address some timeout issues that we
recently have and that with a controlled version of OVN we hope to
reduce.

issue #2320