### PR TITLE
Fix panic when OpenStack server is deleted by an external agent

### DIFF
--- a/api/v1beta1/conditions_consts.go
+++ b/api/v1beta1/conditions_consts.go
@@ -44,6 +44,9 @@ const (
 	OpenStackErrorReason = "OpenStackError"
 	// DependencyFailedReason indicates that a dependent object failed.
 	DependencyFailedReason = "DependencyFailed"
+
+	// ServerUnexpectedDeletedMessage is the message used when the server is unexpectedly deleted via an external agent.
+	ServerUnexpectedDeletedMessage = "The server was unexpectedly deleted"
 )
 
 const (

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -201,6 +201,7 @@ intervals:
   default/wait-control-plane: ["30m", "10s"]
   default/wait-worker-nodes: ["30m", "10s"]
   default/wait-delete-cluster: ["5m", "10s"]
+  default/wait-delete-machine: ["30m", "10s"]
   default/wait-alt-az: ["20m", "30s"]
   default/wait-machine-upgrade: ["30m", "10s"]
   default/wait-nodes-ready: ["15m", "10s"]

--- a/test/e2e/shared/openstack.go
+++ b/test/e2e/shared/openstack.go
@@ -846,6 +846,21 @@ func CreateOpenStackNetwork(e2eCtx *E2EContext, name, cidr string) (*networks.Ne
 	return net, nil
 }
 
+func DeleteOpenStackServer(ctx context.Context, e2eCtx *E2EContext, id string) error {
+	providerClient, clientOpts, _, err := GetTenantProviderClient(e2eCtx)
+	if err != nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "error creating provider client: %s\n", err)
+		return err
+	}
+
+	computeClient, err := openstack.NewComputeV2(providerClient, gophercloud.EndpointOpts{Region: clientOpts.RegionName})
+	if err != nil {
+		return fmt.Errorf("error creating compute client: %s", err)
+	}
+
+	return servers.Delete(ctx, computeClient, id).ExtractErr()
+}
+
 func DeleteOpenStackNetwork(ctx context.Context, e2eCtx *E2EContext, id string) error {
 	providerClient, clientOpts, _, err := GetTenantProviderClient(e2eCtx)
 	if err != nil {


### PR DESCRIPTION
The panic happened because we did not correctly handle that GetInstanceStatus returns a nil server if the server does not exist, rather than a 404 error.

We had the same oversight in the OpenStackServer controller. It looks like this would have resulted in recreating the server.

Fixes: #2474

/hold
