### PR TITLE
🐛 Improve handling of missing load balancer permissions

### DIFF
--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -177,7 +177,7 @@ func (r *OpenStackClusterReconciler) reconcileDelete(ctx context.Context, scope 
 		return reconcile.Result{}, err
 	}
 
-	if (openStackCluster.Spec.APIServerLoadBalancer.IsEnabled() && openStackCluster.Status.APIServerLoadBalancer.ID != "") {
+	if openStackCluster.Spec.APIServerLoadBalancer.IsEnabled() && openStackCluster.Status.APIServerLoadBalancer.ID != "" {
 		loadBalancerService, err := loadbalancer.NewService(scope)
 		if err != nil {
 			return reconcile.Result{}, err


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, when a user tries to create a cluster using OpenStack credentials which are missing the load balancer permissions, CAPO adds the finalized to the OpenStackCluster resource then fails to create the load balancer. When the user then tries to delete the cluster, CAPO makes a GET request to the Octavia API to get the load balancer details and receives a 403 (permission denied) response, so the only way to allow the cluster deletion to proceed is to manually remove the finalizer from the OpenStackCluster resource.

This change prevents the above edge case by only attempting to delete the API server load balancer if the load balancer ID is populated in the OpenStackCluster's status field.

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
