### PR TITLE
🐛 Revert v1beta2 contract

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -27,4 +27,4 @@ releaseSeries:
   contract: v1beta1
 - major: 0
   minor: 13
-  contract: v1beta2
+  contract: v1beta1

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -122,8 +122,7 @@ providers:
   - name: v0.13.99
     value: ../../../config/default
     # This is the upcoming version.
-    # Specify no contract so that upgrade tests that start from a specific contract won't pick it up.
-    # contract: v1beta2
+    contract: v1beta1
     files:
     - sourcePath: "../data/shared/provider/metadata.yaml"
     - sourcePath: "./infrastructure-openstack-no-artifact/cluster-template.yaml"

--- a/test/e2e/data/shared/provider/metadata.yaml
+++ b/test/e2e/data/shared/provider/metadata.yaml
@@ -27,4 +27,4 @@ releaseSeries:
   contract: v1beta1
 - major: 0
   minor: 13
-  contract: v1beta2
+  contract: v1beta1


### PR DESCRIPTION
Manual backport of #2883. The conflict was in the e2e config in the provider versions used in upgrade tests. Those are not really relevant on the release branch anyway. We test the v0.13 -> main upgrade on the main branch, not here.

**What this PR does / why we need it**:

We have not fully implemented the contract yet, so we were wrong to advertise it. Sticking to v1beta1 until we are ready for real.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
