### PR TITLE
✨ Shutdown VMs before Deletion

### DIFF
--- a/api/v1beta1/conditions_consts.go
+++ b/api/v1beta1/conditions_consts.go
@@ -38,6 +38,8 @@ const (
 	InstanceDeletedReason = "InstanceDeleted"
 	// InstanceNotReadyReason used when the instance is in a pending state.
 	InstanceNotReadyReason = "InstanceNotReady"
+	// InstanceStopFailedReason used when stopping the instance failed.
+	InstanceStopFailedReason = "InstanceStopFailed"
 	// InstanceDeleteFailedReason used when deleting the instance failed.
 	InstanceDeleteFailedReason = "InstanceDeleteFailed"
 	// OpenstackErrorReason used when there is an error communicating with OpenStack.

--- a/pkg/clients/mock/compute.go
+++ b/pkg/clients/mock/compute.go
@@ -208,6 +208,20 @@ func (mr *MockComputeClientMockRecorder) ListServers(listOpts any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServers", reflect.TypeOf((*MockComputeClient)(nil).ListServers), listOpts)
 }
 
+// StopServer mocks base method.
+func (m *MockComputeClient) StopServer(serverID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StopServer", serverID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StopServer indicates an expected call of StopServer.
+func (mr *MockComputeClientMockRecorder) StopServer(serverID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopServer", reflect.TypeOf((*MockComputeClient)(nil).StopServer), serverID)
+}
+
 // WithMicroversion mocks base method.
 func (m *MockComputeClient) WithMicroversion(required string) (clients.ComputeClient, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Tries to shutdown the OpenStack VM before deleting it. This way even Pods form Daemonsets are shut down more gracefully and services like license daemons on the VMs can be properly shutdown.

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1973

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
