### PR TITLE
[release-0.10] 🐛 fix: create lbaas in specified subnet

### DIFF
--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -666,14 +666,19 @@ func resolveLoadBalancerNetwork(openStackCluster *infrav1.OpenStackCluster, netw
 
 			// Filter out only relevant subnets specified by the spec
 			lbNetStatus.Subnets = []infrav1.Subnet{}
-			for _, s := range lbSpec.Subnets {
+			for i := range lbSpec.Subnets {
+				s := lbSpec.Subnets[i]
 				matchFound := false
 				for _, subnetID := range lbNet.Subnets {
-					if s.ID != nil && subnetID == *s.ID {
+					subnet, err := networkingService.GetSubnetByParam(&s)
+					if s.ID != nil && subnetID == *s.ID && err == nil {
 						matchFound = true
 						lbNetStatus.Subnets = append(
 							lbNetStatus.Subnets, infrav1.Subnet{
-								ID: *s.ID,
+								ID:   subnet.ID,
+								Name: subnet.Name,
+								CIDR: subnet.CIDR,
+								Tags: subnet.Tags,
 							})
 					}
 				}
@@ -682,6 +687,8 @@ func resolveLoadBalancerNetwork(openStackCluster *infrav1.OpenStackCluster, netw
 					return fmt.Errorf("no subnet match was found in the specified network (specified subnet: %v, available subnets: %v)", s, lbNet.Subnets)
 				}
 			}
+
+			openStackCluster.Status.APIServerLoadBalancer.LoadBalancerNetwork = lbNetStatus
 		}
 	}
 

--- a/pkg/cloud/services/loadbalancer/loadbalancer.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer.go
@@ -294,9 +294,10 @@ func (s *Service) getOrCreateAPILoadBalancer(openStackCluster *infrav1.OpenStack
 	if vipNetworkID == "" && vipSubnetID == "" {
 		// keep the default and create the VIP on the first cluster subnet
 		vipSubnetID = openStackCluster.Status.Network.Subnets[0].ID
+		s.scope.Logger().Info("No load balancer network specified, creating load balancer in the default subnet", "subnetID", vipSubnetID, "name", loadBalancerName)
+	} else {
+		s.scope.Logger().Info("Creating load balancer in subnet", "subnetID", vipSubnetID, "name", loadBalancerName)
 	}
-
-	s.scope.Logger().Info("Creating load balancer in subnet", "subnetID", vipSubnetID, "name", loadBalancerName)
 
 	providers, err := s.loadbalancerClient.ListLoadBalancerProviders()
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a manual backport of https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/2339
The linter was not happy on the release-0.10 branch because of an older go version used.
It was hitting

```
G601: Implicit memory aliasing in for loop.
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
