### PR TITLE
🌱 Update metadata for v0.14

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -28,3 +28,6 @@ releaseSeries:
 - major: 0
   minor: 13
   contract: v1beta1
+- major: 0
+  minor: 14
+  contract: v1beta1

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -17,8 +17,8 @@ providers:
 - name: cluster-api
   type: CoreProvider
   versions:
-  - name: "{go://sigs.k8s.io/cluster-api@v1.11}"
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.11}/core-components.yaml"
+  - name: "{go://sigs.k8s.io/cluster-api@v1.12}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.12}/core-components.yaml"
     type: "url"
     contract: v1beta2
     replacements:
@@ -27,8 +27,8 @@ providers:
     files:
     - sourcePath: "../data/shared/capi/metadata.yaml"
   # For clusterctl upgrade test
-  - name: v1.11.0
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.0/core-components.yaml"
+  - name: "{go://sigs.k8s.io/cluster-api@v1.11}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.11}/core-components.yaml"
     type: "url"
     contract: v1beta2
     replacements:
@@ -50,8 +50,8 @@ providers:
 - name: kubeadm
   type: BootstrapProvider
   versions:
-  - name: "{go://sigs.k8s.io/cluster-api@v1.11}"
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.11}/bootstrap-components.yaml"
+  - name: "{go://sigs.k8s.io/cluster-api@v1.12}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.12}/bootstrap-components.yaml"
     type: "url"
     contract: v1beta2
     replacements:
@@ -60,8 +60,8 @@ providers:
     files:
     - sourcePath: "../data/shared/capi/metadata.yaml"
   # For clusterctl upgrade test
-  - name: v1.11.0
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.0/bootstrap-components.yaml"
+  - name: "{go://sigs.k8s.io/cluster-api@v1.11}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.11}/bootstrap-components.yaml"
     type: "url"
     contract: v1beta2
     replacements:
@@ -83,8 +83,8 @@ providers:
 - name: kubeadm
   type: ControlPlaneProvider
   versions:
-  - name: "{go://sigs.k8s.io/cluster-api@v1.11}"
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.11}/control-plane-components.yaml"
+  - name: "{go://sigs.k8s.io/cluster-api@v1.12}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.12}/control-plane-components.yaml"
     type: "url"
     contract: v1beta2
     replacements:
@@ -93,8 +93,8 @@ providers:
     files:
     - sourcePath: "../data/shared/capi/metadata.yaml"
   # For clusterctl upgrade test
-  - name: v1.11.0
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.0/control-plane-components.yaml"
+  - name: "{go://sigs.k8s.io/cluster-api@v1.11}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.11}/control-plane-components.yaml"
     type: "url"
     contract: v1beta2
     replacements:
@@ -162,7 +162,7 @@ providers:
       new: "--v=4"
     - old: "--leader-elect"
       new: "--leader-elect=false\n        - --sync-period=1m"
-  - name: v0.13.99
+  - name: v0.14.99
     value: ../../../config/default
     # This is the upcoming version.
     contract: v1beta1

--- a/test/e2e/data/shared/capi/metadata.yaml
+++ b/test/e2e/data/shared/capi/metadata.yaml
@@ -31,3 +31,6 @@ releaseSeries:
 - major: 1
   minor: 11
   contract: v1beta2
+- major: 1
+  minor: 12
+  contract: v1beta2

--- a/test/e2e/data/shared/provider/metadata.yaml
+++ b/test/e2e/data/shared/provider/metadata.yaml
@@ -28,3 +28,6 @@ releaseSeries:
 - major: 0
   minor: 13
   contract: v1beta1
+- major: 0
+  minor: 14
+  contract: v1beta1

--- a/test/e2e/suites/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/suites/e2e/clusterctl_upgrade_test.go
@@ -111,10 +111,10 @@ var _ = Describe("When testing clusterctl upgrades for CAPO (v0.13=>current) and
 		capoRelease013, err = clusterctl.ResolveRelease(ctx, "go://github.com/kubernetes-sigs/cluster-api-provider-openstack@v0.13")
 		Expect(err).ToNot(HaveOccurred(), "failed to get stable release of CAPO")
 		capoRelease013 = "v" + capoRelease013
-		// We need CAPI v1.11 here for clusterctl init with the v1beta2 contract.
-		// This is hard-coded to the .0 release because the test will fail if there are no
-		// newer patch releases to upgrade to.
-		capiRelease111 = "v1.11.0"
+		// Note: This gives the version without the 'v' prefix, so we need to add it below.
+		capiRelease111, err = capi_e2e.GetStableReleaseOfMinor(ctx, "1.11")
+		Expect(err).ToNot(HaveOccurred(), "failed to get stable release of CAPI")
+		capiRelease111 = "v" + capiRelease111
 	})
 
 	capi_e2e.ClusterctlUpgradeSpec(context.TODO(), func() capi_e2e.ClusterctlUpgradeSpecInput {


### PR DESCRIPTION
**What this PR does / why we need it**:

Add new metadata entry for v0.14 (and CAPI v1.12).


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/2916

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests
