### PR TITLE
🌱Bump go version to 1.24.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ unexport GOPATH
 TRACE ?= 0
 
 # Go
-GO_VERSION ?= 1.24.6
+GO_VERSION ?= 1.24.7
 
 # Directories.
 ARTIFACTS ?= $(REPO_ROOT)/_artifacts


### PR DESCRIPTION
Fixes an uncalled CVE for net/http (CVE-2025-47910)