### PR TITLE
🌱 E2E: clusterctl-upgrade from v0.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,7 @@ E2E_NO_ARTIFACT_TEMPLATES_DIR=test/e2e/data/infrastructure-openstack-no-artifact
 e2e-templates: ## Generate cluster templates for e2e tests
 e2e-templates: $(addprefix $(E2E_NO_ARTIFACT_TEMPLATES_DIR)/, \
 		 cluster-template-v1alpha7.yaml \
+		 cluster-template-without-orc.yaml \
 		 cluster-template-md-remediation.yaml \
 		 cluster-template-kcp-remediation.yaml \
 		 cluster-template-multi-az.yaml \
@@ -184,7 +185,7 @@ e2e-templates: $(addprefix $(E2E_NO_ARTIFACT_TEMPLATES_DIR)/, \
 		 cluster-template-without-lb.yaml \
 		 cluster-template.yaml \
 		 cluster-template-flatcar.yaml \
-                 cluster-template-k8s-upgrade.yaml \
+     cluster-template-k8s-upgrade.yaml \
 		 cluster-template-flatcar-sysext.yaml \
 		 cluster-template-no-bastion.yaml)
 # Currently no templates that require CI artifacts

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -7,11 +7,11 @@
 managementClusterName: capo-e2e
 
 images:
-- name: registry.k8s.io/cluster-api/cluster-api-controller:v1.9.3
+- name: registry.k8s.io/cluster-api/cluster-api-controller:v1.9.7
   loadBehavior: tryLoad
-- name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.9.3
+- name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.9.7
   loadBehavior: tryLoad
-- name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.9.3
+- name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.9.7
   loadBehavior: tryLoad
 # Use local dev images built source tree;
 - name: gcr.io/k8s-staging-capi-openstack/capi-openstack-controller:e2e
@@ -23,8 +23,8 @@ providers:
 - name: cluster-api
   type: CoreProvider
   versions:
-  - name: v1.9.3
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.3/core-components.yaml"
+  - name: v1.9.7
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.7/core-components.yaml"
     type: url
     contract: v1beta1
     files:
@@ -49,8 +49,8 @@ providers:
 - name: kubeadm
   type: BootstrapProvider
   versions:
-  - name: v1.9.3
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.3/bootstrap-components.yaml"
+  - name: v1.9.7
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.7/bootstrap-components.yaml"
     type: url
     contract: v1beta1
     files:
@@ -75,8 +75,8 @@ providers:
 - name: kubeadm
   type: ControlPlaneProvider
   versions:
-  - name: v1.9.3
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.3/control-plane-components.yaml"
+  - name: v1.9.7
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.7/control-plane-components.yaml"
     type: url
     contract: v1beta1
     files:
@@ -102,8 +102,8 @@ providers:
   type: InfrastructureProvider
   versions:
   # This is only for clusterctl upgrade tests
-  - name: v0.9.0
-    value: "https://github.com/kubernetes-sigs/cluster-api-provider-openstack/releases/download/v0.9.0/infrastructure-components.yaml"
+  - name: v0.10.8
+    value: "https://github.com/kubernetes-sigs/cluster-api-provider-openstack/releases/download/v0.10.8/infrastructure-components.yaml"
     type: url
     contract: v1beta1
     files:

--- a/test/e2e/data/kustomize/common-patches/images-without-ref/images.yaml
+++ b/test/e2e/data/kustomize/common-patches/images-without-ref/images.yaml
@@ -1,0 +1,25 @@
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Image
+metadata:
+  name: node-image
+spec:
+  import:
+    filter:
+      name: ${OPENSTACK_IMAGE_NAME}
+  managementPolicy: unmanaged
+  cloudCredentialsRef:
+    secretName: ${CLUSTER_NAME}-cloud-config
+    cloudName: ${OPENSTACK_CLOUD}
+---
+apiVersion: openstack.k-orc.cloud/v1alpha1
+kind: Image
+metadata:
+  name: bastion-image
+spec:
+  import:
+    filter:
+      name: ${OPENSTACK_BASTION_IMAGE_NAME}
+  managementPolicy: unmanaged
+  cloudCredentialsRef:
+    secretName: ${CLUSTER_NAME}-cloud-config
+    cloudName: ${OPENSTACK_CLOUD}

--- a/test/e2e/data/kustomize/common-patches/images-without-ref/kustomization.yaml
+++ b/test/e2e/data/kustomize/common-patches/images-without-ref/kustomization.yaml
@@ -1,0 +1,27 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+- images.yaml
+
+patches:
+- target:
+    group: infrastructure.cluster.x-k8s.io
+    version: v1beta1
+    kind: OpenStackMachineTemplate
+  patch: |-
+    - op: replace
+      path: /spec/template/spec/image
+      value:
+        filter:
+          name: ${OPENSTACK_IMAGE_NAME}
+- target:
+    group: infrastructure.cluster.x-k8s.io
+    version: v1beta1
+    kind: OpenStackCluster
+  patch: |-
+    - op: replace
+      path: /spec/bastion/spec/image
+      value:
+        filter:
+          name: ${OPENSTACK_BASTION_IMAGE_NAME}

--- a/test/e2e/data/kustomize/without-orc/kustomization.yaml
+++ b/test/e2e/data/kustomize/without-orc/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../../../../kustomize/v1beta1/default
+
+components:
+- ../common-patches/cluster
+- ../common-patches/cni
+- ../upgrade-patches
+- ../common-patches/ccm
+- ../common-patches/externalNetworkByName
+- ../common-patches/images-without-ref

--- a/test/e2e/shared/defaults.go
+++ b/test/e2e/shared/defaults.go
@@ -55,6 +55,7 @@ const (
 	FlavorWithoutLB            = "without-lb"
 	FlavorMultiNetwork         = "multi-network"
 	FlavorMultiAZ              = "multi-az"
+	FlavorWithoutORC           = "without-orc"
 	FlavorV1alpha7             = "v1alpha7"
 	FlavorMDRemediation        = "md-remediation"
 	FlavorKCPRemediation       = "kcp-remediation"

--- a/test/e2e/suites/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/suites/e2e/clusterctl_upgrade_test.go
@@ -30,7 +30,7 @@ import (
 
 const OldCAPIVersion = "v1.6.0"
 
-var _ = Describe("When testing clusterctl upgrades (v0.9=>current) [clusterctl-upgrade]", func() {
+var _ = Describe("When testing clusterctl upgrades (v0.10=>current) [clusterctl-upgrade]", func() {
 	BeforeEach(func(ctx context.Context) {
 		shared.ApplyCoreImagesPlus(ctx, e2eCtx, upgradeImage)
 
@@ -53,12 +53,12 @@ var _ = Describe("When testing clusterctl upgrades (v0.9=>current) [clusterctl-u
 			SkipCleanup:                     false,
 			InitWithBinary:                  "https://github.com/kubernetes-sigs/cluster-api/releases/download/" + OldCAPIVersion + "/clusterctl-{OS}-{ARCH}",
 			InitWithProvidersContract:       "v1beta1",
-			InitWithInfrastructureProviders: []string{"openstack:v0.9.0"},
+			InitWithInfrastructureProviders: []string{"openstack:v0.10.8"},
 			InitWithCoreProvider:            "cluster-api:" + OldCAPIVersion,
 			InitWithBootstrapProviders:      []string{"kubeadm:" + OldCAPIVersion},
 			InitWithControlPlaneProviders:   []string{"kubeadm:" + OldCAPIVersion},
 			MgmtFlavor:                      shared.FlavorDefault,
-			WorkloadFlavor:                  shared.FlavorV1alpha7,
+			WorkloadFlavor:                  shared.FlavorWithoutORC,
 			InitWithKubernetesVersion:       e2eCtx.E2EConfig.GetVariable(shared.KubernetesVersion),
 		}
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:

This is an attempt to fix the clusterctl-upgrade test that is currently failing on this branch. Starting from v0.9 is probably part of the issue since this is so old an unsupported now.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
