### PR TITLE
[release-0.9] Fix instance deletion order

### DIFF
--- a/pkg/cloud/services/compute/instance_test.go
+++ b/pkg/cloud/services/compute/instance_test.go
@@ -1032,13 +1032,12 @@ func TestService_DeleteInstance(t *testing.T) {
 						Alias: "trunk",
 					},
 				}}, nil)
-				r.compute.DeleteAttachedInterface(instanceUUID, portUUID).Return(nil)
+				r.compute.DeleteServer(instanceUUID).Return(nil)
+				r.compute.GetServer(instanceUUID).Return(nil, gophercloud.ErrDefault404{})
+
 				// FIXME: Why we are looking for a trunk when we know the port is not trunked?
 				r.network.ListTrunk(trunks.ListOpts{PortID: portUUID}).Return([]trunks.Trunk{}, nil)
 				r.network.DeletePort(portUUID).Return(nil)
-
-				r.compute.DeleteServer(instanceUUID).Return(nil)
-				r.compute.GetServer(instanceUUID).Return(nil, gophercloud.ErrDefault404{})
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
Delete the OpenStack instance before deleting its network ports. This prevents "Policy doesn't allow compute:detach primary port" errors that occur when attempting to delete a primary NIC while the instance still exists.

Deleting the instance automatically detaches all interfaces, so the explicit detach call is no longer needed.

Related to https://issues.redhat.com/browse/OCPBUGS-65712.