### PR TITLE
🌱 Bump cloud-build image to support go 1.23

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,15 +4,19 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20241229-5dc092c636'
-    entrypoint: make
-    env:
-    - DOCKER_CLI_EXPERIMENTAL=enabled
-    - TAG=$_GIT_TAG
-    - PULL_BASE_REF=$_PULL_BASE_REF
-    - DOCKER_BUILDKIT=1
-    args:
-    - release-staging
+# To check if the image can handle the build, you can try it like this:
+# docker run --rm -it -v $(pwd):/workspace gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:${TAG}
+# make clean # make sure we have something to build
+# make staging-manifests
+- name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250116-2a05ea7e3d'
+  entrypoint: make
+  env:
+  - DOCKER_CLI_EXPERIMENTAL=enabled
+  - TAG=$_GIT_TAG
+  - PULL_BASE_REF=$_PULL_BASE_REF
+  - DOCKER_BUILDKIT=1
+  args:
+  - release-staging
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

I noticed that the cloud-build was showing errors while doing the releases. It is due to the image used. It did not have go1.23, which is required since release-0.12 in CAPO. Container image builds still worked because those are built inside a build container.
The cloud-build has been failing with errors like this:

```
make -C hack/tools bin/kustomize
make[4]: Entering directory '/workspace/hack/tools'
mkdir -p bin
CGO_ENABLED=0 go build -tags=tools -o bin/kustomize sigs.k8s.io/kustomize/kustomize/v5
go: go.mod requires go >= 1.23.0 (running go 1.22.9; GOTOOLCHAIN=local)
make[4]: *** [Makefile:115: bin/kustomize] Error 1
make[4]: Leaving directory '/workspace/hack/tools'
make[3]: Leaving directory '/workspace'
make[3]: *** [common.mk:49: hack/tools/bin/kustomize] Error 2
make[2]: *** [Makefile:497: out/infrastructure-components.yaml] Error 2
make[2]: Leaving directory '/workspace'
make[1]: *** [Makefile:365: staging-manifests] Error 2
make[1]: Leaving directory '/workspace'
make: *** [Makefile:434: release-staging] Error 2
ERROR
ERROR: build step 0 "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20241229-5dc092c636" failed: step exited with non-zero status: 2
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests
