### PR TITLE
🌱 cmd: strip out symbol table & DWARF debugging info

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,13 +36,13 @@ COPY ./ ./
 # Build
 ARG package=.
 ARG ARCH
-ARG ldflags
+ARG ldflags=-s -w -extldflags=-static
 
 # Do not force rebuild of up-to-date packages (do not use -a) and use the compiler cache folder
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
-    go build -ldflags "${ldflags} -extldflags '-static'" \
+    go build -ldflags "${ldflags}" \
     -o manager ${package}
 
 # Production image

--- a/Makefile
+++ b/Makefile
@@ -340,7 +340,16 @@ generate-api-docs-%: $(GEN_CRD_API_REFERENCE_DOCS) FORCE
 
 .PHONY: docker-build
 docker-build: ## Build the docker image for controller-manager
-	docker build -f Dockerfile --build-arg GO_VERSION=$(GO_VERSION) --build-arg goproxy=$(GOPROXY) --build-arg ARCH=$(ARCH) --build-arg ldflags="$(LDFLAGS)" . -t $(CONTROLLER_IMG_TAG)
+	docker build -f Dockerfile --build-arg GO_VERSION=$(GO_VERSION) \
+	--build-arg goproxy=$(GOPROXY) \
+	--build-arg ARCH=$(ARCH) . -t $(CONTROLLER_IMG_TAG)
+
+.PHONY: docker-build-debug
+docker-build-debug: ## Build the docker image for controller-manager with debug info
+	docker build -f Dockerfile --build-arg GO_VERSION=$(GO_VERSION) \
+	--build-arg goproxy=$(GOPROXY) \
+	--build-arg ARCH=$(ARCH) \
+	--build-arg ldflags="-extldflags=-static" . -t $(CONTROLLER_IMG_TAG)
 
 .PHONY: docker-push
 docker-push: ## Push the docker image


### PR DESCRIPTION
DWARF is mostly needed when we are using Delve. DWARF was originally created for C language and the need for it in go and other debugging features is very small in general. As such, switch to using `-ldflags="-s -w" `by default and have an option to opt in for debugging info for those who would really need it. We are able to reduce almost 30mb image size

```
Original version
cluster-api-provider-openstack$ docker images gcr.io/k8s-staging-capi-openstack/capi-openstack-controller-amd64
REPOSITORY                                                          TAG       IMAGE ID         SIZE
gcr.io/k8s-staging-capi-openstack/capi-openstack-controller-amd64   dev       e7ed43be0c1f     89.2MB
```

```
After this PR change
cluster-api-provider-openstack$ docker images gcr.io/k8s-staging-capi-openstack/capi-openstack-controller-amd64
REPOSITORY                                                          TAG       IMAGE ID         SIZE
gcr.io/k8s-staging-capi-openstack/capi-openstack-controller-amd64   dev       ad5bf2646b53     62.1MB 

```
Ref: [CAPM3](https://github.com/metal3-io/cluster-api-provider-metal3/pull/2830)