### PR TITLE
✨ Allow changing DNSNameservers in subnet config for OpenstackCluster

### DIFF
--- a/pkg/cloud/services/networking/network.go
+++ b/pkg/cloud/services/networking/network.go
@@ -201,6 +201,10 @@ func (s *Service) ReconcileSubnet(openStackCluster *infrav1.OpenStackCluster, cl
 	} else if len(subnetList) == 1 {
 		subnet = &subnetList[0]
 		s.scope.Logger().V(6).Info("Reusing existing subnet", "name", subnet.Name, "id", subnet.ID)
+
+		if err := s.updateSubnetDNSNameservers(openStackCluster, subnet); err != nil {
+			return err
+		}
 	}
 
 	openStackCluster.Status.Network.Subnets = []infrav1.Subnet{
@@ -246,6 +250,44 @@ func (s *Service) createSubnet(openStackCluster *infrav1.OpenStackCluster, clust
 	}
 
 	return subnet, nil
+}
+
+// updateSubnetDNSNameservers updates the DNS nameservers for an existing subnet if they differ from the desired configuration
+func (s *Service) updateSubnetDNSNameservers(openStackCluster *infrav1.OpenStackCluster, subnet *subnets.Subnet) error {
+	// Picking the first managed subnet since we only support one for now
+	desiredNameservers := openStackCluster.Spec.ManagedSubnets[0].DNSNameservers
+	currentNameservers := subnet.DNSNameservers
+
+	needsUpdate := false
+	if len(desiredNameservers) != len(currentNameservers) {
+		needsUpdate = true
+	} else {
+		for i, ns := range desiredNameservers {
+			if i >= len(currentNameservers) || ns != currentNameservers[i] {
+				needsUpdate = true
+				break
+			}
+		}
+	}
+
+	if needsUpdate {
+		s.scope.Logger().Info("Updating subnet DNS nameservers", "id", subnet.ID, "from", currentNameservers, "to", desiredNameservers)
+
+		updateOpts := subnets.UpdateOpts{
+			DNSNameservers: &desiredNameservers,
+		}
+
+		updatedSubnet, err := s.client.UpdateSubnet(subnet.ID, updateOpts)
+		if err != nil {
+			record.Warnf(openStackCluster, "FailedUpdateSubnet", "Failed to update DNS nameservers for subnet %s: %v", subnet.ID, err)
+			return err
+		}
+
+		*subnet = *updatedSubnet
+		record.Eventf(openStackCluster, "SuccessfulUpdateSubnet", "Updated DNS nameservers for subnet %s", subnet.ID)
+	}
+
+	return nil
 }
 
 func (s *Service) getNetworkByName(networkName string) (networks.Network, error) {

--- a/pkg/webhooks/openstackcluster_webhook.go
+++ b/pkg/webhooks/openstackcluster_webhook.go
@@ -139,6 +139,62 @@ func (*openStackClusterWebhook) ValidateUpdate(_ context.Context, oldObjRaw, new
 		newObj.Spec.ManagedSecurityGroups.AllowAllInClusterTraffic = false
 	}
 
+	// Allow changes only to DNSNameservers in ManagedSubnets spec
+	if newObj.Spec.ManagedSubnets != nil && oldObj.Spec.ManagedSubnets != nil {
+		// Check if any fields other than DNSNameservers have changed
+		if len(oldObj.Spec.ManagedSubnets) != len(newObj.Spec.ManagedSubnets) {
+			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "managedSubnets"), "cannot add or remove subnets"))
+		} else {
+			// Build maps of subnets by CIDR
+			oldSubnetMap := make(map[string]infrav1.SubnetSpec)
+			newSubnetMap := make(map[string]infrav1.SubnetSpec)
+
+			for _, subnet := range oldObj.Spec.ManagedSubnets {
+				oldSubnetMap[subnet.CIDR] = subnet
+			}
+
+			// Check if all new subnets have matching old subnets with the same CIDR
+			for _, newSubnet := range newObj.Spec.ManagedSubnets {
+				oldSubnet, exists := oldSubnetMap[newSubnet.CIDR]
+				if !exists {
+					allErrs = append(allErrs, field.Forbidden(
+						field.NewPath("spec", "managedSubnets"),
+						fmt.Sprintf("cannot change subnet CIDR from existing value to %s", newSubnet.CIDR),
+					))
+					continue
+				}
+
+				// Check if AllocationPools have changed
+				if !reflect.DeepEqual(oldSubnet.AllocationPools, newSubnet.AllocationPools) {
+					allErrs = append(allErrs, field.Forbidden(
+						field.NewPath("spec", "managedSubnets").Child("allocationPools"),
+						"cannot modify allocation pools in existing subnet",
+					))
+				}
+
+				newSubnetMap[newSubnet.CIDR] = newSubnet
+			}
+
+			// Create modified copies of the subnets with DNSNameservers cleared
+			oldSubnets := make([]infrav1.SubnetSpec, 0, len(oldObj.Spec.ManagedSubnets))
+			newSubnets := make([]infrav1.SubnetSpec, 0, len(newObj.Spec.ManagedSubnets))
+			for _, subnet := range oldObj.Spec.ManagedSubnets {
+				subnetCopy := subnet
+				subnetCopy.DNSNameservers = nil
+				oldSubnets = append(oldSubnets, subnetCopy)
+
+				if newSubnet, exists := newSubnetMap[subnet.CIDR]; exists {
+					newSubnetCopy := newSubnet
+					newSubnetCopy.DNSNameservers = nil
+					newSubnets = append(newSubnets, newSubnetCopy)
+				}
+			}
+
+			oldObj.Spec.ManagedSubnets = oldSubnets
+			newObj.Spec.ManagedSubnets = newSubnets
+		}
+	}
+
 	// Allow changes on AllowedCIDRs
 	if newObj.Spec.APIServerLoadBalancer != nil && oldObj.Spec.APIServerLoadBalancer != nil {
 		oldObj.Spec.APIServerLoadBalancer.AllowedCIDRs = []string{}


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows changing DNSNameservers in subnet config for OpenstackCluster after the initial deployment

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2468

/hold
