### PR TITLE
:seedling: Pin kustomize on release-0.12

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -149,6 +149,8 @@ updates:
   - dependency-name: "github.com/onsi/gomega"
   - dependency-name: "golang.org/x/crypto"
   - dependency-name: "golang.org/x/text"
+  # Newer kustomize requires a bump to kube-openapi, which has some incompatibility with gengo.
+  - dependency-name: "sigs.k8s.io/kustomize/kustomize/*"
   labels:
   - "area/dependency"
   - "ok-to-test"


### PR DESCRIPTION
**What this PR does / why we need it**:

We are currently seeing errors like the following when kustomize is bumped on release-0.12:

```
 make -C hack/tools bin/openapi-gen
make[1]: Entering directory '/home/prow/go/src/sigs.k8s.io/cluster-api-provider-openstack/hack/tools'
go build -tags=tools -o bin/openapi-gen k8s.io/kube-openapi/cmd/openapi-gen
go: downloading k8s.io/gengo/v2 v2.0.0-20240228010128-51d4e06bde70
go: downloading k8s.io/gengo v0.0.0-20201203183100-97869a43a9d9
# k8s.io/kube-openapi/pkg/generators
/root/go/pkg/mod/k8s.io/kube-openapi@v0.0.0-20241212222426-2c72e554b1e7/pkg/generators/openapi.go:252:11: r.Type undefined (type *"k8s.io/gengo/v2/types".Type has no field or method Type)
make[1]: *** [Makefile:76: bin/openapi-gen] Error 1
make[1]: Leaving directory '/home/prow/go/src/sigs.k8s.io/cluster-api-provider-openstack/hack/tools'
make: *** [common.mk:49: hack/tools/bin/openapi-gen] Error 2 
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests
