### PR TITLE
🌱 Bump go to 1.24.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 # Build the manager binary
 ARG GO_VERSION
-FROM golang:${GO_VERSION} AS builder
+FROM golang:${GO_VERSION:-1.24.9} AS builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg goproxy=$(go env GOPROXY) to override the goproxy
@@ -28,7 +28,7 @@ COPY go.sum go.sum
 # Cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN --mount=type=cache,target=/go/pkg/mod \
-    go mod download
+  go mod download
 
 # Copy the sources
 COPY ./ ./
@@ -40,10 +40,10 @@ ARG ldflags
 
 # Do not force rebuild of up-to-date packages (do not use -a) and use the compiler cache folder
 RUN --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg/mod \
-    CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
-    go build -ldflags "${ldflags} -extldflags '-static'" \
-    -o manager ${package}
+  --mount=type=cache,target=/go/pkg/mod \
+  CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
+  go build -ldflags "${ldflags} -extldflags '-static'" \
+  -o manager ${package}
 
 # Production image
 FROM gcr.io/distroless/static:nonroot

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ unexport GOPATH
 TRACE ?= 0
 
 # Go
-GO_VERSION ?= 1.23.12
+GO_VERSION ?= 1.24.9
 
 # Directories.
 ARTIFACTS ?= $(REPO_ROOT)/_artifacts


### PR DESCRIPTION
**What this PR does / why we need it**:

Let's bump also for release-0.12. 1.24.8 contains many security fixes. I am bumping here to 1.24.9 since this contains a fix for a TLS validation regression.
This is just the go version we use for building and testing and does not affect the required go version for release-0.12.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests
