### PR TITLE
🌱 dependabot: ignore CAPI tag changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,6 +46,8 @@ updates:
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
   # We will need k8s v0.31.3 to bump structured-merge-diff to v4.4.2 (check git history for details).
   - dependency-name: "sigs.k8s.io/structured-merge-diff/*"
+  # For now we deploy CAPI from an unreleased commit
+  - dependency-name: "sigs.k8s.io/cluster-api*"
   labels:
     - "area/dependency"
     - "ok-to-test"


### PR DESCRIPTION
**What this PR does / why we need it**:

dependabot tries to bump CAPI to the latest tag but right now we use an
unreleased commit.
