### PR TITLE
ci: build e2e prerequisites in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ $(E2E_NO_ARTIFACT_TEMPLATES_DIR)/cluster-template.yaml: $(E2E_KUSTOMIZE_DIR)/wit
 $(E2E_NO_ARTIFACT_TEMPLATES_DIR)/cluster-template-%.yaml: $(E2E_KUSTOMIZE_DIR)/% $(KUSTOMIZE) FORCE
 	$(KUSTOMIZE) build "$<" > "$@"
 
-e2e-prerequisites: e2e-templates e2e-image test-e2e-image-prerequisites ## Build all artifacts required by e2e tests
+e2e-prerequisites: $(GINKGO) e2e-templates e2e-image test-e2e-image-prerequisites ## Build all artifacts required by e2e tests
 
 # Can be run manually, e.g. via:
 # export OPENSTACK_CLOUD_YAML_FILE="$(pwd)/clouds.yaml"
@@ -197,6 +197,12 @@ test-e2e: $(GINKGO) e2e-prerequisites ## Run e2e tests
 		-focus="$(E2E_GINKGO_FOCUS)" $(_SKIP_ARGS) $(E2E_GINKGO_ARGS) ./test/e2e/suites/e2e/... -- \
 			-config-path="$(E2E_CONF_PATH)" -artifacts-folder="$(ARTIFACTS)" \
 			-data-folder="$(E2E_DATA_DIR)" $(E2E_ARGS)
+
+# Pre-compile tests
+# This is not required, but it will make the tests start faster
+.PHONY: build-e2e-tests
+build-e2e-tests: $(GINKGO)
+	$(GINKGO) build -tags=e2e ./test/e2e/suites/e2e/...
 
 .PHONY: e2e-image
 e2e-image: CONTROLLER_IMG_TAG = "gcr.io/k8s-staging-capi-openstack/capi-openstack-controller:e2e"

--- a/hack/ci/common.sh
+++ b/hack/ci/common.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# retry $1 times with $2 sleep in between
+function retry {
+    attempt=0
+    max_attempts=${1}
+    interval=${2}
+    shift; shift
+    until [[ "$attempt" -ge "$max_attempts" ]] ; do
+        attempt=$((attempt+1))
+        set +e
+        eval "$*" && return || echo "failed $attempt times: $*"
+        set -e
+        sleep "$interval"
+    done
+    echo "error: reached max attempts at retry($*)"
+    return 1
+}
+
+function wait_for_ssh {
+    local ip=$1 && shift
+
+    retry 10 30 "$(get_ssh_cmd) ${ip} -- true"
+}
+
+function get_ssh_cmd {
+    echo "ssh -l cloud $(get_ssh_common_args)"
+}
+
+function get_ssh_common_args {
+    local private_key_file=$(get_ssh_private_key_file)
+    if [ -z "$private_key_file" ]; then
+        # If there's no private key file use the public key instead
+        # This allows us to specify a private key which is held only on a
+        # hardware device and therefore has no key file
+        private_key_file=$(get_ssh_public_key_file)
+    fi
+
+    echo "-i ${private_key_file} " \
+         "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o PasswordAuthentication=no "
+}


### PR DESCRIPTION
With this change we build the prerequisites of the e2e tests in parallel with the devstack build. We also upload the e2e image to devstack while devstack is still building, as soon as SSH is available.

This seems to result in an approximately 10 minute speed-up.

/hold
