### PR TITLE
🐛 Handle SOFT_DELETED and DELETED states in server deletion

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -792,6 +792,11 @@ var (
 	// InstanceStateDeleted is the string representing an instance in a deleted state.
 	InstanceStateDeleted = InstanceState("DELETED")
 
+	// InstanceStateSoftDeleted is the string representing an instance in a soft-deleted state.
+	// This state occurs when OpenStack is configured with a reclaim_instance_interval > 0,
+	// allowing recovery of deleted instances within the reclaim period.
+	InstanceStateSoftDeleted = InstanceState("SOFT_DELETED")
+
 	// InstanceStateUndefined is the string representing an undefined instance state.
 	InstanceStateUndefined = InstanceState("")
 )


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
When OpenStack's soft-delete is enabled, deleted servers enter SOFT_DELETED state instead of being immediately purged, causing CAPO's deletion poll to timeout and stall cluster cleanup.
This PR updates the deletion poll to treat SOFT_DELETED (and DELETED) as success, allowing reconciliation to proceed while respecting OpenStack's reclaim policy.

** Special Notes **

**Design Approach**
Updated `DeleteInstance` to treat servers in `SOFT_DELETED` or `DELETED` state as successfully deleted. This allows cluster deletion to complete when OpenStack has soft delete enabled, while respecting the cloud admin's recovery policy. CAPO proceeds with cleanup, and OpenStack handles permanent deletion per its configured reclaim interval.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2618

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [x] adds unit tests

/hold
