### PR TITLE
🌱 deps: skip github.com/onsi/ginkgo/v2 on release-0.11

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -159,6 +159,7 @@ updates:
   - dependency-name: "golang.org/x/crypto"
   - dependency-name: "github.com/a8m/envsubst"
   - dependency-name: "golang.org/x/text"
+  - dependency-name: "github.com/onsi/ginkgo/v2"
   labels:
     - "area/dependency"
     - "ok-to-test"


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/onsi/ginkgo/commit/37a511b5bca15e628309b421c20e834b7f67dad4

This commit now requires golang >= 1.23 which we don't have in 0.11 so
we now skip new versions of ginkgo on release-0.11 branch.
