### PR TITLE
✨ feat: reconcile pre-existing router

### DIFF
--- a/pkg/cloud/services/networking/router.go
+++ b/pkg/cloud/services/networking/router.go
@@ -157,10 +157,10 @@ func (s *Service) getExternallyManagedRouter(openStackCluster *infrav1.OpenStack
 	if openStackCluster.Status.Router != nil {
 		return s.client.GetRouter(openStackCluster.Status.Router.ID)
 	}
-	return s.getRouterByParam(openStackCluster.Spec.Router)
+	return s.GetRouterByParam(openStackCluster.Spec.Router)
 }
 
-func (s *Service) getRouterByParam(routerParam *infrav1.RouterParam) (*routers.Router, error) {
+func (s *Service) GetRouterByParam(routerParam *infrav1.RouterParam) (*routers.Router, error) {
 	if routerParam.ID != nil {
 		return s.client.GetRouter(*routerParam.ID)
 	}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Currently only pre existing networks and subnets are reconciled and not a pre existing router.

I think it is a good idea to also reconcile pre-existing routers and put them in the status. This is useful for debugging, reading info from the status (e.g. outgoing router ip of the cluster) and if the router ip is written to the status, it can be used for the lb allowlist.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

none

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [x] adds unit tests
