### PR TITLE
🌱 Use the same version of Go everywhere (latest: 1.23.4)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -182,7 +182,7 @@ issues:
   - "zz_generated.*\\.go$"
 
 run:
-  go: "1.22"
+  go: "1.23"
   timeout: 10m
   build-tags:
   - e2e

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 # Build the manager binary
 ARG GO_VERSION
-FROM golang:${GO_VERSION} as builder
+FROM golang:${GO_VERSION} AS builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg goproxy=$(go env GOPROXY) to override the goproxy

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ export GO111MODULE=on
 unexport GOPATH
 
 # Go
-GO_VERSION ?= 1.23.0
+GO_VERSION ?= 1.23.4
 
 # Directories.
 ARTIFACTS ?= $(REPO_ROOT)/_artifacts

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module sigs.k8s.io/cluster-api-provider-openstack
 
-go 1.23.0
-
-toolchain go1.23.4
+go 1.23.4
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,8 +1,6 @@
 module sigs.k8s.io/cluster-api-provider-openstack/hack/tools
 
-go 1.23.0
-
-toolchain go1.23.2
+go 1.23.4
 
 require (
 	github.com/a8m/envsubst v1.4.2

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@ command = "make -C docs/book build"
 publish = "docs/book/book"
 
 [build.environment]
-GO_VERSION = "1.22.6"
+GO_VERSION = "1.23.4"
 
 # Standard Netlify redirects
 [[redirects]]


### PR DESCRIPTION
This PR updates the Go version to 1.23.4 (current latest) for consistency.
