### PR TITLE
🐛 Search by either port ID or name/network

### DIFF
--- a/controllers/openstackserver_controller_test.go
+++ b/controllers/openstackserver_controller_test.go
@@ -119,9 +119,7 @@ var listDefaultPorts = func(r *recorders) {
 
 var listDefaultPortsWithID = func(r *recorders) {
 	r.network.ListPort(ports.ListOpts{
-		Name:      openStackServerName + "-0",
-		ID:        portUUID,
-		NetworkID: networkUUID,
+		ID: portUUID,
 	}).Return([]ports.Port{
 		{
 			ID: portUUID,

--- a/pkg/cloud/services/networking/port.go
+++ b/pkg/cloud/services/networking/port.go
@@ -156,12 +156,12 @@ func (s *Service) ensurePortTagsAndTrunk(port *ports.Port, eventObject runtime.O
 // and that the port has suitable tags and trunk. If the PortStatus is already known,
 // use the ID when filtering for existing ports.
 func (s *Service) EnsurePort(eventObject runtime.Object, portSpec *infrav1.ResolvedPortSpec, portStatus infrav1.PortStatus) (*ports.Port, error) {
-	opts := ports.ListOpts{
-		Name:      portSpec.Name,
-		NetworkID: portSpec.NetworkID,
-	}
+	opts := ports.ListOpts{}
 	if portStatus.ID != "" {
 		opts.ID = portStatus.ID
+	} else {
+		opts.Name = portSpec.Name
+		opts.NetworkID = portSpec.NetworkID
 	}
 
 	existingPorts, err := s.client.ListPort(opts)


### PR DESCRIPTION
When port ID is available we should just search by the ID and not combine name and network of the port.

**What this PR does / why we need it**:
When we have Port ID available we should just search using the Port ID. This is more efficient and avoids issues when port are renamed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2576 



**TODOs**:

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
