### PR TITLE
🌱 Bump e2e k8s versions and update templates

### DIFF
--- a/kustomize/v1beta1/default/cluster-template.yaml
+++ b/kustomize/v1beta1/default/cluster-template.yaml
@@ -73,9 +73,6 @@ spec:
           cloud-provider: external
           provider-id: "openstack:///'{{ instance_id }}'"
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/kustomize/v1beta1/flatcar-sysext/patch-flatcar.yaml
+++ b/kustomize/v1beta1/flatcar-sysext/patch-flatcar.yaml
@@ -38,16 +38,16 @@ spec:
                 mode: 0644
                 contents:
                   remote:
-                    url: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-${KUBERNETES_VERSION%.*}.conf
+                    url: https://extensions.flatcar.org/extensions/kubernetes/kubernetes-${KUBERNETES_VERSION%.*}.conf
               - path: /etc/sysupdate.d/noop.conf
                 mode: 0644
                 contents:
                   remote:
-                    url: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
+                    url: https://extensions.flatcar.org/extensions/noop.conf
               - path: /opt/extensions/kubernetes/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
                 contents:
                   remote:
-                    url: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
+                    url: https://extensions.flatcar.org/extensions/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
           systemd:
             units:
               - name: systemd-sysupdate.service
@@ -82,10 +82,10 @@ spec:
                       [Service]
                       EnvironmentFile=/run/metadata/flatcar
     preKubeadmCommands:
-      - export COREOS_OPENSTACK_HOSTNAME=$${COREOS_OPENSTACK_HOSTNAME%.*}
-      - export COREOS_OPENSTACK_INSTANCE_UUID=$${COREOS_OPENSTACK_INSTANCE_UUID}
-      - envsubst < /etc/kubeadm.yml > /etc/kubeadm.yml.tmp
-      - mv /etc/kubeadm.yml.tmp /etc/kubeadm.yml
+    - export COREOS_OPENSTACK_HOSTNAME=$${COREOS_OPENSTACK_HOSTNAME%.*}
+    - export COREOS_OPENSTACK_INSTANCE_UUID=$${COREOS_OPENSTACK_INSTANCE_UUID}
+    - envsubst < /etc/kubeadm.yml > /etc/kubeadm.yml.tmp
+    - mv /etc/kubeadm.yml.tmp /etc/kubeadm.yml
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
@@ -100,10 +100,10 @@ spec:
           kubeletExtraArgs:
             provider-id: openstack:///$${COREOS_OPENSTACK_INSTANCE_UUID}
       preKubeadmCommands:
-        - export COREOS_OPENSTACK_HOSTNAME=$${COREOS_OPENSTACK_HOSTNAME%.*}
-        - export COREOS_OPENSTACK_INSTANCE_UUID=$${COREOS_OPENSTACK_INSTANCE_UUID}
-        - envsubst < /etc/kubeadm.yml > /etc/kubeadm.yml.tmp
-        - mv /etc/kubeadm.yml.tmp /etc/kubeadm.yml
+      - export COREOS_OPENSTACK_HOSTNAME=$${COREOS_OPENSTACK_HOSTNAME%.*}
+      - export COREOS_OPENSTACK_INSTANCE_UUID=$${COREOS_OPENSTACK_INSTANCE_UUID}
+      - envsubst < /etc/kubeadm.yml > /etc/kubeadm.yml.tmp
+      - mv /etc/kubeadm.yml.tmp /etc/kubeadm.yml
       format: ignition
       ignition:
         containerLinuxConfig:
@@ -118,16 +118,16 @@ spec:
                   mode: 0644
                   contents:
                     remote:
-                      url: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-${KUBERNETES_VERSION%.*}.conf
+                      url: https://extensions.flatcar.org/extensions/kubernetes/kubernetes-${KUBERNETES_VERSION%.*}.conf
                 - path: /etc/sysupdate.d/noop.conf
                   mode: 0644
                   contents:
                     remote:
-                      url: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
+                      url: https://extensions.flatcar.org/extensions/noop.conf
                 - path: /opt/extensions/kubernetes/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
                   contents:
                     remote:
-                      url: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
+                      url: https://extensions.flatcar.org/extensions/kubernetes/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
             systemd:
               units:
                 - name: systemd-sysupdate.service

--- a/templates/cluster-template-flatcar-sysext.yaml
+++ b/templates/cluster-template-flatcar-sysext.yaml
@@ -30,16 +30,16 @@ spec:
                   mode: 0644
                   contents:
                     remote:
-                      url: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-${KUBERNETES_VERSION%.*}.conf
+                      url: https://extensions.flatcar.org/extensions/kubernetes/kubernetes-${KUBERNETES_VERSION%.*}.conf
                 - path: /etc/sysupdate.d/noop.conf
                   mode: 0644
                   contents:
                     remote:
-                      url: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
+                      url: https://extensions.flatcar.org/extensions/noop.conf
                 - path: /opt/extensions/kubernetes/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
                   contents:
                     remote:
-                      url: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
+                      url: https://extensions.flatcar.org/extensions/kubernetes/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
             systemd:
               units:
                 - name: systemd-sysupdate.service
@@ -135,9 +135,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external
@@ -156,16 +153,16 @@ spec:
                 mode: 0644
                 contents:
                   remote:
