### PR TITLE
🌱Uplift go 1.23.12 to address security issue in release-0.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ unexport GOPATH
 TRACE ?= 0
 
 # Go
-GO_VERSION ?= 1.23.10
+GO_VERSION ?= 1.23.12
 
 # Directories.
 ARTIFACTS ?= $(REPO_ROOT)/_artifacts


### PR DESCRIPTION
Uplifting go version to 1.23.12 to address security [issues](https://groups.google.com/g/golang-announce/c/x5MKroML2yM) here. It will address
CVE-2025-47906 with Go [issue](https://go.dev/issue/74466)
https://github.com/advisories/GHSA-j5pm-7495-qmr3 with Go [issue](https://go.dev/issue/74831)
