### PR TITLE
:bug: #2617 Selecting fixed subnet when provided

### DIFF
--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -571,7 +571,7 @@ func bastionToOpenStackServerSpec(openStackCluster *infrav1.OpenStackCluster) *i
 	if bastion.AvailabilityZone != nil {
 		az = *bastion.AvailabilityZone
 	}
-	openStackServerSpec := openStackMachineSpecToOpenStackServerSpec(bastion.Spec, openStackCluster.Spec.IdentityRef, compute.InstanceTags(bastion.Spec, openStackCluster), az, nil, getBastionSecurityGroupID(openStackCluster), openStackCluster.Status.Network.ID)
+	openStackServerSpec := openStackMachineSpecToOpenStackServerSpec(bastion.Spec, openStackCluster.Spec.IdentityRef, compute.InstanceTags(bastion.Spec, openStackCluster), az, nil, getBastionSecurityGroupID(openStackCluster), openStackCluster)
 
 	return openStackServerSpec
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enable the usage of a provided subnet when it is provided. At first the provided network wasn't used when the there where multiple subnet attached to the network, one random subnet was used (the first returned by the api).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2617

**Special notes for your reviewer**:
This is the first PR i have ever made.
I have redo the work on the _release-0.12_ and the _main_ branches if needed. 


**TODOs**:

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [X] adds unit tests

/hold
