### PR TITLE
 🌱Uplift go 1.24.6 to address security issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ unexport GOPATH
 TRACE ?= 0
 
 # Go
-GO_VERSION ?= 1.24.4
+GO_VERSION ?= 1.24.6
 
 # Directories.
 ARTIFACTS ?= $(REPO_ROOT)/_artifacts


### PR DESCRIPTION
Uplifting go version to 1.24.6 to address security [issues](https://groups.google.com/g/golang-announce/c/x5MKroML2yM) here. It will address 
 CVE-2025-47906 with Go [issue](https://go.dev/issue/74466)
 CVE-2025-47907 with Go [issue](https://go.dev/issue/74831)