### PR TITLE
:bug: New IPAddressClaim.ObjectMeta.Labels nil map assign panic

### DIFF
--- a/controllers/openstackserver_controller.go
+++ b/controllers/openstackserver_controller.go
@@ -602,6 +602,7 @@ func (r *OpenStackServerReconciler) getOrCreateIPAddressClaimForFloatingAddress(
 				},
 			},
 			Finalizers: []string{infrav1.IPClaimMachineFinalizer},
+			Labels:     map[string]string{},
 		},
 		Spec: ipamv1.IPAddressClaimSpec{
 			PoolRef: *poolRef,


### PR DESCRIPTION
**What this PR does / why we need it**:

When an IPAddressClaim is created and the openstackserver has a cluster name label, the capo controller panics because the Labels map is nil by default.

This PR creates an empty Lables map on new IPAddressClaim ObjectMeta.

**TODOs**:

- [X] squashed commits

/hold
