### PR TITLE
🌱 Ignore ORC major/minor bumps on release branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -93,6 +93,9 @@ updates:
     update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
   - dependency-name: "sigs.k8s.io/controller-tools"
     update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+  # Ignore ORC major and minor bumps to prevent cascading k8s.io and controller-runtime updates
+  - dependency-name: "github.com/k-orc/openstack-resource-controller*"
+    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
   labels:
   - "area/dependency"
   - "ok-to-test"
@@ -141,6 +144,9 @@ updates:
   - dependency-name: "k8s.io/*"
     update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
   - dependency-name: "sigs.k8s.io/controller-tools"
+    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+  # Ignore ORC major and minor bumps to prevent cascading k8s.io and controller-runtime updates
+  - dependency-name: "github.com/k-orc/openstack-resource-controller*"
     update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
   # We will need k8s v0.31.3 to bump structured-merge-diff to v4.4.2 (check git history for details).
   - dependency-name: "sigs.k8s.io/structured-merge-diff/*"


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

ORC v2.4.0 depends on k8s.io/* v0.34
and controller-runtime v0.22, which causes cascading updates when Dependabot tries to update ORC on release branches.

By adding ORC to the ignore list for release branches, we prevent these cascading updates from occurring.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests
