### PR TITLE
🌱 Dependabot/0.12: skip gomega bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -103,6 +103,7 @@ updates:
   - dependency-name: "sigs.k8s.io/structured-merge-diff/*"
   # These dependencies are skipped because they require a newer version of go:
   - dependency-name: "github.com/a8m/envsubst"
+  - dependency-name: "github.com/onsi/gomega"
   labels:
     - "area/dependency"
     - "ok-to-test"


### PR DESCRIPTION
It requires a new version of go since 1.38.1 [1].

[1] https://github.com/onsi/gomega/compare/v1.38.0...v1.38.1#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6