### PR TITLE
🌱 Update golangci-lint to v2.8.0

### DIFF
--- a/controllers/openstackserver_controller_test.go
+++ b/controllers/openstackserver_controller_test.go
@@ -353,7 +353,8 @@ func TestOpenStackServerReconciler_requeueOpenStackServersForCluster(t *testing.
 			g.Expect(clusterv1.AddToScheme(scheme)).To(Succeed())
 			g.Expect(infrav1alpha1.AddToScheme(scheme)).To(Succeed())
 
-			objs := []client.Object{tt.cluster}
+			objs := make([]client.Object, 0, 1+len(tt.servers))
+			objs = append(objs, tt.cluster)
 			for _, server := range tt.servers {
 				objs = append(objs, server)
 			}

--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -15,7 +15,7 @@
 ROOT_DIR_RELATIVE := ../..
 include $(ROOT_DIR_RELATIVE)/common.mk
 
-GOLANGCI_LINT_VERSION ?= v2.7.2
+GOLANGCI_LINT_VERSION ?= v2.8.0
 
 # GOTESTSUM version without the leading 'v'
 GOTESTSUM_VERSION ?= 1.12.0

--- a/main.go
+++ b/main.go
@@ -344,7 +344,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager, caCerts []byte) {
 			UseCache: true,
 		},
 	}
-	crdMigratorSkipPhases := []crdmigrator.Phase{}
+	crdMigratorSkipPhases := make([]crdmigrator.Phase, 0, len(skipCRDMigrationPhases))
 	for _, p := range skipCRDMigrationPhases {
 		crdMigratorSkipPhases = append(crdMigratorSkipPhases, crdmigrator.Phase(p))
 	}

--- a/pkg/cloud/services/compute/instance_types.go
+++ b/pkg/cloud/services/compute/instance_types.go
@@ -146,7 +146,8 @@ func (is *InstanceStatus) NetworkStatus() (*InstanceNetworkStatus, error) {
 			return nil, fmt.Errorf("error unmarshalling addresses for instance %s: %w", is.ID(), err)
 		}
 
