### PR TITLE
[release-0.11] 🌱 Bump golangci-lint to support go1.24

### DIFF
--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -15,7 +15,7 @@
 ROOT_DIR_RELATIVE := ../..
 include $(ROOT_DIR_RELATIVE)/common.mk
 
-GOLANGCI_LINT_VERSION ?= v1.61.0
+GOLANGCI_LINT_VERSION ?= v1.64.6
 
 # GOTESTSUM version without the leading 'v'
 GOTESTSUM_VERSION ?= 1.11.0

--- a/orc/Makefile
+++ b/orc/Makefile
@@ -184,7 +184,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 KUSTOMIZE_VERSION ?= v5.4.2
 CONTROLLER_TOOLS_VERSION ?= v0.16.4
 ENVTEST_VERSION ?= release-0.18
-GOLANGCI_LINT_VERSION ?= v1.61.0
+GOLANGCI_LINT_VERSION ?= v1.64.6
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.


### PR DESCRIPTION
This is a manual cherry-pick of #2448.
