### PR TITLE
📖 Add mandre to maintainers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -21,6 +21,7 @@ aliases:
   cluster-api-openstack-maintainers:
     - emilienm
     - lentzi90
+    - mandre
     - stephenfin
   cluster-api-openstack-reviewers:
     - bnallapeta


### PR DESCRIPTION
Following @stephenfin's recent addition to maintainers (https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/2906), I would also like to propose myself as a maintainer to help support the project's ongoing development.

Relevant experience:
* I am a maintainer of [gophercloud](https://github.com/gophercloud/gophercloud/commits/main/?author=mandre).
* I lead the [ORC](https://github.com/k-orc/openstack-resource-controller) project. As CAPO moves toward utilizing ORC more heavily (e.g. for the new machine controller), my involvement here will help facilitate that integration and alignment between the projects.

I am committed to using maintainer privileges responsibly, ensuring I only provide approvals on changes where I possess sufficient context and understanding.