### PR TITLE
🌱 Make security scanners happy release-0.11

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,4 @@
+# These require updating the go version to 1.23.
+# According to govulncheck we are not using code that is affected by them anyway
+CVE-2025-22870
+CVE-2025-22872

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.22.0 as builder
+ARG GO_VERSION
+FROM golang:${GO_VERSION} AS builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg goproxy=$(go env GOPROXY) to override the goproxy
@@ -30,7 +31,7 @@ COPY orc/go.sum orc/go.sum
 # Cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN --mount=type=cache,target=/go/pkg/mod \
-    go mod download
+  go mod download
 
 # Copy the sources
 COPY ./ ./
@@ -42,10 +43,10 @@ ARG ldflags
 
 # Do not force rebuild of up-to-date packages (do not use -a) and use the compiler cache folder
 RUN --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg/mod \
-    CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
-    go build -ldflags "${ldflags} -extldflags '-static'" \
-    -o manager ${package}
+  --mount=type=cache,target=/go/pkg/mod \
+  CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
+  go build -ldflags "${ldflags} -extldflags '-static'" \
+  -o manager ${package}
 
 # Production image
 FROM gcr.io/distroless/static:nonroot

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ unexport GOPATH
 TRACE ?= 0
 
 # Go
-GO_VERSION ?= 1.22.7
+GO_VERSION ?= 1.22.12
 
 # Directories.
 ARTIFACTS ?= $(REPO_ROOT)/_artifacts

--- a/Makefile
+++ b/Makefile
@@ -359,7 +359,7 @@ generate-api-docs-%: $(GEN_CRD_API_REFERENCE_DOCS) FORCE
 
 .PHONY: docker-build
 docker-build: ## Build the docker image for controller-manager
-	docker build -f Dockerfile --build-arg goproxy=$(GOPROXY) --build-arg ARCH=$(ARCH) --build-arg ldflags="$(LDFLAGS)" . -t $(CONTROLLER_IMG_TAG)
+	docker build -f Dockerfile --build-arg GO_VERSION=$(GO_VERSION) --build-arg goproxy=$(GOPROXY) --build-arg ARCH=$(ARCH) --build-arg ldflags="$(LDFLAGS)" . -t $(CONTROLLER_IMG_TAG)
 
 .PHONY: docker-push
 docker-push: ## Push the docker image


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR consists of:
1. a backport of https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/2337
2. a bump of the go version to 1.22.12. Fixes [GO-2025-3563](https://pkg.go.dev/vuln/GO-2025-3563), [GO-2025-3447](https://pkg.go.dev/vuln/GO-2025-3447),  [GO-2025-3420](https://pkg.go.dev/vuln/GO-2025-3420) and [GO-2025-3373](https://pkg.go.dev/vuln/GO-2025-3373) (see the [security scan job](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/actions/runs/15109209113/job/42606231041)).
3. adding .trivyignore to ignore false positives or vulnerabilities we cannot patch.
Specifically, we ignore CVE-2025-22870 and CVE-2025-22872, which would require go version 1.23 (which we cannot do on release branches).
According to govulncheck, we are not affected by them anyway. This was checked by running govulncheck with `-show verbose`. It then lists the vulnerabilities even when not relevant so that this can be cross referenced with what Trivy found.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

