### PR TITLE
:seedling: Dependabot/0.11: skip prometheus bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -156,12 +156,13 @@ updates:
   # We will need k8s v0.31.3 to bump structured-merge-diff to v4.4.2 (check git history for details).
   - dependency-name: "sigs.k8s.io/structured-merge-diff/*"
   # These dependencies are skipped because they require a newer version of go:
-  - dependency-name: "golang.org/x/crypto"
   - dependency-name: "github.com/a8m/envsubst"
-  - dependency-name: "golang.org/x/text"
   - dependency-name: "github.com/onsi/ginkgo/v2"
   - dependency-name: "github.com/onsi/gomega"
+  - dependency-name: "github.com/prometheus/client_golang"
   - dependency-name: "go.uber.org/mock"
+  - dependency-name: "golang.org/x/crypto"
+  - dependency-name: "golang.org/x/text"
   labels:
     - "area/dependency"
     - "ok-to-test"


### PR DESCRIPTION
It requires a new version of go since v1.23.0 [1].

[1] https://github.com/prometheus/client_golang/releases/tag/v1.23.0