### PR TITLE
:seedling: Remove unused vars/consts

### DIFF
--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -60,8 +60,7 @@ import (
 )
 
 const (
-	waitForBastionToReconcile  = 15 * time.Second
-	waitForOctaviaPortsCleanup = 15 * time.Second
+	waitForBastionToReconcile = 15 * time.Second
 )
 
 // OpenStackClusterReconciler reconciles a OpenStackCluster object.

--- a/pkg/cloud/services/loadbalancer/loadbalancer.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer.go
@@ -45,7 +45,6 @@ import (
 const (
 	networkPrefix           string = "k8s-clusterapi"
 	kubeapiLBSuffix         string = "kubeapi"
-	resolvedMsg             string = "ControlPlaneEndpoint.Host is not an IP address, using the first resolved IP address"
 	waitForOctaviaLBCleanup        = 15 * time.Second
 )
 

--- a/pkg/cloud/services/networking/securitygroups.go
+++ b/pkg/cloud/services/networking/securitygroups.go
@@ -36,7 +36,6 @@ const (
 	controlPlaneSuffix string = "controlplane"
 	workerSuffix       string = "worker"
 	bastionSuffix      string = "bastion"
-	allNodesSuffix     string = "allNodes"
 	remoteGroupIDSelf  string = "self"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove unused variables and constants detected by gopls but not reported by golangci-lint.

**Special notes for your reviewer**:
Not sure why those were not caught by golangci-lint (it does use a different "unused" than gopls), spent some time trying to figure it out but couldn't. 

- [X] squashed commits
- if necessary:
  - [X] includes documentation
  - [X] adds unit tests

/hold
