### PR TITLE
🐛 Fixes out-of-range bug when multiple ports are passed to getSGControlPlaneAdditionalPorts

### DIFF
--- a/pkg/cloud/services/networking/securitygroups_rules.go
+++ b/pkg/cloud/services/networking/securitygroups_rules.go
@@ -258,20 +258,19 @@ func getSGWorkerAllowAll(remoteGroupIDSelf, secControlPlaneGroupID string) []res
 // Permit ports that defined in openStackCluster.Spec.APIServerLoadBalancer.AdditionalPorts.
 func getSGControlPlaneAdditionalPorts(ports []int) []resolvedSecurityGroupRuleSpec {
 	controlPlaneRules := []resolvedSecurityGroupRuleSpec{}
-
-	r := []resolvedSecurityGroupRuleSpec{
-		{
-			Description: "Additional ports",
-			Direction:   "ingress",
-			EtherType:   "IPv4",
-			Protocol:    "tcp",
-		},
-	}
+	// Preallocate r with len(ports)
+	r := make([]resolvedSecurityGroupRuleSpec, len(ports))
 	for i, p := range ports {
-		r[i].PortRangeMin = p
-		r[i].PortRangeMax = p
-		controlPlaneRules = append(controlPlaneRules, r...)
+		r[i] = resolvedSecurityGroupRuleSpec{
+			Description:  "Additional port",
+			Direction:    "ingress",
+			EtherType:    "IPv4",
+			Protocol:     "tcp",
+			PortRangeMin: p,
+			PortRangeMax: p,
+		}
 	}
+	controlPlaneRules = append(controlPlaneRules, r...)
 	return controlPlaneRules
 }
 

--- a/pkg/cloud/services/networking/securitygroups_test.go
+++ b/pkg/cloud/services/networking/securitygroups_test.go
@@ -681,3 +681,62 @@ func TestService_ReconcileSecurityGroups(t *testing.T) {
 		})
 	}
 }
+
+func TestGetSGControlPlaneAdditionalPorts(t *testing.T) {
+	tests := []struct {
+		name  string
+		ports []int
+		want  []resolvedSecurityGroupRuleSpec
+	}{
+		{
+			name:  "no ports",
+			ports: []int{},
+			want:  []resolvedSecurityGroupRuleSpec{},
+		},
+		{
+			name:  "single port",
+			ports: []int{6443},
+			want: []resolvedSecurityGroupRuleSpec{
+				{
+					Description:  "Additional port",
+					Direction:    "ingress",
+					EtherType:    "IPv4",
+					Protocol:     "tcp",
+					PortRangeMin: 6443,
+					PortRangeMax: 6443,
+				},
+			},
+		},
+		{
+			name:  "multiple ports",
+			ports: []int{80, 443},
+			want: []resolvedSecurityGroupRuleSpec{
+				{
+					Description:  "Additional port",
+					Direction:    "ingress",
+					EtherType:    "IPv4",
+					Protocol:     "tcp",
+					PortRangeMin: 80,
+					PortRangeMax: 80,
+				},
+				{
+					Description:  "Additional port",
+					Direction:    "ingress",
+					EtherType:    "IPv4",
+					Protocol:     "tcp",
+					PortRangeMin: 443,
+					PortRangeMax: 443,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getSGControlPlaneAdditionalPorts(tt.ports)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getSGControlPlaneAdditionalPorts() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Prevents index out-of-range panic when passing multiple control plane additional ports and ensures correct validation with added unit tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2666

**Special notes for your reviewer**:

No image version changes.


1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [x ] adds unit tests

/hold
