### PR TITLE
🌱 E2E: Fix the CCM patch for the v1beta1 cluster-template

### DIFF
--- a/test/e2e/data/kustomize/capi-v1beta1/ccm.yaml
+++ b/test/e2e/data/kustomize/capi-v1beta1/ccm.yaml
@@ -4,6 +4,22 @@ metadata:
   name: ccm-${CLUSTER_NAME}-crs-1
 data: ${CCM_RESOURCES}
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ccm-${CLUSTER_NAME}-crs-1
+type: addons.cluster.x-k8s.io/resource-set
+stringData:
+  cloud-config-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      # This name is referenced in the CCM deployment manifest
+      name: cloud-config
+      namespace: kube-system
+    data:
+      cloud.conf: ${OPENSTACK_CLOUD_PROVIDER_CONF_B64}
+---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:
@@ -14,5 +30,7 @@ spec:
       ccm: ${CLUSTER_NAME}-crs-1
   resources:
   - kind: ConfigMap
+    name: ccm-${CLUSTER_NAME}-crs-1
+  - kind: Secret
     name: ccm-${CLUSTER_NAME}-crs-1
   strategy: ApplyOnce

--- a/test/e2e/data/kustomize/capi-v1beta1/patch-ccm-cloud-config.yaml
+++ b/test/e2e/data/kustomize/capi-v1beta1/patch-ccm-cloud-config.yaml
@@ -4,14 +4,6 @@
 - op: add
   path: /spec/kubeadmConfigSpec/files/-
   value:
-    content: ${OPENSTACK_CLOUD_PROVIDER_CONF_B64}
-    encoding: base64
-    owner: root
-    path: /etc/kubernetes/cloud.conf
-    permissions: "0600"
-- op: add
-  path: /spec/kubeadmConfigSpec/files/-
-  value:
     content: ${OPENSTACK_CLOUD_CACERT_B64}
     encoding: base64
     owner: root


### PR DESCRIPTION
**What this PR does / why we need it**:

This should fix the clusterctl-upgrade tests that are currently broken.
I forgot this when changing the CCM to use a Secret instead of a host path mount in https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/2744.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes upgrade tests. See https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-openstack#periodic-e2e-full-test-main

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
