### PR TITLE
🌱 E2E: Fix log collection for machines

### DIFF
--- a/test/e2e/shared/common.go
+++ b/test/e2e/shared/common.go
@@ -169,7 +169,8 @@ func getOpenStackClusterFromMachine(ctx context.Context, client client.Client, m
 	}
 
 	key = types.NamespacedName{
-		Name: cluster.Spec.InfrastructureRef.Name,
+		Name:      cluster.Spec.InfrastructureRef.Name,
+		Namespace: cluster.Namespace,
 	}
 	openStackCluster := &infrav1.OpenStackCluster{}
 	err = client.Get(ctx, key, openStackCluster)


### PR DESCRIPTION
**What this PR does / why we need it**:

I mistakenly removed the namespace when [switching to CAPI v1beta2](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/commit/3489aa8368edcd9cb63ae39585af09abd401f6c5). The infrastructureRef no longer specifies a namespace since it is implied to be the same as the clusters namespace. However, we still need to set a namespace for the NamespacedName...

This is what it looks like in the logs before this fix:
```
Failed to get logs for Machine cluster-e2e-gnh1j1-control-plane-rwsnw, Cluster e2e-gnh1j1/cluster-e2e-gnh1j1: error getting OpenStackCluster for Machine: an empty namespace may not be set when a resource name is provided
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests
