### PR TITLE
🌱 Bump golangci-lint to v2.6.2

### DIFF
--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -15,7 +15,7 @@
 ROOT_DIR_RELATIVE := ../..
 include $(ROOT_DIR_RELATIVE)/common.mk
 
-GOLANGCI_LINT_VERSION ?= v2.4.0
+GOLANGCI_LINT_VERSION ?= v2.6.2
 
 # GOTESTSUM version without the leading 'v'
 GOTESTSUM_VERSION ?= 1.12.0

--- a/pkg/cloud/services/compute/instance.go
+++ b/pkg/cloud/services/compute/instance.go
@@ -65,8 +65,7 @@ func (s *Service) createInstanceImpl(eventObject runtime.Object, instanceSpec *I
 		})
 	}
 
-	instanceCreateTimeout := getTimeout("CLUSTER_API_OPENSTACK_INSTANCE_CREATE_TIMEOUT", timeoutInstanceCreate)
-	instanceCreateTimeout *= time.Minute
+	instanceCreateTimeout := getTimeout("CLUSTER_API_OPENSTACK_INSTANCE_CREATE_TIMEOUT", timeoutInstanceCreate, time.Minute)
 
 	// Don't set ImageRef on the server if we're booting from volume
 	var serverImageRef string
@@ -606,14 +605,14 @@ func (s *Service) GetInstanceStatusByName(eventObject runtime.Object, name strin
 	return nil, nil
 }
 
-func getTimeout(name string, timeout int) time.Duration {
+func getTimeout(name string, timeout int, unit time.Duration) time.Duration {
 	if v := os.Getenv(name); v != "" {
 		timeout, err := strconv.Atoi(v)
 		if err == nil {
-			return time.Duration(timeout)
+			return time.Duration(timeout) * unit
 		}
 	}
-	return time.Duration(timeout)
+	return time.Duration(timeout) * unit
 }
 
 // requiresTagging checks if the instanceSpec requires tagging,

--- a/test/e2e/shared/cluster.go
+++ b/test/e2e/shared/cluster.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2021 The Kubernetes Authors.

--- a/test/e2e/shared/common.go
+++ b/test/e2e/shared/common.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2021 The Kubernetes Authors.

--- a/test/e2e/shared/context.go
+++ b/test/e2e/shared/context.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2021 The Kubernetes Authors.

--- a/test/e2e/shared/defaults.go
+++ b/test/e2e/shared/defaults.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2021 The Kubernetes Authors.

--- a/test/e2e/shared/exec.go
+++ b/test/e2e/shared/exec.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2021 The Kubernetes Authors.

--- a/test/e2e/shared/exec_test.go
+++ b/test/e2e/shared/exec_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2021 The Kubernetes Authors.

--- a/test/e2e/shared/images.go
+++ b/test/e2e/shared/images.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2024 The Kubernetes Authors.

--- a/test/e2e/shared/openstack.go
+++ b/test/e2e/shared/openstack.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2021 The Kubernetes Authors.

--- a/test/e2e/shared/openstack_test.go
+++ b/test/e2e/shared/openstack_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2021 The Kubernetes Authors.

--- a/test/e2e/shared/suite.go
+++ b/test/e2e/shared/suite.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2021 The Kubernetes Authors.

--- a/test/e2e/suites/conformance/conformance_suite_test.go
+++ b/test/e2e/suites/conformance/conformance_suite_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2021 The Kubernetes Authors.

--- a/test/e2e/suites/conformance/conformance_test.go
+++ b/test/e2e/suites/conformance/conformance_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2021 The Kubernetes Authors.

--- a/test/e2e/suites/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/suites/e2e/clusterctl_upgrade_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2021 The Kubernetes Authors.

--- a/test/e2e/suites/e2e/e2e_suite_test.go
+++ b/test/e2e/suites/e2e/e2e_suite_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2021 The Kubernetes Authors.

--- a/test/e2e/suites/e2e/e2e_test.go
+++ b/test/e2e/suites/e2e/e2e_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2021 The Kubernetes Authors.

--- a/test/e2e/suites/e2e/remediations_test.go
+++ b/test/e2e/suites/e2e/remediations_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2021 The Kubernetes Authors.

--- a/test/e2e/suites/e2e/self_hosted_test.go
+++ b/test/e2e/suites/e2e/self_hosted_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2022 The Kubernetes Authors.


### PR DESCRIPTION
**What this PR does / why we need it**:

Similar to https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/2825.
Bumping golangci-lint to latest version and fixing issues.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests
