### PR TITLE
🌱 Dockerfile: add the ARG defaulting within the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 # Build the manager binary
 ARG GO_VERSION
-FROM golang:${GO_VERSION} AS builder
+FROM golang:${GO_VERSION:-1.24.7} AS builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg goproxy=$(go env GOPROXY) to override the goproxy


### PR DESCRIPTION
**What this PR does / why we need it**:
Add the default value for `GO_VERSION` within the Dockerfile to fix build checks warnings that come from an empty variable. This doesn’t break existing behavior; version control is still managed by the Makefile
```
 - InvalidDefaultArgInFrom: Default value for ARG golang:${GO_VERSION} results in empty or invalid base image name (line 17)
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

