### PR TITLE
🌱(deps): skip github.com/onsi/gomega on release-0.11

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -160,6 +160,7 @@ updates:
   - dependency-name: "github.com/a8m/envsubst"
   - dependency-name: "golang.org/x/text"
   - dependency-name: "github.com/onsi/ginkgo/v2"
+  - dependency-name: "github.com/onsi/gomega"
   labels:
     - "area/dependency"
     - "ok-to-test"


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/onsi/gomega/commit/adb8b4976faa398931a6fb1c5fe17eda7dbe72c7
is not compatible with release-0.11 since it bumps the version of
Golang.
