### PR TITLE
📖 Document move labels for ORC CRDs

### DIFF
--- a/docs/book/src/clusteropenstack/configuration.md
+++ b/docs/book/src/clusteropenstack/configuration.md
@@ -132,7 +132,7 @@ or [configure custom security groups](#security-groups) with rules allowing ingr
 
 ## ORC
 
-ORC ([OpenStack Resource Controller](https://github.com/k-orc/openstack-resource-controller)) provides a set of Kubernetes controllers and is required by CAPO to 
+ORC ([OpenStack Resource Controller](https://github.com/k-orc/openstack-resource-controller)) provides a set of Kubernetes controllers and is required by CAPO to
 manage some OpenStack resources. ORC is a separate project and is not part of CAPO, therefore it needs to be installed separately.
 
 To install ORC, run the following command:
@@ -150,6 +150,13 @@ kubectl apply --server-side -k "https://github.com/k-orc/openstack-resource-cont
 
 In most cases, the default configuration should be sufficient.
 Check the [ORC documentation](https://k-orc.cloud) for more information.
+
+**Note:** You need to add the `clusterctl.cluster.x-k8s.io/move` label to the ORC CRDs in order to successfully move objects from bootstrap cluster to target cluster during clusterctl move operations:
+
+```bash
+kubectl label crd servers.openstack.k-orc.cloud clusterctl.cluster.x-k8s.io/move=""
+kubectl label crd images.openstack.k-orc.cloud clusterctl.cluster.x-k8s.io/move=""
+```
 
 ## OpenStack credential
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Since CAPO is now relying on ORC resources, it is necessary to label them correctly before doing a [clusterctl move](https://cluster-api.sigs.k8s.io/developer/providers/contracts/clusterctl.html?highlight=clusterctl.cluster.x-k8s.io%2Fmove-hierarchy#move). This PR adds documentation for it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2592

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [x] includes documentation
  - [ ] adds unit tests

/hold
