### PR TITLE
🌱 E2E: Bump ORC to v2.2.0

### DIFF
--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -16,7 +16,7 @@ images:
 # Use local dev images built source tree;
 - name: gcr.io/k8s-staging-capi-openstack/capi-openstack-controller:e2e
   loadBehavior: mustLoad
-- name: quay.io/orc/openstack-resource-controller:v2.0.3
+- name: quay.io/orc/openstack-resource-controller:v2.2.0
   loadBehavior: tryLoad
 
 providers:
@@ -137,7 +137,7 @@ providers:
 - name: openstack-resource-controller
   type: RuntimeExtensionProvider # ORC isn't a provider but we fake it so it can be handled by the clusterctl machinery.
   versions:
-  - name: v2.0.99
+  - name: v2.2.0
     value: ../../../../cluster-api-provider-openstack/test/infrastructure/openstack-resource-controller/config/default
     contract: v1beta1
     files:

--- a/test/e2e/data/shared/openstack-resource-controller/metadata.yaml
+++ b/test/e2e/data/shared/openstack-resource-controller/metadata.yaml
@@ -8,3 +8,9 @@ releaseSeries:
 - major: 2
   minor: 0
   contract: v1beta1
+- major: 2
+  minor: 1
+  contract: v1beta1
+- major: 2
+  minor: 2
+  contract: v1beta1

--- a/test/e2e/shared/openstack.go
+++ b/test/e2e/shared/openstack.go
@@ -139,6 +139,26 @@ func dumpOpenStack(_ context.Context, e2eCtx *E2EContext, bootstrapClusterProxyN
 	if err := dumpOpenStackVolumes(e2eCtx, logPath); err != nil {
 		_, _ = fmt.Fprintf(GinkgoWriter, "error dumping OpenStack volumes: %s\n", err)
 	}
+
+	if err := dumpOpenStackServers(e2eCtx, logPath); err != nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "error dumping OpenStack servers: %s\n", err)
+	}
+}
+
+// dumpOpenStackServers writes all OpenStack servers to servers.json under the logPath.
+func dumpOpenStackServers(e2eCtx *E2EContext, logPath string) error {
+	serversList, err := DumpOpenStackServers(e2eCtx, servers.ListOpts{})
+	if err != nil {
+		return err
+	}
+	serversJSON, err := json.MarshalIndent(serversList, "", "    ")
+	if err != nil {
+		return fmt.Errorf("error marshalling servers %v: %s", serversList, err)
+	}
+	if err := os.WriteFile(path.Join(logPath, "servers.json"), serversJSON, 0o600); err != nil {
+		return fmt.Errorf("error writing servers.json %s: %s", serversJSON, err)
+	}
+	return nil
 }
 
 // dumpOpenStackVolumes returns all OpenStack volumes to a file in the artifact folder.

--- a/test/infrastructure/openstack-resource-controller/config/default/kustomization.yaml
+++ b/test/infrastructure/openstack-resource-controller/config/default/kustomization.yaml
@@ -8,4 +8,4 @@ labels:
     cluster.x-k8s.io/provider: "runtime-extension-openstack-resource-controller"
 
 resources:
-- https://github.com/k-orc/openstack-resource-controller/releases/download/v2.0.3/install.yaml
+- https://github.com/k-orc/openstack-resource-controller/releases/download/v2.2.0/install.yaml


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Bump ORC in e2e tests. We already bumped to go module.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
