### PR TITLE
🌱 Disable security scanning for release-0.10

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [main, release-0.12, release-0.11, release-0.10]
+        branch: [main, release-0.12, release-0.11]
     name: Trivy
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Cluster API Provider OpenStack maintains the most recent release/releases for al
 |---------------|--------------|------------------------------------------------|
 | v0.12.x       | **v1beta1**  | when v0.14.0 will be released                  |
 | v0.11.x       | **v1beta1**  | when v0.13.0 will be released                  |
-| v0.10.x       | **v1beta1**  | EOL to be defined (v0.12.0 release date)       |
+| v0.10.x       | **v1beta1**  | EOL since 2025-02-06 - v0.12.0 release date    |
 | v0.9.x        | **v1alpha7** | EOL since 2024-10-24 - v0.11.0 release date    |
 | v0.8.x        | **v1alpha7** | EOL since 2024-04-17 - v0.10.0 release date    |
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We are not supporting release-0.10 any more so running security scans there doesn't make much sense for anything other than seeing how fast things deteriorate.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

