### PR TITLE
🌱 Exclude govulncheck from verify target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -570,7 +570,7 @@ clean-release-git: ## Restores the git files usually modified during a release
 	git restore ./*manager_image_patch.yaml ./*manager_pull_policy.yaml
 
 .PHONY: verify
-verify: verify-boilerplate verify-modules verify-gen verify-govulncheck
+verify: verify-boilerplate verify-modules verify-gen
 
 .PHONY: verify-boilerplate
 verify-boilerplate:


### PR DESCRIPTION
**What this PR does / why we need it**:

It was not intentional to make govulncheck run as part of PR tests. The PR tests run the verify target. This commit removes the govulncheck from that target.
The PR tests are anyway running with a different go version than what we use to build release artifacts, so we cannot really rely on the results.

Govulncheck will still be run in the weekly security-scan.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests
