### PR TITLE
🌱 Update cloudbuild image

### DIFF
--- a/cloudbuild-nightly.yaml
+++ b/cloudbuild-nightly.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220609-2e4c91eb7e'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20241229-5dc092c636'
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220609-2e4c91eb7e'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20241229-5dc092c636'
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled


### PR DESCRIPTION
**What this PR does / why we need it**:

The image used in the postsubmit job that builds staging images was outdated. It had an image with go1.18 and could not build the image.

The postsubmit is defined here: https://github.com/kubernetes/test-infra/blob/db5b76499f19afb56681629ec1e1b9514e1ecf24/config/jobs/image-pushing/k8s-staging-cluster-api.yaml#L244

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2297

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
