### PR TITLE
[release-0.9] Bump golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,13 +5,13 @@ linters:
   - asciicheck
   - bidichk
   - bodyclose
+  - copyloopvar
   - cyclop
 #  - depguard
   - dogsled
   - dupword
   - durationcheck
   - errcheck
-  - exportloopref
   - forbidigo
   - gci
   - goconst

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -157,8 +157,13 @@ issues:
   - linters:
     - revive
     - stylecheck
-    path: (test)/.*.go
+    path: (.+)_test\.go|(test)/.*.go
     text: should not use dot imports
+  - linters:
+    - revive
+    - stylecheck
+    path: (.+)_test\.go|(test)/.*.go
+    text: unused-parameter
   - linters:
     - revive
     path: test/e2e/shared/defaults.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,8 @@ linters:
   - asciicheck
   - bidichk
   - bodyclose
-  - copyloopvar
+  # Commented out as this linter doesn't work against go 1.20 projects
+  # - copyloopvar
   - cyclop
 #  - depguard
   - dogsled
@@ -56,7 +57,10 @@ linters-settings:
     # TODO(sbuerin) fix remaining findings and set to 20 afterwards
     max-complexity: 30
   gci:
-    local-prefixes: sigs.k8s.io/cluster-api-provider-openstack
+    sections:
+      - standard
+      - default
+      - prefix(sigs.k8s.io/cluster-api-provider-openstack)
   gocritic:
     enabled-tags:
       - diagnostic
@@ -129,10 +133,6 @@ linters-settings:
   nolintlint:
     # https://github.com/golangci/golangci-lint/issues/3228
     allow-unused: true
-  staticcheck:
-    go: "1.20"
-  stylecheck:
-    go: "1.20"
   nestif:
     # minimal complexity of if statements to report, 5 by default
     # TODO(sbuerin) fix remaining findings and set to 5 after:
@@ -171,12 +171,13 @@ issues:
     - stylecheck
     text: "ST1003: should not use underscores in Go names;"
     path: .*(api|types)\/.*\/.*conversion.*\.go$
+  exclude-files:
+    - "zz_generated.*\\.go$"
 
 run:
   timeout: 10m
   build-tags:
   - e2e
+  go: "1.20"
 
-  skip-files:
-    - "zz_generated.*\\.go$"
   allow-parallel-runners: true

--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -566,6 +566,7 @@ func reconcileNetworkComponents(scope scope.Scope, cluster *clusterv1.Cluster, o
 		// Set APIEndpoints so the Cluster API Cluster Controller can pull them
 		openStackCluster.Spec.ControlPlaneEndpoint = clusterv1.APIEndpoint{
 			Host: host,
+			//nolint:gosec // disable G115
 			Port: int32(apiServerPort),
 		}
 	}

--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -15,7 +15,7 @@
 ROOT_DIR_RELATIVE := ../..
 include $(ROOT_DIR_RELATIVE)/common.mk
 
-GOLANGCI_LINT_VERSION := v1.54.2
+GOLANGCI_LINT_VERSION := v1.64.8
 
 UNAME := $(shell uname -s)
 

--- a/pkg/cloud/services/networking/securitygroups.go
+++ b/pkg/cloud/services/networking/securitygroups.go
@@ -71,7 +71,6 @@ func (s *Service) ReconcileSecurityGroups(openStackCluster *infrav1.OpenStackClu
 	for k, desiredSecGroup := range desiredSecGroups {
 		var err error
 		observedSecGroups[k], err = s.getSecurityGroupByName(desiredSecGroup.Name)
-
 		if err != nil {
 			return err
 		}

--- a/test/e2e/shared/exec.go
+++ b/test/e2e/shared/exec.go
@@ -146,6 +146,7 @@ func executeCommand(ctx context.Context, p commandParameter) error {
 		return fmt.Errorf("unable to send command %q: %s", "sudo "+p.cmd.cmd, err)
 	}
 	result := strings.TrimSuffix(stdoutBuf.String(), "\n") + "\n" + strings.TrimSuffix(stderrBuf.String(), "\n")
+	//nolint:gosec // disable G306
 	if err := os.WriteFile(logFile, []byte(result), os.ModePerm); err != nil {
 		return fmt.Errorf("error writing log file: %s", err)
 	}


### PR DESCRIPTION
Trying to debug CI failures in release-0.9 branch.

/hold