-		var IPv4addresses, IPv6addresses []corev1.NodeAddress
+		IPv4addresses := make([]corev1.NodeAddress, 0, len(interfaceList))
+		IPv6addresses := make([]corev1.NodeAddress, 0, len(interfaceList))
 		for i := range interfaceList {
 			address := &interfaceList[i]
 
@@ -194,7 +195,12 @@ func (ns *InstanceNetworkStatus) Addresses() []corev1.NodeAddress {
 	}
 	sort.Strings(networks)
 
-	var addresses []corev1.NodeAddress
+	// Calculate total number of addresses to preallocate
+	totalAddresses := 0
+	for _, addrs := range ns.addresses {
+		totalAddresses += len(addrs)
+	}
+	addresses := make([]corev1.NodeAddress, 0, totalAddresses)
 	for _, network := range networks {
 		addressList := ns.addresses[network]
 		addresses = append(addresses, addressList...)

--- a/pkg/cloud/services/loadbalancer/loadbalancer.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer.go
@@ -153,7 +153,8 @@ func (s *Service) ReconcileLoadBalancer(openStackCluster *infrav1.OpenStackClust
 		lbStatus.AllowedCIDRs = nil
 	}
 
-	portList := []int{apiServerPort}
+	portList := make([]int, 0, 1+len(lbSpec.AdditionalPorts))
+	portList = append(portList, apiServerPort)
 	portList = append(portList, lbSpec.AdditionalPorts...)
 	for _, port := range portList {
 		if err := s.reconcileAPILoadBalancerListener(lb, openStackCluster, clusterResourceName, port); err != nil {
@@ -247,7 +248,7 @@ func getCanonicalAllowedCIDRs(openStackCluster *infrav1.OpenStackCluster) []stri
 	}
 
 	// Filter invalid CIDRs and convert any IPs into CIDRs.
-	validCIDRs := []string{}
+	validCIDRs := make([]string, 0, len(allowedCIDRs))
 	for _, v := range allowedCIDRs {
 		switch {
 		case utilsnet.IsIPv4String(v):

--- a/pkg/cloud/services/networking/port.go
+++ b/pkg/cloud/services/networking/port.go
@@ -663,7 +663,7 @@ func uniqueSortedTags(tags []string) []string {
 		tagsMap[t] = t
 	}
 
-	uniqueTags := []string{}
+	uniqueTags := make([]string, 0, len(tagsMap))
 	for k := range tagsMap {
 		uniqueTags = append(uniqueTags, k)
 	}

--- a/pkg/cloud/services/networking/securitygroups_rules.go
+++ b/pkg/cloud/services/networking/securitygroups_rules.go
@@ -257,7 +257,6 @@ func getSGWorkerAllowAll(remoteGroupIDSelf, secControlPlaneGroupID string) []res
 
 // Permit ports that defined in openStackCluster.Spec.APIServerLoadBalancer.AdditionalPorts.
 func getSGControlPlaneAdditionalPorts(ports []int) []resolvedSecurityGroupRuleSpec {
-	controlPlaneRules := []resolvedSecurityGroupRuleSpec{}
 	// Preallocate r with len(ports)
 	r := make([]resolvedSecurityGroupRuleSpec, len(ports))
 	for i, p := range ports {
@@ -270,18 +269,13 @@ func getSGControlPlaneAdditionalPorts(ports []int) []resolvedSecurityGroupRuleSp
 			PortRangeMax: p,
 		}
 	}
-	controlPlaneRules = append(controlPlaneRules, r...)
-	return controlPlaneRules
+	return r
 }
 
 func getSGControlPlaneGeneral(remoteGroupIDSelf, secWorkerGroupID string) []resolvedSecurityGroupRuleSpec {
-	controlPlaneRules := []resolvedSecurityGroupRuleSpec{}
-	controlPlaneRules = append(controlPlaneRules, getSGControlPlaneCommon(remoteGroupIDSelf, secWorkerGroupID)...)
-	return controlPlaneRules
+	return getSGControlPlaneCommon(remoteGroupIDSelf, secWorkerGroupID)
 }
 
 func getSGWorkerGeneral(remoteGroupIDSelf, secControlPlaneGroupID string) []resolvedSecurityGroupRuleSpec {
-	workerRules := []resolvedSecurityGroupRuleSpec{}
-	workerRules = append(workerRules, getSGWorkerCommon(remoteGroupIDSelf, secControlPlaneGroupID)...)
-	return workerRules
+	return getSGWorkerCommon(remoteGroupIDSelf, secControlPlaneGroupID)
 }

--- a/test/e2e/suites/e2e/e2e_test.go
+++ b/test/e2e/suites/e2e/e2e_test.go
@@ -764,7 +764,7 @@ var _ = Describe("e2e tests [PR-Blocking]", func() {
 			openStackCluster, err := shared.ClusterForSpec(ctx, e2eCtx, namespace)
 			Expect(err).NotTo(HaveOccurred())
 
-			var allMachines []clusterv1.Machine
+			allMachines := make([]clusterv1.Machine, 0, len(controlPlaneMachines)+len(workerMachines))
 			allMachines = append(allMachines, controlPlaneMachines...)
 			allMachines = append(allMachines, workerMachines...)
 
@@ -787,7 +787,7 @@ var _ = Describe("e2e tests [PR-Blocking]", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(ports).To(HaveLen(len(expectedPorts)))
 
-				var seenNetworks []string
+				seenNetworks := make([]string, 0, len(ports))
 				var seenAddresses clusterv1.MachineAddresses
 				for j := range ports {
 					port := &ports[j]
@@ -938,7 +938,7 @@ var _ = Describe("e2e tests [PR-Blocking]", func() {
 				fmt.Sprintf("Cluster %s: worker machines were not scheduled in the expected AZ", cluster.Name))
 
 			// Check that all machines were actually scheduled in the correct AZ
-			var allMachines []clusterv1.Machine
+			allMachines := make([]clusterv1.Machine, 0, len(controlPlaneMachines)+len(workerMachines))
 			allMachines = append(allMachines, controlPlaneMachines...)
 			allMachines = append(allMachines, workerMachines...)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump golangci-lint to v2.8.0 #2951

Changes
1. Version Update
  Updated hack/tools/Makefile to use v2.8.0.

2. Code Fixes
  Fixed prealloc linter issues in the following files by preallocating slices with known usage capacities:
  
    test/e2e/suites/e2e/e2e_test.go
    pkg/cloud/services/networking/port.go
    pkg/cloud/services/networking/securitygroups_rules.go
    pkg/cloud/services/compute/instance_types.go
    pkg/cloud/services/loadbalancer/loadbalancer.go
    main.gocontrollers/openstackserver_controller_test.go
    

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

- [x ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
