### PR TITLE
🌱 ci: add GH workflow to automate golangci-lint bumps

### DIFF
--- a/.github/workflows/update-golangci-lint.yaml
+++ b/.github/workflows/update-golangci-lint.yaml
@@ -1,0 +1,42 @@
+name: Update golangci-lint version
+
+on:
+  schedule:
+    - cron: '0 0 * * 1' # Runs every Monday at midnight UTC
+  workflow_dispatch: # Allows manual triggering
+
+jobs:
+  update-golangci-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get latest golangci-lint version
+        id: get_version
+        run: |
+          LATEST_VERSION=$(curl -s https://api.github.com/repos/golangci/golangci-lint/releases/latest | jq -r .tag_name | sed 's/v//')
+          echo "LATEST_VERSION=$LATEST_VERSION" >> $GITHUB_ENV
+          echo "Latest version: $LATEST_VERSION"
+
+      - name: Check current version in Makefile
+        id: check_version
+        run: |
+          CURRENT_VERSION=$(grep 'GOLANGCI_LINT_VERSION' hack/tools/Makefile | cut -d '=' -f2 | tr -d ' ')
+          echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
+          echo "Current version: $CURRENT_VERSION"
+
+      - name: Update Makefile if needed
+        if: env.CURRENT_VERSION != env.LATEST_VERSION
+        run: |
+          sed -i "s/GOLANGCI_LINT_VERSION=.*/GOLANGCI_LINT_VERSION=${LATEST_VERSION}/" hack/tools/Makefile
+
+      - uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # tag=v9.1.4
+        name: Commit changes
+        with:
+          author_name: github-actions[bot]
+          author_email: github-actions[bot]@users.noreply.github.com
+          default_author: github_actor
+          message: "chore: bump golangci-lint to v${LATEST_VERSION}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a new GH action to periodically bump the golangci-lint when a new tag is available.
