### PR TITLE
🐛 Uplift go 1.24.8 to address security issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 # Build the manager binary
 ARG GO_VERSION
-FROM golang:${GO_VERSION:-1.24.7} AS builder
+FROM golang:${GO_VERSION:-1.24.8} AS builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg goproxy=$(go env GOPROXY) to override the goproxy

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ unexport GOPATH
 TRACE ?= 0
 
 # Go
-GO_VERSION ?= 1.24.7
+GO_VERSION ?= 1.24.8
 
 # Directories.
 ARTIFACTS ?= $(REPO_ROOT)/_artifacts


### PR DESCRIPTION
Uplift go 1.24.8 to address the security vulnerabilities. These minor releases include PRIVATE security fixes to the standard library, covering the following CVEs: [announcement](https://groups.google.com/g/golang-announce/c/ask65OnfzGU)
CVE-2025-61724
CVE-2025-61725
CVE-2025-58187
CVE-2025-61723
CVE-2025-47912
CVE-2025-58185
CVE-2025-58186
CVE-2025-58188
CVE-2025-58183