### PR TITLE
🌱 E2E: Use kind cluster for clusterctl upgrade tests

### DIFF
--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -218,6 +218,7 @@ variables:
   CNI: "../../data/cni/calico.yaml"
   CCM: "../../data/ccm/cloud-controller-manager.yaml"
   EXP_CLUSTER_RESOURCE_SET: "true"
+  IP_FAMILY: "ipv4"
   OPENSTACK_BASTION_IMAGE_NAME: "cirros-0.6.1-x86_64-disk"
   OPENSTACK_BASTION_IMAGE_URL: https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/cirros/2022-12-05/cirros-0.6.1-x86_64-disk.img
   OPENSTACK_BASTION_IMAGE_HASH: 0c839612eb3f2469420f2ccae990827f

--- a/test/e2e/suites/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/suites/e2e/clusterctl_upgrade_test.go
@@ -68,6 +68,7 @@ var _ = Describe("When testing clusterctl upgrades for CAPO (v0.11=>current) and
 			WorkloadFlavor:                    shared.FlavorCapiV1Beta1,
 			InitWithKubernetesVersion:         e2eCtx.E2EConfig.MustGetVariable(shared.KubernetesVersion),
 			InitWithRuntimeExtensionProviders: []string{"openstack-resource-controller:v1.0.2"},
+			UseKindForManagementCluster:       true,
 		}
 	})
 })
@@ -102,6 +103,7 @@ var _ = Describe("When testing clusterctl upgrades for CAPO (v0.12=>current) and
 			WorkloadFlavor:                    shared.FlavorCapiV1Beta1,
 			InitWithKubernetesVersion:         e2eCtx.E2EConfig.MustGetVariable(shared.KubernetesVersion),
 			InitWithRuntimeExtensionProviders: []string{"openstack-resource-controller:v1.0.2"},
+			UseKindForManagementCluster:       true,
 		}
 	})
 })
@@ -136,6 +138,7 @@ var _ = Describe("When testing clusterctl upgrades for CAPO (v0.13=>current) and
 			WorkloadFlavor:                    shared.FlavorDefault,
 			InitWithKubernetesVersion:         e2eCtx.E2EConfig.MustGetVariable(shared.KubernetesVersion),
 			InitWithRuntimeExtensionProviders: []string{"openstack-resource-controller:v1.0.2"},
+			UseKindForManagementCluster:       true,
 		}
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

This enables the UseKindForManagementCluster flag for all clusterctl upgrade tests, which makes them use a kind cluster as the secondary management cluster instead of creating an OpenStack workload cluster.

This significantly reduces the resource requirements for these tests by using lightweight kind containers instead of full VMs, and it also speeds up the test execution.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2098

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
