### PR TITLE
🌱Update log verbosity level according to CAPI

### DIFF
--- a/controllers/openstackserver_controller.go
+++ b/controllers/openstackserver_controller.go
@@ -325,7 +325,7 @@ func (r *OpenStackServerReconciler) reconcileNormal(ctx context.Context, scope *
 	// that in the delete path we can be sure that if there are no resolved
 	// resources then no resources were created.
 	if changed {
-		scope.Logger().V(6).Info("Server resources updated, requeuing")
+		scope.Logger().V(5).Info("Server resources updated, requeuing")
 		return ctrl.Result{}, nil
 	}
 
@@ -716,10 +716,10 @@ func OpenStackServerReconcileComplete(log logr.Logger) predicate.Funcs {
 			log = log.WithValues("OpenStackServer", klog.KObj(server))
 
 			if server.Status.Ready || IsServerTerminalError(server) {
-				log.V(6).Info("OpenStackServer finished reconciling, allowing further processing")
+				log.V(5).Info("OpenStackServer finished reconciling, allowing further processing")
 				return true
 			}
-			log.V(6).Info("OpenStackServer is still reconciling, blocking further processing")
+			log.V(5).Info("OpenStackServer is still reconciling, blocking further processing")
 			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
@@ -741,7 +741,7 @@ func OpenStackServerReconcileComplete(log logr.Logger) predicate.Funcs {
 			oldFinished := oldServer.Status.Ready || IsServerTerminalError(oldServer)
 			newFinished := newServer.Status.Ready || IsServerTerminalError(newServer)
 			if !oldFinished && newFinished {
-				log.V(6).Info("OpenStackServer finished reconciling, allowing further processing")
+				log.V(5).Info("OpenStackServer finished reconciling, allowing further processing")
 				return true
 			}
 

--- a/pkg/cloud/services/compute/instance_types.go
+++ b/pkg/cloud/services/compute/instance_types.go
@@ -157,7 +157,7 @@ func (is *InstanceStatus) NetworkStatus() (*InstanceNetworkStatus, error) {
 			case "fixed":
 				addressType = corev1.NodeInternalIP
 			default:
-				is.logger.V(6).Info("Ignoring address with unknown type", "address", address.Address, "type", address.Type)
+				is.logger.V(5).Info("Ignoring address with unknown type", "address", address.Address, "type", address.Type)
 				continue
 			}
 			if address.Version == 4 {

--- a/pkg/cloud/services/networking/network.go
+++ b/pkg/cloud/services/networking/network.go
@@ -109,7 +109,7 @@ func (s *Service) ReconcileNetwork(openStackCluster *infrav1.OpenStackCluster, c
 		openStackCluster.Status.Network.ID = res.ID
 		openStackCluster.Status.Network.Name = res.Name
 		openStackCluster.Status.Network.Tags = res.Tags
-		s.scope.Logger().V(6).Info("Reusing existing network", "name", res.Name, "id", res.ID)
+		s.scope.Logger().V(5).Info("Reusing existing network", "name", res.Name, "id", res.ID)
 		return nil
 	}
 
@@ -201,7 +201,7 @@ func (s *Service) ReconcileSubnet(openStackCluster *infrav1.OpenStackCluster, cl
 		}
 	} else if len(subnetList) == 1 {
 		subnet = &subnetList[0]
-		s.scope.Logger().V(6).Info("Reusing existing subnet", "name", subnet.Name, "id", subnet.ID)
+		s.scope.Logger().V(5).Info("Reusing existing subnet", "name", subnet.Name, "id", subnet.ID)
 
 		if err := s.updateSubnetDNSNameservers(openStackCluster, subnet); err != nil {
 			return err

--- a/pkg/cloud/services/networking/securitygroups.go
+++ b/pkg/cloud/services/networking/securitygroups.go
@@ -99,7 +99,7 @@ func (s *Service) ReconcileSecurityGroups(openStackCluster *infrav1.OpenStackClu
 			if err != nil {
 				return err
 			}
-			s.scope.Logger().V(6).Info("Updated tags for security group", "name", group.Name, "id", group.ID)
+			s.scope.Logger().V(5).Info("Updated tags for security group", "name", group.Name, "id", group.ID)
 		}
 	}
 
@@ -471,7 +471,7 @@ func (s *Service) reconcileGroupRules(desired *securityGroupSpec, observed *grou
 	if len(rulesToDelete) > 0 {
 		s.scope.Logger().V(4).Info("Deleting rules not needed anymore for group", "name", observed.Name, "amount", len(rulesToDelete))
 		for _, rule := range rulesToDelete {
-			s.scope.Logger().V(6).Info("Deleting rule", "ID", rule, "name", observed.Name)
+			s.scope.Logger().V(5).Info("Deleting rule", "ID", rule, "name", observed.Name)
 			err := s.client.DeleteSecGroupRule(rule)
 			if err != nil {
 				return err
@@ -502,17 +502,17 @@ func (s *Service) getOrCreateSecurityGroup(openStackCluster *infrav1.OpenStackCl
 		return nil, err
 	}
 	if secGroup != nil {
-		s.scope.Logger().V(6).Info("Reusing existing SecurityGroup", "name", groupName, "id", secGroup.ID)
+		s.scope.Logger().V(5).Info("Reusing existing SecurityGroup", "name", groupName, "id", secGroup.ID)
 		return secGroup, nil
 	}
 
-	s.scope.Logger().V(6).Info("Group doesn't exist, creating it", "name", groupName)
+	s.scope.Logger().V(5).Info("Group doesn't exist, creating it", "name", groupName)
 
 	createOpts := groups.CreateOpts{
 		Name:        groupName,
 		Description: "Cluster API managed group",
 	}
-	s.scope.Logger().V(6).Info("Creating group", "name", groupName)
+	s.scope.Logger().V(5).Info("Creating group", "name", groupName)
 
 	group, err := s.client.CreateSecGroup(createOpts)
 	if err != nil {
@@ -529,7 +529,7 @@ func (s *Service) getSecurityGroupByName(name string) (*groups.SecGroup, error) 
 		Name: name,
 	}
 
-	s.scope.Logger().V(6).Info("Attempting to fetch security group with", "name", name)
+	s.scope.Logger().V(5).Info("Attempting to fetch security group with", "name", name)
 	allGroups, err := s.client.ListSecGroup(opts)
 	if err != nil {
 		return nil, err
@@ -561,7 +561,7 @@ func (s *Service) createRule(securityGroupID string, r resolvedSecurityGroupRule
 		RemoteIPPrefix: r.RemoteIPPrefix,
 		SecGroupID:     securityGroupID,
 	}
-	s.scope.Logger().V(6).Info("Creating rule", "description", r.Description, "direction", dir, "portRangeMin", r.PortRangeMin, "portRangeMax", r.PortRangeMax, "proto", proto, "etherType", etherType, "remoteGroupID", r.RemoteGroupID, "remoteIPPrefix", r.RemoteIPPrefix, "securityGroupID", securityGroupID)
+	s.scope.Logger().V(5).Info("Creating rule", "description", r.Description, "direction", dir, "portRangeMin", r.PortRangeMin, "portRangeMax", r.PortRangeMax, "proto", proto, "etherType", etherType, "remoteGroupID", r.RemoteGroupID, "remoteIPPrefix", r.RemoteIPPrefix, "securityGroupID", securityGroupID)
 	_, err := s.client.CreateSecGroupRule(createOpts)
 	if err != nil {
 		return err

--- a/pkg/scope/provider.go
+++ b/pkg/scope/provider.go
@@ -171,7 +171,7 @@ func NewCachedProviderScope(cache *cache.LRUExpireCache, cloud clientconfig.Clou
 	}
 
 	if scope, found := cache.Get(key); found {
-		logger.V(6).Info("Using scope from cache")
+		logger.V(5).Info("Using scope from cache")
 		return scope.(Scope), nil
 	}
 
@@ -272,7 +272,7 @@ func NewProviderClient(cloud clientconfig.Cloud, regionName string, caCert []byt
 	}
 
 	provider.HTTPClient.Transport = &http.Transport{Proxy: http.ProxyFromEnvironment, TLSClientConfig: config}
-	if klog.V(6).Enabled() {
+	if klog.V(5).Enabled() {
 		provider.HTTPClient.Transport = &osclient.RoundTripper{
 			Rt:     provider.HTTPClient.Transport,
 			Logger: &gophercloudLogger{logger},


### PR DESCRIPTION
We are trying to follow CAPI guideline to use maximum verbosity to level 5.
CAPI has some guidelines on log levels: https://cluster-api.sigs.k8s.io/developer/core/logging#log-levels