### PR TITLE
🌱Add new config to pr-link check

### DIFF
--- a/.github/workflows/pr-link-check.yaml
+++ b/.github/workflows/pr-link-check.yaml
@@ -54,6 +54,9 @@ jobs:
           --root-dir "$(pwd)/"
           --fallback-extensions "md"
           --github-token "${GITHUB_TOKEN}"
+          --insecure
+          --exclude-all-private
+          --no-progress
           $(cat changed-files.txt | tr '\n' ' ')
 
     - name: Provide helpful failure message


### PR DESCRIPTION
Adding new config for link check on PRs.

1. --insecure = ignore ssl problems 
2. --exclude-all-private = private addresses are unreachable anyways
3. --no-progress = don't print progress
