### PR TITLE
:bug: Allow setting disablePortSecurity on OSM port

### DIFF
--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -556,7 +556,10 @@ func openStackMachineSpecToOpenStackServerSpec(openStackMachineSpec *infrav1.Ope
 			}
 			serverPort.FixedIPs = clusterSubnets
 		}
-		if len(serverPort.SecurityGroups) == 0 && defaultSecGroup != nil {
+		// Only inject the default SG when portSecurity is not disabled,
+		// there are no SGs passed by user and defaultSecGroup is set
+		portSecurityDisabled := serverPort.DisablePortSecurity != nil && *serverPort.DisablePortSecurity
+		if !portSecurityDisabled && len(serverPort.SecurityGroups) == 0 && defaultSecGroup != nil {
 			serverPort.SecurityGroups = []infrav1.SecurityGroupParam{
 				{
 					ID: defaultSecGroup,

--- a/controllers/openstackmachine_controller_test.go
+++ b/controllers/openstackmachine_controller_test.go
@@ -346,6 +346,34 @@ func TestOpenStackMachineSpecToOpenStackServerSpec(t *testing.T) {
 				UserDataRef: userData,
 			},
 		},
+		{
+			name: "Explicit port with disablePortSecurity",
+			spec: &infrav1.OpenStackMachineSpec{
+				Flavor: ptr.To(flavorName),
+				Image:  image,
+				Ports: []infrav1.PortOpts{{
+					Network: &infrav1.NetworkParam{ID: ptr.To(networkUUID)},
+					ResolvedPortSpecFields: infrav1.ResolvedPortSpecFields{
+						DisablePortSecurity: ptr.To(true),
+					},
+				}},
+			},
+			cluster: openStackClusterNetworkWithoutID,
+			want: &infrav1alpha1.OpenStackServerSpec{
+				Flavor:      ptr.To(flavorName),
+				IdentityRef: identityRef,
+				Image:       image,
+				Ports: []infrav1.PortOpts{{
+					Network:        &infrav1.NetworkParam{ID: ptr.To(networkUUID)},
+					SecurityGroups: nil,
+					ResolvedPortSpecFields: infrav1.ResolvedPortSpecFields{
+						DisablePortSecurity: ptr.To(true),
+					},
+				}},
+				Tags:        tags,
+				UserDataRef: userData,
+			},
+		},
 	}
 	for i := range tests {
 		tt := tests[i]


### PR DESCRIPTION
**What this PR does / why we need it**:
Ensure that disablePortSecurity is unset or false before setting the default securityGroup to a port.

Currently the default SG is added without checking disablePortSecurity. This leads to both disablePortSecurity and securityGroup being set which triggers an api validation error.


**Which issue(s) this PR fixes**:
Fixes #2783

**Special notes for your reviewer**:

1. I spent some time looking on e2e tests but couldnt find a scenario to cover this, unit-test were updated though.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- if necessary:
  - [X] includes documentation
  - [X] adds unit tests

/hold
