### PR TITLE
🐛 codegen: Remove sigs.k8s.io/cluster-api/api/ipam/v1beta1

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -49,7 +49,6 @@ declare -a gen_openapi_args=(
     --extra-pkgs sigs.k8s.io/cluster-api/api/core/v1beta2
     --extra-pkgs sigs.k8s.io/cluster-api/api/ipam/v1beta2
     --extra-pkgs sigs.k8s.io/cluster-api/api/core/v1beta1
-    --extra-pkgs sigs.k8s.io/cluster-api/api/ipam/v1beta1
     --extra-pkgs k8s.io/api/core/v1
 )
 


### PR DESCRIPTION

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

We have not needed this since the bump to CAPI v1beta2 in commit 3489aa8368edcd9cb63ae39585af09abd401f6c5. Its presence breaks the script when vendoring is in use.

This only applies to `release-0.13` since the update-codegen.sh script has been removed as part of a larger codegen rework in `main`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

(not bug reported: I can open one if needed though)

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
