### PR TITLE
🌱 Bump e2e to use k8s v1.34.2

### DIFF
--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -208,9 +208,11 @@ providers:
 variables:
   # used to ensure we deploy to the correct management cluster
   KUBE_CONTEXT: "kind-capo-e2e"
-  KUBERNETES_VERSION: "v1.33.1"
-  KUBERNETES_VERSION_UPGRADE_FROM: "v1.32.5"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.33.1"
+  # Pick a version that has a kind node image available. This is used in clusterctl upgrade tests.
+  KUBERNETES_KIND_VERSION: "v1.34.0"
+  KUBERNETES_VERSION: "v1.34.2"
+  KUBERNETES_VERSION_UPGRADE_FROM: "v1.33.1"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.34.2"
   # NOTE: To see default images run kubeadm config images list (optionally with --kubernetes-version=vX.Y.Z)
   ETCD_VERSION_UPGRADE_TO: "3.5.21-0"
   COREDNS_VERSION_UPGRADE_TO: "v1.12.0"
@@ -235,10 +237,10 @@ variables:
   OPENSTACK_DNS_NAMESERVERS: "8.8.8.8"
   OPENSTACK_FAILURE_DOMAIN: "testaz1"
   OPENSTACK_FAILURE_DOMAIN_ALT: "testaz2"
-  OPENSTACK_IMAGE_NAME: "ubuntu-2404-kube-v1.33.1"
-  OPENSTACK_IMAGE_URL: https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/ubuntu/ubuntu-2404-kube-v1.33.1
-  OPENSTACK_IMAGE_NAME_UPGRADE_FROM: "ubuntu-2404-kube-v1.32.5"
-  OPENSTACK_IMAGE_URL_UPGRADE_FROM: https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/ubuntu/ubuntu-2404-kube-v1.32.5
+  OPENSTACK_IMAGE_NAME: "ubuntu-2404-kube-latest"
+  OPENSTACK_IMAGE_URL: https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/ubuntu/ubuntu-2404-kube-v1.34.2
+  OPENSTACK_IMAGE_NAME_UPGRADE_FROM: "ubuntu-2404-kube-previous"
+  OPENSTACK_IMAGE_URL_UPGRADE_FROM: https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/ubuntu/ubuntu-2404-kube-v1.33.1
   OPENSTACK_NODE_MACHINE_FLAVOR: "m1.small"
   OPENSTACK_SSH_KEY_NAME: "cluster-api-provider-openstack-sigs-k8s-io"
   # The default external network created by devstack
@@ -252,8 +254,8 @@ variables:
   CLUSTER_TOPOLOGY: "true"
   EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION: "true"
   # The Flatcar image produced by the image-builder
-  OPENSTACK_FLATCAR_IMAGE_NAME: "flatcar-stable-4152.2.3-kube-v1.33.1"
-  OPENSTACK_FLATCAR_IMAGE_URL: "https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/flatcar/flatcar-stable-4152.2.3-kube-v1.33.1"
+  OPENSTACK_FLATCAR_IMAGE_NAME: "flatcar-stable"
+  OPENSTACK_FLATCAR_IMAGE_URL: "https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/flatcar/flatcar-stable-4459.2.0-kube-v1.34.2"
   # A plain Flatcar from the Flatcar releases server
   FLATCAR_IMAGE_NAME: "flatcar_production_openstack_image"
   FLATCAR_IMAGE_URL: https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_openstack_image.img

--- a/test/e2e/shared/defaults.go
+++ b/test/e2e/shared/defaults.go
@@ -37,6 +37,7 @@ import (
 const (
 	DefaultSSHKeyPairName      = "cluster-api-provider-openstack-sigs-k8s-io"
 	KubeContext                = "KUBE_CONTEXT"
+	KubernetesKindVersion      = "KUBERNETES_KIND_VERSION"
 	KubernetesVersion          = "KUBERNETES_VERSION"
 	CCMPath                    = "CCM"
 	CCMResources               = "CCM_RESOURCES"

--- a/test/e2e/suites/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/suites/e2e/clusterctl_upgrade_test.go
@@ -65,7 +65,7 @@ var _ = Describe("When testing clusterctl upgrades for CAPO (v0.11=>current) and
 			InitWithControlPlaneProviders:     []string{"kubeadm:" + capiRelease110},
 			MgmtFlavor:                        shared.FlavorDefault,
 			WorkloadFlavor:                    shared.FlavorCapiV1Beta1,
-			InitWithKubernetesVersion:         e2eCtx.E2EConfig.MustGetVariable(shared.KubernetesVersion),
+			InitWithKubernetesVersion:         e2eCtx.E2EConfig.MustGetVariable(shared.KubernetesKindVersion),
 			InitWithRuntimeExtensionProviders: []string{"openstack-resource-controller:v1.0.2"},
 			UseKindForManagementCluster:       true,
 		}
@@ -99,7 +99,7 @@ var _ = Describe("When testing clusterctl upgrades for CAPO (v0.12=>current) and
 			InitWithControlPlaneProviders:     []string{"kubeadm:" + capiRelease110},
 			MgmtFlavor:                        shared.FlavorDefault,
 			WorkloadFlavor:                    shared.FlavorCapiV1Beta1,
-			InitWithKubernetesVersion:         e2eCtx.E2EConfig.MustGetVariable(shared.KubernetesVersion),
+			InitWithKubernetesVersion:         e2eCtx.E2EConfig.MustGetVariable(shared.KubernetesKindVersion),
 			InitWithRuntimeExtensionProviders: []string{"openstack-resource-controller:v1.0.2"},
 			UseKindForManagementCluster:       true,
 		}
@@ -133,7 +133,7 @@ var _ = Describe("When testing clusterctl upgrades for CAPO (v0.13=>current) and
 			InitWithControlPlaneProviders:     []string{"kubeadm:" + capiRelease111},
 			MgmtFlavor:                        shared.FlavorDefault,
 			WorkloadFlavor:                    shared.FlavorDefault,
-			InitWithKubernetesVersion:         e2eCtx.E2EConfig.MustGetVariable(shared.KubernetesVersion),
+			InitWithKubernetesVersion:         e2eCtx.E2EConfig.MustGetVariable(shared.KubernetesKindVersion),
 			InitWithRuntimeExtensionProviders: []string{"openstack-resource-controller:v1.0.2"},
 			UseKindForManagementCluster:       true,
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Run e2e tests with k8s v1.34.2. Upgrades from v1.33.1.

Also changes the image names to not include the versions. It felt a bit unnecessary to constantly change both the URLs and the names.

Since we use kind for the clusterctl upgrade tests, we need
to use a kubernetes version that has a kind node image available also.
I have added a separate variable for this.
(We could also build the kind image but that takes time and resources.)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests
