### PR TITLE
🌱Bump golang version to 1.24.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 # Build the manager binary
 ARG GO_VERSION
-FROM golang:${GO_VERSION:-1.24.11} AS builder
+FROM golang:${GO_VERSION:-1.24.12} AS builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg goproxy=$(go env GOPROXY) to override the goproxy

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ unexport GOPATH
 TRACE ?= 0
 
 # Go
-GO_VERSION ?= 1.24.11
+GO_VERSION ?= 1.24.12
 
 # Directories.
 ARTIFACTS ?= $(REPO_ROOT)/_artifacts

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@ command = "make -C docs/book build"
 publish = "docs/book/book"
 
 [build.environment]
-GO_VERSION = "1.24.11"
+GO_VERSION = "1.24.12"
 
 # Standard Netlify redirects
 [[redirects]]


### PR DESCRIPTION
Uplift go version to 1.24.12 to address some new vulnerabilities
This is CVE-2025-68119 and Go issue https://go.dev/issue/77099
This is CVE-2025-61731 and Go issue https://go.dev/issue/77100
This is CVE-2025-61728 and Go issue https://go.dev/issue/77102
This is CVE-2025-61726 and Go issue https://go.dev/issue/77101
This is CVE-2025-68121 and Go issue https://go.dev/issue/77113
