### PR TITLE
🌱 Bump go version to 1.24.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 # Build the manager binary
 ARG GO_VERSION
-FROM golang:${GO_VERSION:-1.24.9} AS builder
+FROM golang:${GO_VERSION:-1.24.11} AS builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg goproxy=$(go env GOPROXY) to override the goproxy

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ unexport GOPATH
 TRACE ?= 0
 
 # Go
-GO_VERSION ?= 1.24.9
+GO_VERSION ?= 1.24.11
 
 # Directories.
 ARTIFACTS ?= $(REPO_ROOT)/_artifacts

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@ command = "make -C docs/book build"
 publish = "docs/book/book"
 
 [build.environment]
-GO_VERSION = "1.24.9"
+GO_VERSION = "1.24.11"
 
 # Standard Netlify redirects
 [[redirects]]


### PR DESCRIPTION
New x/crypto vulnerablities to fix with go 1.24.11
 [CVE-2025-61727](https://go.dev/issue/76442)
 [CVE-2025-61729](https://go.dev/issue/76445)
