### PR TITLE
🌱 Exclude `openshift` dir from boilerplate

### DIFF
--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -160,7 +160,7 @@ prune_dirs = [
     '.git',
     '.tiltbuild',
     'vendor',
-    'orc',
+    'openshift',
 ]
 
 # Paths to be ignored for boilerplate detection


### PR DESCRIPTION
**What this PR does / why we need it**:

While this obviously doesn't affect CAPO itself, such a tweak avoids us (Red Hat) having to carry this patch in the downstream mirror, leaving us more time to focus on CAPO itself :smile:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

n/a

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests
