### PR TITLE
🌱 Update OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -20,7 +20,8 @@ aliases:
     - vincepri
   cluster-api-openstack-maintainers:
     - emilienm
-    - jichenjc
     - lentzi90
     - mdbooth
   cluster-api-openstack-reviewers:
+  cluster-api-openstack-emeritus-maintainers:
+    - jichenjc


### PR DESCRIPTION
**What this PR does / why we need it**:

We were giving some time but it doesn't sound like jichenjc
is involved anymore, so let's update OWNERS_ALIASES and move him
to cluster-api-openstack-emeritus-maintainers.
