### PR TITLE
🌱 Build with go1.23.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ unexport GOPATH
 TRACE ?= 0
 
 # Go
-GO_VERSION ?= 1.22.12
+GO_VERSION ?= 1.23.8
 
 # Directories.
 ARTIFACTS ?= $(REPO_ROOT)/_artifacts


### PR DESCRIPTION
I was mistaken in https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/2557 when I said that it fixed GO-2025-3563. It only looked that way because I had a go version with the fix locally when I ran the scan.
In the [scan job with correct go version](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/actions/runs/15109209113/job/42654556860) it still shows up as affected.

**What this PR does / why we need it**:

This bumps the go version that we use for building the binaries to 1.23.8 without touching the required version. I.e. it is still possible to build everything using go 1.22, but we are using go 1.23.8 to avoid vulnerabilities.

I am fairly certain that this should be ok and I have double checked with CAPI, to see how they are handling this.
In release-1.8, they [require go 1.22](https://github.com/kubernetes-sigs/cluster-api/blob/efba545bd52d724a9248c0d47dcdfb6e36e637c3/go.mod#L3) just like we do in release-0.11, but they also use [go1.23.8 to build the binaries](https://github.com/kubernetes-sigs/cluster-api/blob/efba545bd52d724a9248c0d47dcdfb6e36e637c3/Makefile#L26).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
