### PR TITLE
🌱 E2E: Use bucket for flatcar production image

### DIFF
--- a/test/e2e/shared/images.go
+++ b/test/e2e/shared/images.go
@@ -60,6 +60,8 @@ type DownloadImage struct {
 	ArtifactPath string
 	// A hash used to verify the downloaded image
 	Hash, HashAlgorithm string
+	// GlanceName overrides the inferred Glance image name if set
+	GlanceName string
 }
 
 func CoreImages(e2eCtx *E2EContext) []DownloadImage {
@@ -128,13 +130,16 @@ func ApplyGlanceImages(ctx context.Context, e2eCtx *E2EContext, images []Downloa
 		Expect(err).NotTo(HaveOccurred(), "parsing "+url)
 		d := strings.Split(u.Path, "/")
 		Expect(len(d)).To(BeNumerically(">", 1), "Not enough path elements in "+url)
-		glanceName := d[len(d)-1]
+		glanceName := image.GlanceName
+		if glanceName == "" {
+			glanceName = d[len(d)-1]
 
-		// Remove the type suffix
-		for _, suffix := range []string{".img", ".qcow2"} {
-			if strings.HasSuffix(glanceName, suffix) {
-				glanceName = glanceName[:len(glanceName)-len(suffix)]
-				continue
+			// Remove the type suffix
+			for _, suffix := range []string{".img", ".qcow2"} {
+				if strings.HasSuffix(glanceName, suffix) {
+					glanceName = glanceName[:len(glanceName)-len(suffix)]
+					continue
+				}
 			}
 		}
 

--- a/test/e2e/suites/e2e/e2e_test.go
+++ b/test/e2e/suites/e2e/e2e_test.go
@@ -72,8 +72,9 @@ func flatcarImages(e2eCtx *shared.E2EContext) []shared.DownloadImage {
 			ArtifactPath: "flatcar/" + e2eCtx.E2EConfig.GetVariable("OPENSTACK_FLATCAR_IMAGE_NAME") + ".img",
 		},
 		{
-			Name: "flatcar-openstack",
-			URL:  "https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_openstack_image.img",
+			Name:       "flatcar-openstack",
+			URL:        "https://storage.googleapis.com/artifacts.k8s-staging-capi-openstack.appspot.com/test/flatcar/flatcar_production_openstack_image-4459.2.2.img",
+			GlanceName: "flatcar_production_openstack_image",
 		},
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

There seems to be an issue with downloading the image straight from upstream.
Adapted from https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/2923

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
