### PR TITLE
🌱 Update dependabot and security scan for release-0.14

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
   target-branch: main
   groups:
     all-github-actions:
-      patterns: [ "*" ]
+      patterns: ["*"]
   commit-message:
     prefix: ":seedling:"
     include: scope
@@ -30,24 +30,73 @@ updates:
   target-branch: main
   groups:
     all-go-mod-patch-and-minor:
-      patterns: [ "*" ]
-      update-types: [ "patch", "minor" ]
+      patterns: ["*"]
+      update-types: ["patch", "minor"]
   commit-message:
     prefix: ":seedling:"
     include: scope
   ignore:
   # Ignore controller-runtime major and minor bumps as its upgraded manually.
   - dependency-name: "sigs.k8s.io/controller-runtime"
-    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
   # Ignore k8s major and minor bumps and its transitives modules
   - dependency-name: "k8s.io/*"
-    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
   - dependency-name: "sigs.k8s.io/controller-tools"
-    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
   labels:
   - "area/dependency"
   - "ok-to-test"
 ## main branch config ends here
+## release-0.14 branch config starts here
+# github-actions
+- directory: "/"
+  package-ecosystem: "github-actions"
+  schedule:
+    interval: "weekly"
+    day: "monday"
+  target-branch: release-0.14
+  groups:
+    all-github-actions:
+      patterns: ["*"]
+  commit-message:
+    prefix: ":seedling:"
+    include: scope
+  labels:
+  - "area/dependency"
+  - "ok-to-test"
+# Go directories
+- directories:
+  - "/"
+  - "/hack/tools"
+  package-ecosystem: "gomod"
+  schedule:
+    interval: "weekly"
+    day: "monday"
+  target-branch: release-0.14
+  groups:
+    all-go-mod-patch-and-minor:
+      patterns: ["*"]
+      update-types: ["patch", "minor"]
+  commit-message:
+    prefix: ":seedling:"
+    include: scope
+  ignore:
+  # Ignore CAPI major and minor bumps
+  - dependency-name: "sigs.k8s.io/cluster-api*"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  # Ignore controller-runtime major and minor bumps as its upgraded manually.
+  - dependency-name: "sigs.k8s.io/controller-runtime"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  # Ignore k8s major and minor bumps and its transitives modules
+  - dependency-name: "k8s.io/*"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  - dependency-name: "sigs.k8s.io/controller-tools"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  labels:
+  - "area/dependency"
+  - "ok-to-test"
+## release-0.14 branch config ends here
 ## release-0.13 branch config starts here
 # github-actions
 - directory: "/"
@@ -58,7 +107,7 @@ updates:
   target-branch: release-0.13
   groups:
     all-github-actions:
-      patterns: [ "*" ]
+      patterns: ["*"]
   commit-message:
     prefix: ":seedling:"
     include: scope
@@ -76,90 +125,27 @@ updates:
   target-branch: release-0.13
   groups:
     all-go-mod-patch-and-minor:
-      patterns: [ "*" ]
-      update-types: [ "patch", "minor" ]
+      patterns: ["*"]
+      update-types: ["patch", "minor"]
   commit-message:
     prefix: ":seedling:"
     include: scope
   ignore:
   # Ignore CAPI major and minor bumps
   - dependency-name: "sigs.k8s.io/cluster-api*"
-    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
   # Ignore controller-runtime major and minor bumps as its upgraded manually.
   - dependency-name: "sigs.k8s.io/controller-runtime"
-    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
   # Ignore k8s major and minor bumps and its transitives modules
   - dependency-name: "k8s.io/*"
-    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
   - dependency-name: "sigs.k8s.io/controller-tools"
-    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
   # Ignore ORC major and minor bumps to prevent cascading k8s.io and controller-runtime updates
   - dependency-name: "github.com/k-orc/openstack-resource-controller*"
-    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
   labels:
   - "area/dependency"
   - "ok-to-test"
 ## release-0.13 branch config ends here
-## release-0.12 branch config starts here
-# github-actions
-- directory: "/"
-  package-ecosystem: "github-actions"
-  schedule:
-    interval: "weekly"
-    day: "monday"
-  target-branch: release-0.12
-  groups:
-    all-github-actions:
-      patterns: [ "*" ]
-  commit-message:
-    prefix: ":seedling:"
-    include: scope
-  labels:
-  - "area/dependency"
-  - "ok-to-test"
-# Go directories
-- directories:
-  - "/"
-  - "/hack/tools"
-  package-ecosystem: "gomod"
-  schedule:
-    interval: "weekly"
-    day: "monday"
-  target-branch: release-0.12
-  groups:
-    all-go-mod-patch-and-minor:
-      patterns: [ "*" ]
-      update-types: [ "patch", "minor" ]
-  commit-message:
-    prefix: ":seedling:"
-    include: scope
-  ignore:
-  # Ignore CAPI major and minor bumps
-  - dependency-name: "sigs.k8s.io/cluster-api*"
-    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-  # Ignore controller-runtime major and minor bumps as its upgraded manually.
-  - dependency-name: "sigs.k8s.io/controller-runtime"
-    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-  # Ignore k8s major and minor bumps and its transitives modules
-  - dependency-name: "k8s.io/*"
-    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-  - dependency-name: "sigs.k8s.io/controller-tools"
-    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-  # Ignore ORC major and minor bumps to prevent cascading k8s.io and controller-runtime updates
-  - dependency-name: "github.com/k-orc/openstack-resource-controller*"
-    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-  # We will need k8s v0.31.3 to bump structured-merge-diff to v4.4.2 (check git history for details).
-  - dependency-name: "sigs.k8s.io/structured-merge-diff/*"
-  # These dependencies are skipped because they require a newer version of go:
-  - dependency-name: "github.com/a8m/envsubst"
-  - dependency-name: "github.com/onsi/gomega"
-  - dependency-name: "github.com/itchyny/gojq"
-  - dependency-name: "golang.org/x/crypto"
-  - dependency-name: "golang.org/x/text"
-  # Newer kustomize requires a bump to kube-openapi, which has some incompatibility with gengo.
-  - dependency-name: "sigs.k8s.io/kustomize/kustomize/*"
-  labels:
-  - "area/dependency"
-  - "ok-to-test"
-
-## release-0.12 branch config ends here

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [ main, release-0.13, release-0.12 ]
+        branch: [main, release-0.14, release-0.13]
     name: Trivy
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
**What this PR does / why we need it**:

Update dependabot and security scan config for release-0.14. We drop release-0.12 and add release-0.14.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #2916

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