-                    url: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-${KUBERNETES_VERSION%.*}.conf
+                    url: https://extensions.flatcar.org/extensions/kubernetes/kubernetes-${KUBERNETES_VERSION%.*}.conf
               - path: /etc/sysupdate.d/noop.conf
                 mode: 0644
                 contents:
                   remote:
-                    url: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
+                    url: https://extensions.flatcar.org/extensions/noop.conf
               - path: /opt/extensions/kubernetes/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
                 contents:
                   remote:
-                    url: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
+                    url: https://extensions.flatcar.org/extensions/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
           systemd:
             units:
               - name: systemd-sysupdate.service

--- a/templates/cluster-template-flatcar.yaml
+++ b/templates/cluster-template-flatcar.yaml
@@ -97,9 +97,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/templates/cluster-template-without-lb.yaml
+++ b/templates/cluster-template-without-lb.yaml
@@ -73,9 +73,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -73,9 +73,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/templates/clusterclass-dev-test.yaml
+++ b/templates/clusterclass-dev-test.yaml
@@ -308,9 +308,6 @@ spec:
     spec:
       kubeadmConfigSpec:
         clusterConfiguration:
-          apiServer:
-            extraArgs:
-              cloud-provider: external
           controllerManager:
             extraArgs:
               cloud-provider: external

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -161,12 +161,12 @@ providers:
 variables:
   # used to ensure we deploy to the correct management cluster
   KUBE_CONTEXT: "kind-capo-e2e"
-  KUBERNETES_VERSION: "v1.31.2"
-  KUBERNETES_VERSION_UPGRADE_FROM: "v1.30.1"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.31.2"
+  KUBERNETES_VERSION: "v1.33.1"
+  KUBERNETES_VERSION_UPGRADE_FROM: "v1.32.5"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.33.1"
   # NOTE: To see default images run kubeadm config images list (optionally with --kubernetes-version=vX.Y.Z)
-  ETCD_VERSION_UPGRADE_TO: "3.5.12-0"
-  COREDNS_VERSION_UPGRADE_TO: "v1.11.1"
+  ETCD_VERSION_UPGRADE_TO: "3.5.21-0"
+  COREDNS_VERSION_UPGRADE_TO: "v1.12.0"
   CONTROL_PLANE_MACHINE_TEMPLATE_UPGRADE_TO: "upgrade-to-control-plane"
   WORKERS_MACHINE_TEMPLATE_UPGRADE_TO: "upgrade-to-md-0"
   CNI: "../../data/cni/calico.yaml"
@@ -186,10 +186,10 @@ variables:
   OPENSTACK_DNS_NAMESERVERS: "8.8.8.8"
   OPENSTACK_FAILURE_DOMAIN: "testaz1"
   OPENSTACK_FAILURE_DOMAIN_ALT: "testaz2"
-  OPENSTACK_IMAGE_NAME: "ubuntu-2404-kube-v1.31.2"
-  OPENSTACK_IMAGE_URL: https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/ubuntu/2024-11-21/ubuntu-2404-kube-v1.31.2.img
-  OPENSTACK_IMAGE_NAME_UPGRADE_FROM: "ubuntu-2204-kube-v1.30.1"
-  OPENSTACK_IMAGE_URL_UPGRADE_FROM: https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/ubuntu/2024-05-28/ubuntu-2204-kube-v1.30.1.img
+  OPENSTACK_IMAGE_NAME: "ubuntu-2404-kube-v1.33.1"
+  OPENSTACK_IMAGE_URL: https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/ubuntu/ubuntu-2404-kube-v1.33.1
+  OPENSTACK_IMAGE_NAME_UPGRADE_FROM: "ubuntu-2404-kube-v1.32.5"
+  OPENSTACK_IMAGE_URL_UPGRADE_FROM: https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/ubuntu/ubuntu-2404-kube-v1.32.5
   OPENSTACK_NODE_MACHINE_FLAVOR: "m1.small"
   OPENSTACK_SSH_KEY_NAME: "cluster-api-provider-openstack-sigs-k8s-io"
   # The default external network created by devstack
@@ -202,8 +202,8 @@ variables:
   SSH_USER_MACHINE: "ubuntu"
   EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION: "true"
   # The Flatcar image produced by the image-builder
-  OPENSTACK_FLATCAR_IMAGE_NAME: "flatcar-stable-4152.2.0-kube-v1.31.2"
-  OPENSTACK_FLATCAR_IMAGE_URL: "https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/flatcar/flatcar-stable-4152.2.0-kube-v1.31.2.img"
+  OPENSTACK_FLATCAR_IMAGE_NAME: "flatcar-stable-4152.2.3-kube-v1.33.1"
+  OPENSTACK_FLATCAR_IMAGE_URL: "https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/flatcar/flatcar-stable-4152.2.3-kube-v1.33.1"
   # A plain Flatcar from the Flatcar releases server
   FLATCAR_IMAGE_NAME: "flatcar_production_openstack_image"
   FLATCAR_IMAGE_URL: https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_openstack_image.img


### PR DESCRIPTION
**What this PR does / why we need it**:

Normal tests run with kubernetes v1.33.1. Upgrades are going from v1.32.5 to v1.33.1.
Templates needed to be updated for v1.32 as the API server has dropped the cloud-provider flag.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
