### PR TITLE
🌱 go.mod: stick to 1.23.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api-provider-openstack
 
-go 1.23.4
+go 1.23.0
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api-provider-openstack/hack/tools
 
-go 1.23.4
+go 1.23.0
 
 require (
 	github.com/a8m/envsubst v1.4.2


### PR DESCRIPTION
**What this PR does / why we need it**:

Specifying the patch version is not needed and can causes problems on systems which haven't updated yet to the 1.23.4.
