### PR TITLE
🐛 Stop printing InstanceState for OpenStackMachine

### DIFF
--- a/api/v1beta1/openstackmachine_types.go
+++ b/api/v1beta1/openstackmachine_types.go
@@ -199,6 +199,8 @@ type OpenStackMachineStatus struct {
 	Addresses []corev1.NodeAddress `json:"addresses,omitempty"`
 
 	// InstanceState is the state of the OpenStack instance for this machine.
+	// This field is not set anymore by the OpenStackMachine controller.
+	// Instead, it's set by the OpenStackServer controller.
 	// +optional
 	InstanceState *InstanceState `json:"instanceState,omitempty"`
 
@@ -241,7 +243,6 @@ type OpenStackMachineStatus struct {
 // +kubebuilder:resource:path=openstackmachines,scope=Namespaced,categories=cluster-api,shortName=osm
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this OpenStackMachine belongs"
-// +kubebuilder:printcolumn:name="InstanceState",type="string",JSONPath=".status.instanceState",description="OpenStack instance state"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Machine ready status"
 // +kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="OpenStack instance ID"
 // +kubebuilder:printcolumn:name="Machine",type="string",JSONPath=".metadata.ownerReferences[?(@.kind==\"Machine\")].name",description="Machine object which owns with this OpenStackMachine"

--- a/cmd/models-schema/zz_generated.openapi.go
+++ b/cmd/models-schema/zz_generated.openapi.go
@@ -21537,7 +21537,7 @@ func schema_sigsk8sio_cluster_api_provider_openstack_api_v1beta1_OpenStackMachin
 					},
 					"instanceState": {
 						SchemaProps: spec.SchemaProps{
-							Description: "InstanceState is the state of the OpenStack instance for this machine.",
+							Description: "InstanceState is the state of the OpenStack instance for this machine. This field is not set anymore by the OpenStackMachine controller. Instead, it's set by the OpenStackServer controller.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
@@ -547,10 +547,6 @@ spec:
       jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
       name: Cluster
       type: string
-    - description: OpenStack instance state
-      jsonPath: .status.instanceState
-      name: InstanceState
-      type: string
     - description: Machine ready status
       jsonPath: .status.ready
       name: Ready
@@ -1555,8 +1551,10 @@ spec:
                 description: InstanceID is the OpenStack instance ID for this machine.
                 type: string
               instanceState:
-                description: InstanceState is the state of the OpenStack instance
-                  for this machine.
+                description: |-
+                  InstanceState is the state of the OpenStack instance for this machine.
+                  This field is not set anymore by the OpenStackMachine controller.
+                  Instead, it's set by the OpenStackServer controller.
                 type: string
               ready:
                 description: Ready is true when the provider resource is ready.

--- a/docs/book/src/api/v1beta1/api.md
+++ b/docs/book/src/api/v1beta1/api.md
@@ -3548,7 +3548,9 @@ InstanceState
 </td>
 <td>
 <em>(Optional)</em>
-<p>InstanceState is the state of the OpenStack instance for this machine.</p>
+<p>InstanceState is the state of the OpenStack instance for this machine.
+This field is not set anymore by the OpenStackMachine controller.
+Instead, it&rsquo;s set by the OpenStackServer controller.</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
**What this PR does / why we need it**:

`InstanceState` was copied to the `OpenStackServer` API and the
`OpenStackMachine` controller doesn't care about this field anymore.
The field still exists for backward compatibility but it was decided
long time ago (when we worked on the `OpenStackServer` API) that it
wouldn't be populated anymore.
We missed to stop printing this field when listing the
`OpenStackMachines`.

Also, we now document that the field is not populated anymore. This was
also a miss.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2400
