### PR TITLE
:seedling: Mark autoscaler e2e test as non-blocking

### DIFF
--- a/test/e2e/suites/e2e/autoscaler_test.go
+++ b/test/e2e/suites/e2e/autoscaler_test.go
@@ -31,7 +31,7 @@ import (
 
 // Currently marked as PR-blocking to ensure it runs
 // might need to remove it.
-var _ = Describe("Autoscaler on ClusterClass cluster [PR-Blocking] [Autoscaler] [ClusterClass]", func() {
+var _ = Describe("Autoscaler on ClusterClass cluster [Autoscaler] [ClusterClass]", func() {
 	capi_e2e.AutoscalerSpec(context.TODO(), func() capi_e2e.AutoscalerSpecInput {
 		infraAPIGroup := infrav1.GroupName
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Mark autoscaler e2e test as non-blocking

**Which issue(s) this PR fixes**:
Fixes #2952 

**TODOs**:

- [X] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
