### PR TITLE
OpenStackServer controller: minor log message fix

### DIFF
--- a/controllers/openstackserver_controller.go
+++ b/controllers/openstackserver_controller.go
@@ -106,7 +106,7 @@ func (r *OpenStackServerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 	if cluster != nil {
 		if annotations.IsPaused(cluster, openStackServer) {
-			scope.Logger().Info("OpenStackServer %s/%s linked to a Cluster that is paused. Won't reconcile", openStackServer.Namespace, openStackServer.Name)
+			scope.Logger().Info("OpenStackServer linked to a Cluster that is paused. Won't reconcile")
 			return reconcile.Result{}, nil
 		}
 	}


### PR DESCRIPTION
This fixes a bad error message format, wtih "%s" appearing in the log message ("OpenStackServer %s/%s linked to..."):

```
I0317 13:20:19.512088  1 openstackserver_controller.go:109] 
    "OpenStackServer %s/%s linked to a Cluster that is paused. Won't reconcile" 
    controllerGroup="infrastructure.cluster.x-k8s.io" 
controllerKind="OpenStackServer" 
OpenStackServer="sylva-system/management-cluster-cp-f7843e31d7-rbv5c" 
namespace="sylva-system" 
name="management-cluster-cp-f7843e31d7-rbv5c" 
reconcileID="a0e2f500-ae75-47af-bc3b-85bb9ae4b59b" 
sylva-system="management-cluster-cp-f7843e31d7-rbv5c"
```

We in fact don't need the "%s/%s" and also the additional parameters aren't needed because the logger is derived from "scope" and already logging the server name and namespace.

