### PR TITLE
fix: allow modification of all ManagedSecurityGroups

### DIFF
--- a/pkg/webhooks/openstackcluster_webhook.go
+++ b/pkg/webhooks/openstackcluster_webhook.go
@@ -119,7 +119,7 @@ func (*openStackClusterWebhook) ValidateUpdate(_ context.Context, oldObjRaw, new
 	oldObj.Spec.Bastion = &infrav1.Bastion{}
 	newObj.Spec.Bastion = &infrav1.Bastion{}
 
-	// Allow changes to the managed allNodesSecurityGroupRules.
+	// Allow changes to the managed securityGroupRules.
 	if newObj.Spec.ManagedSecurityGroups != nil {
 		if oldObj.Spec.ManagedSecurityGroups == nil {
 			oldObj.Spec.ManagedSecurityGroups = &infrav1.ManagedSecurityGroups{}
@@ -127,6 +127,12 @@ func (*openStackClusterWebhook) ValidateUpdate(_ context.Context, oldObjRaw, new
 
 		oldObj.Spec.ManagedSecurityGroups.AllNodesSecurityGroupRules = []infrav1.SecurityGroupRuleSpec{}
 		newObj.Spec.ManagedSecurityGroups.AllNodesSecurityGroupRules = []infrav1.SecurityGroupRuleSpec{}
+
+		oldObj.Spec.ManagedSecurityGroups.ControlPlaneNodesSecurityGroupRules = []infrav1.SecurityGroupRuleSpec{}
+		newObj.Spec.ManagedSecurityGroups.ControlPlaneNodesSecurityGroupRules = []infrav1.SecurityGroupRuleSpec{}
+
+		oldObj.Spec.ManagedSecurityGroups.WorkerNodesSecurityGroupRules = []infrav1.SecurityGroupRuleSpec{}
+		newObj.Spec.ManagedSecurityGroups.WorkerNodesSecurityGroupRules = []infrav1.SecurityGroupRuleSpec{}
 
 		// Allow change to the allowAllInClusterTraffic.
 		oldObj.Spec.ManagedSecurityGroups.AllowAllInClusterTraffic = false

--- a/pkg/webhooks/openstackcluster_webhook_test.go
+++ b/pkg/webhooks/openstackcluster_webhook_test.go
@@ -165,6 +165,94 @@ func TestOpenStackCluster_ValidateUpdate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "Changing security group rules on the OpenStackCluster.Spec.ManagedSecurityGroups.ControlPlaneNodesSecurityGroupRules is allowed",
+			oldTemplate: &infrav1.OpenStackCluster{
+				Spec: infrav1.OpenStackClusterSpec{
+					IdentityRef: infrav1.OpenStackIdentityReference{
+						Name:      "foobar",
+						CloudName: "foobar",
+					},
+					ManagedSecurityGroups: &infrav1.ManagedSecurityGroups{
+						ControlPlaneNodesSecurityGroupRules: []infrav1.SecurityGroupRuleSpec{
+							{
+								Name:                "foobar",
+								Description:         ptr.To("foobar"),
+								PortRangeMin:        ptr.To(80),
+								PortRangeMax:        ptr.To(80),
+								Protocol:            ptr.To("tcp"),
+								RemoteManagedGroups: []infrav1.ManagedSecurityGroupName{"controlplane"},
+							},
+						},
+					},
+				},
+			},
+			newTemplate: &infrav1.OpenStackCluster{
+				Spec: infrav1.OpenStackClusterSpec{
+					IdentityRef: infrav1.OpenStackIdentityReference{
+						Name:      "foobar",
+						CloudName: "foobar",
+					},
+					ManagedSecurityGroups: &infrav1.ManagedSecurityGroups{
+						ControlPlaneNodesSecurityGroupRules: []infrav1.SecurityGroupRuleSpec{
+							{
+								Name:                "foobar",
+								Description:         ptr.To("foobar"),
+								PortRangeMin:        ptr.To(80),
+								PortRangeMax:        ptr.To(80),
+								Protocol:            ptr.To("tcp"),
+								RemoteManagedGroups: []infrav1.ManagedSecurityGroupName{"controlplane", "worker"},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Changing security group rules on the OpenStackCluster.Spec.ManagedSecurityGroups.WorkerNodesSecurityGroupRules is allowed",
+			oldTemplate: &infrav1.OpenStackCluster{
+				Spec: infrav1.OpenStackClusterSpec{
+					IdentityRef: infrav1.OpenStackIdentityReference{
+						Name:      "foobar",
+						CloudName: "foobar",
+					},
+					ManagedSecurityGroups: &infrav1.ManagedSecurityGroups{
+						WorkerNodesSecurityGroupRules: []infrav1.SecurityGroupRuleSpec{
+							{
+								Name:                "foobar",
+								Description:         ptr.To("foobar"),
+								PortRangeMin:        ptr.To(80),
+								PortRangeMax:        ptr.To(80),
+								Protocol:            ptr.To("tcp"),
+								RemoteManagedGroups: []infrav1.ManagedSecurityGroupName{"worker"},
+							},
+						},
+					},
+				},
+			},
+			newTemplate: &infrav1.OpenStackCluster{
+				Spec: infrav1.OpenStackClusterSpec{
+					IdentityRef: infrav1.OpenStackIdentityReference{
+						Name:      "foobar",
+						CloudName: "foobar",
+					},
+					ManagedSecurityGroups: &infrav1.ManagedSecurityGroups{
+						WorkerNodesSecurityGroupRules: []infrav1.SecurityGroupRuleSpec{
+							{
+								Name:                "foobar",
+								Description:         ptr.To("foobar"),
+								PortRangeMin:        ptr.To(80),
+								PortRangeMax:        ptr.To(80),
+								Protocol:            ptr.To("tcp"),
+								RemoteManagedGroups: []infrav1.ManagedSecurityGroupName{"worker", "controlplane"},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "Changing CIDRs on the OpenStackCluster.Spec.APIServerLoadBalancer.AllowedCIDRs is allowed",
 			oldTemplate: &infrav1.OpenStackCluster{
 				Spec: infrav1.OpenStackClusterSpec{


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

controlplane and worker security groups weren't allowed to be changed, this PR changes that.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
