### PR TITLE
✨ allow switching from network.filter.name to network.id in OSC spec

### DIFF
--- a/pkg/webhooks/openstackcluster_webhook.go
+++ b/pkg/webhooks/openstackcluster_webhook.go
@@ -159,6 +159,13 @@ func (*openStackClusterWebhook) ValidateUpdate(_ context.Context, oldObjRaw, new
 		newObj.Spec.APIServerFloatingIP = nil
 		oldObj.Spec.APIServerFloatingIP = nil
 	}
+	// Allow change from spec.network.filter to spec.network.id only if it matches the current network.
+	if newObj.Spec.network != nil && oldObj.Spec.network != nil {
+		if ptr.Deref(newObj.Spec.network.id, "") == oldObj.Status.network.id {
+			newObj.Spec.network.id = nil
+			oldObj.Spec.network.id = nil
+		}
+	}
 
 	if !reflect.DeepEqual(oldObj.Spec, newObj.Spec) {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec"), "cannot be modified"))


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows switching from `spec.network.filter.name` to `spec.network.id` in OpenstackCluster webhook.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
