### PR TITLE
🌱 Bump go to 1.23.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ unexport GOPATH
 TRACE ?= 0
 
 # Go
-GO_VERSION ?= 1.23.8
+GO_VERSION ?= 1.23.10
 
 # Directories.
 ARTIFACTS ?= $(REPO_ROOT)/_artifacts

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@ command = "make -C docs/book build"
 publish = "docs/book/book"
 
 [build.environment]
-GO_VERSION = "1.23.8"
+GO_VERSION = "1.23.10"
 
 # Standard Netlify redirects
 [[redirects]]


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This addresses three vulnerabilities in the standard library:
- GO-2025-3751
- GO-2025-3750
- GO-2025-3749

Found by the weekly security scan: https://github.com/kubernetes-sigs/cluster-api-provider-openstack/actions/runs/15676904973/job/44159233148

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

