### PR TITLE
📖 Add stephenfin to maintainers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -21,6 +21,7 @@ aliases:
   cluster-api-openstack-maintainers:
     - emilienm
     - lentzi90
+    - stephenfin
   cluster-api-openstack-reviewers:
     - bnallapeta
     - smoshiur1237


### PR DESCRIPTION
I would like to step up and help more with the maintenance of CAPO, as I have been already doing for [for cloud-provider-openstack](https://github.com/kubernetes/cloud-provider-openstack/commits/master/?author=stephenfin) and [Gophercloud](https://github.com/gophercloud/gophercloud/commits/main/?author=stephenfin). This is in part to help plug the gap left by @mdbooth and @emilienm moving into other teams in RH.

Repeating myself from my equivalent proposal for CPO [earlier this year](https://github.com/kubernetes/cloud-provider-openstack/pull/2887), I expect my initial focus to mainly be maintenance of CI and occasional bug fixes, although I also expect that to grow rapidly given how of late I have taken ownership of CAPO's integration into various OpenShift components (Installer, cluster-capi-operator, HyperShift, ...).

As a more general point, I have also been [**very** active](https://review.opendev.org/q/owner:stephenfin@redhat.com) in upstream OpenStack for over a decade and have also been heavily involved in Gophercloud over the past 2-3 years. I am also a long-term active contributor to and maintainer of a variety of other (mostly Python-based) projects, so rest assured I am "vouched for" and won't be ramming features in, ignoring CI failures on PRs etc.

/hold
