### PR TITLE
Ci fixes release 0.9

### DIFF
--- a/hack/ci/cloud-init/controller.yaml.tpl
+++ b/hack/ci/cloud-init/controller.yaml.tpl
@@ -83,7 +83,7 @@
     IMAGE_URLS+="https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/cirros/2022-12-05/cirros-0.6.1-x86_64-disk.img,"
     IMAGE_URLS+="https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/ubuntu/2023-09-29/ubuntu-2204-kube-v1.27.2.img,"
     IMAGE_URLS+="https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/ubuntu/2023-09-29/ubuntu-2204-kube-v1.28.2.img,"
-    IMAGE_URLS+="https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/flatcar/flatcar-stable-3602.2.0-kube-v1.28.2.img"
+    IMAGE_URLS+="https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/flatcar/flatcar-stable-3815.2.0-kube-v1.28.5.img"
 
     [[post-config|$NOVA_CONF]]
     [DEFAULT]

--- a/hack/ci/gce-project.sh
+++ b/hack/ci/gce-project.sh
@@ -34,12 +34,12 @@ function cloud_init {
   # Generate local ssh configuration
   # NOTE(mdbooth): This command successfully populates ssh config and then
   # fails for some reason I don't understand. We ignore the failure.
-  gcloud compute config-ssh || true
+  gcloud compute config-ssh >/dev/null 2>&1 || true
 }
 
 function init_infrastructure() {
   if [[ ${GCP_NETWORK_NAME} != "default" ]]; then
-    if ! gcloud compute networks describe "$GCP_NETWORK_NAME" --project "$GCP_PROJECT" >/dev/null; then
+    if ! gcloud compute networks describe "$GCP_NETWORK_NAME" --project "$GCP_PROJECT" >/dev/null 2>&1; then
       gcloud compute networks create --project "$GCP_PROJECT" "$GCP_NETWORK_NAME" --subnet-mode custom
       gcloud compute networks subnets create "$GCP_NETWORK_NAME" --project "$GCP_PROJECT" \
         --network="$GCP_NETWORK_NAME" --range="$PRIVATE_NETWORK_CIDR" --region "$GCP_REGION"
@@ -64,12 +64,12 @@ function init_infrastructure() {
   gcloud compute networks list --project="$GCP_PROJECT"
   gcloud compute networks describe "$GCP_NETWORK_NAME" --project="$GCP_PROJECT"
 
-  if ! gcloud compute routers describe "${CLUSTER_NAME}-myrouter" --project="$GCP_PROJECT" --region="$GCP_REGION" >/dev/null; then
+  if ! gcloud compute routers describe "${CLUSTER_NAME}-myrouter" --project="$GCP_PROJECT" --region="$GCP_REGION" >/dev/null 2>&1; then
     gcloud compute routers create "${CLUSTER_NAME}-myrouter" --project="$GCP_PROJECT" \
       --region="$GCP_REGION" --network="$GCP_NETWORK_NAME"
   fi
   if ! gcloud compute routers nats describe --router="$CLUSTER_NAME-myrouter" "$CLUSTER_NAME-mynat" \
-    --project="$GCP_PROJECT" --region="${GCP_REGION}" >/dev/null; then
+    --project="$GCP_PROJECT" --region="${GCP_REGION}" >/dev/null 2>&1; then
     gcloud compute routers nats create "${CLUSTER_NAME}-mynat" --project="$GCP_PROJECT" \
       --router-region="$GCP_REGION" --router="${CLUSTER_NAME}-myrouter" \
       --nat-all-subnet-ip-ranges --auto-allocate-nat-external-ips
@@ -89,7 +89,7 @@ function create_vm {
   # Loop over all zones in the GCP region to ignore a full zone.
   # We are not able to use 'gcloud compute zones list' as the gcloud.compute.zones.list permission is missing.
   for GCP_ZONE in "${GCP_REGION}-a" "${GCP_REGION}-b" "${GCP_REGION}-c"; do
-    if ! gcloud compute instances describe "$servername" --project "$GCP_PROJECT" --zone "$GCP_ZONE" >/dev/null; then
+    if ! gcloud compute instances describe "$servername" --project "$GCP_PROJECT" --zone "$GCP_ZONE" >/dev/null 2>&1; then
       if gcloud compute instances create "$servername" \
         --project "$GCP_PROJECT" \
         --zone "$GCP_ZONE" \

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -197,7 +197,7 @@ variables:
   # The default user for SSH connections from bastion to machines
   SSH_USER_MACHINE: "ubuntu"
   EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION: "true"
-  OPENSTACK_FLATCAR_IMAGE_NAME: "flatcar-stable-3602.2.0-kube-v1.28.2"
+  OPENSTACK_FLATCAR_IMAGE_NAME: "flatcar-stable-3815.2.0-kube-v1.28.5"
 
 intervals:
   conformance/wait-control-plane: ["30m", "10s"]

--- a/test/e2e/suites/e2e/e2e_test.go
+++ b/test/e2e/suites/e2e/e2e_test.go
@@ -85,7 +85,7 @@ var _ = Describe("e2e tests [PR-Blocking]", func() {
 	})
 
 	Describe("Workload cluster (default)", func() {
-		It("It should be creatable and deletable", func() {
+		It("should be creatable and deletable", func() {
 			shared.Logf("Creating a cluster")
 			clusterName := fmt.Sprintf("cluster-%s", namespace.Name)
 			configCluster := defaultConfigCluster(clusterName, namespace.Name)
@@ -206,7 +206,7 @@ var _ = Describe("e2e tests [PR-Blocking]", func() {
 	})
 
 	Describe("Workload cluster (without lb)", func() {
-		It("Should create port(s) with custom options", func() {
+		It("should create port(s) with custom options", func() {
 			shared.Logf("Creating a cluster")
 			clusterName := fmt.Sprintf("cluster-%s", namespace.Name)
 			configCluster := defaultConfigCluster(clusterName, namespace.Name)
@@ -526,7 +526,7 @@ var _ = Describe("e2e tests [PR-Blocking]", func() {
 	})
 
 	Describe("MachineDeployment misconfigurations", func() {
-		It("Should fail to create MachineDeployment with invalid subnet or invalid availability zone", func() {
+		It("should fail to create MachineDeployment with invalid subnet or invalid availability zone", func() {
 			shared.Logf("Creating a cluster")
 			clusterName := fmt.Sprintf("cluster-%s", namespace.Name)
 			configCluster := defaultConfigCluster(clusterName, namespace.Name)
@@ -594,7 +594,7 @@ var _ = Describe("e2e tests [PR-Blocking]", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("It should be creatable and deletable", func() {
+		It("should be creatable and deletable", func() {
 			workerMachines := framework.GetMachinesByMachineDeployments(ctx, framework.GetMachinesByMachineDeploymentsInput{
 				Lister:            e2eCtx.Environment.BootstrapClusterProxy.GetClient(),
 				ClusterName:       clusterName,


### PR DESCRIPTION
Backport of https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1820 to silent worrying but harmless error messages, and bump the flatcar image as the original one is gone. 