### PR TITLE
🌱(deps): skip golang.org/x/text on release-0.11

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -158,6 +158,7 @@ updates:
   # These dependencies are skipped because they require a newer version of go:
   - dependency-name: "golang.org/x/crypto"
   - dependency-name: "github.com/a8m/envsubst"
+  - dependency-name: "golang.org/x/text"
   labels:
     - "area/dependency"
     - "ok-to-test"


### PR DESCRIPTION
**What this PR does / why we need it**:

The new version requires go 1.23 and we don't want it.
