### PR TITLE
📖 Fix broken link to external cloud provider template

### DIFF
--- a/docs/book/src/topics/external-cloud-provider.md
+++ b/docs/book/src/topics/external-cloud-provider.md
@@ -9,7 +9,8 @@
 
 # External Cloud Provider
 
-To deploy a cluster using [external cloud provider](https://github.com/kubernetes/cloud-provider-openstack), create a cluster configuration with the [external cloud provider template](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/main/templates/cluster-template-external-cloud-provider.yaml) or refer to [helm chart](https://github.com/kubernetes/cloud-provider-openstack/tree/master/charts/openstack-cloud-controller-manager).
+All [cluster templates](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/main/templates) are meant to be used with the external cloud provider for OpenStack.
+Refer to the [external cloud provider repository](https://github.com/kubernetes/cloud-provider-openstack) or the [helm chart](https://github.com/kubernetes/cloud-provider-openstack/tree/master/charts/openstack-cloud-controller-manager) for more details.
 
 ## Steps of using external cloud provider template
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the broken link to external cloud provider template

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1.  The `cluster-template-flatcar.yaml` was made the default external cloud provider template in [#1522](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1522), and the dedicated external cloud provider template was removed in [#1551](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1551).
So, I'm now pointing to `cluster-template-flatcar.yaml` as the external cloud provider template. I’m not entirely sure if this is correct. Please confirm.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
