### PR TITLE
:seedling: dependabot/0.11: skip mock bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -161,6 +161,7 @@ updates:
   - dependency-name: "golang.org/x/text"
   - dependency-name: "github.com/onsi/ginkgo/v2"
   - dependency-name: "github.com/onsi/gomega"
+  - dependency-name: "go.uber.org/mock"
   labels:
     - "area/dependency"
     - "ok-to-test"


### PR DESCRIPTION
**What this PR does / why we need it**:

It requires a newer version of Go since:
https://github.com/uber-go/mock/commit/8ce01ac54df4c2f4443bbe7de345188289af8c4e
