### PR TITLE
🌱 hack/tools: bump gotestsum and golangci to latest tags

### DIFF
--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -15,10 +15,10 @@
 ROOT_DIR_RELATIVE := ../..
 include $(ROOT_DIR_RELATIVE)/common.mk
 
-GOLANGCI_LINT_VERSION ?= v1.61.0
+GOLANGCI_LINT_VERSION ?= v1.63.4
 
 # GOTESTSUM version without the leading 'v'
-GOTESTSUM_VERSION ?= 1.11.0
+GOTESTSUM_VERSION ?= 1.12.0
 
 # Directories.
 BIN_DIR := bin


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump golangci lint to v1.63.4 and gotestsum to 1.12.0 (latest tags).
