### PR TITLE
🌱 Add OpenStackAuthenticationSucceeded condition

### DIFF
--- a/api/v1beta1/conditions_consts.go
+++ b/api/v1beta1/conditions_consts.go
@@ -73,6 +73,14 @@ const (
 )
 
 const (
+	// OpenStackAuthenticationSucceeded reports on the current status of the OpenStack credentials.
+	OpenStackAuthenticationSucceeded clusterv1beta1.ConditionType = "OpenStackAuthenticationSucceeded"
+
+	// OpenStackAuthenticationFailedReason is used when the controller fails to authenticate with OpenStack.
+	OpenStackAuthenticationFailedReason = "OpenStackAuthenticationFailed"
+)
+
+const (
 	// NetworkReadyCondition reports on the current status of the cluster network infrastructure.
 	// Ready indicates that the network, subnets, and related resources have been successfully provisioned.
 	NetworkReadyCondition clusterv1beta1.ConditionType = "NetworkReady"

--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -124,8 +124,10 @@ func (r *OpenStackClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	clientScope, err := r.ScopeFactory.NewClientScopeFromObject(ctx, r.Client, r.CaCertificates, log, openStackCluster)
 	if err != nil {
+		v1beta1conditions.MarkFalse(openStackCluster, infrav1.OpenStackAuthenticationSucceeded, infrav1.OpenStackAuthenticationFailedReason, clusterv1beta1.ConditionSeverityError, "Failed to create OpenStack client scope: %v", err)
 		return reconcile.Result{}, err
 	}
+	v1beta1conditions.MarkTrue(openStackCluster, infrav1.OpenStackAuthenticationSucceeded)
 	scope := scope.NewWithLogger(clientScope, log)
 
 	// Handle deleted clusters

--- a/controllers/openstackfloatingippool_controller_test.go
+++ b/controllers/openstackfloatingippool_controller_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+	"go.uber.org/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
+	"sigs.k8s.io/cluster-api/test/framework"
+	v1beta1conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions"
+	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	infrav1alpha1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
+)
+
+var _ = Describe("OpenStackFloatingIPPool controller", func() {
+	var (
+		testPool        *infrav1alpha1.OpenStackFloatingIPPool
+		testNamespace   string
+		poolReconciler  *OpenStackFloatingIPPoolReconciler
+		poolMockCtrl    *gomock.Controller
+		poolMockFactory *scope.MockScopeFactory
+		testNum         int
+	)
+
+	BeforeEach(func() {
+		testNum++
+		testNamespace = fmt.Sprintf("pool-test-%d", testNum)
+
+		testPool = &infrav1alpha1.OpenStackFloatingIPPool{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: infrav1alpha1.SchemeGroupVersion.Group + "/" + infrav1alpha1.SchemeGroupVersion.Version,
+				Kind:       "OpenStackFloatingIPPool",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pool",
+				Namespace: testNamespace,
+			},
+			Spec: infrav1alpha1.OpenStackFloatingIPPoolSpec{
+				IdentityRef: infrav1.OpenStackIdentityReference{
+					Name:      "test-creds",
+					CloudName: "openstack",
+				},
+				ReclaimPolicy: infrav1alpha1.ReclaimDelete,
+			},
+		}
+
+		input := framework.CreateNamespaceInput{
+			Creator: k8sClient,
+			Name:    testNamespace,
+		}
+		framework.CreateNamespace(ctx, input)
+
+		poolMockCtrl = gomock.NewController(GinkgoT())
+		poolMockFactory = scope.NewMockScopeFactory(poolMockCtrl, "")
+		poolReconciler = &OpenStackFloatingIPPoolReconciler{
+			Client:       k8sClient,
+			ScopeFactory: poolMockFactory,
+		}
+	})
+
+	AfterEach(func() {
+		orphan := metav1.DeletePropagationOrphan
+		deleteOptions := client.DeleteOptions{
+			PropagationPolicy: &orphan,
+		}
+
+		// Remove finalizers and delete openstackfloatingippool
+		patchHelper, err := patch.NewHelper(testPool, k8sClient)
+		Expect(err).To(BeNil())
+		testPool.SetFinalizers([]string{})
+		err = patchHelper.Patch(ctx, testPool)
+		Expect(err).To(BeNil())
+		err = k8sClient.Delete(ctx, testPool, &deleteOptions)
+		Expect(err).To(BeNil())
+	})
+
+	It("should set OpenStackAuthenticationSucceededCondition to False when credentials secret is missing", func() {
+		testPool.SetName("missing-pool-credentials")
+		testPool.Spec.IdentityRef = infrav1.OpenStackIdentityReference{
+			Type:      "Secret",
+			Name:      "non-existent-secret",
+			CloudName: "openstack",
+		}
+
+		err := k8sClient.Create(ctx, testPool)
+		Expect(err).To(BeNil())
+
+		credentialsErr := fmt.Errorf("secret not found: non-existent-secret")
+		poolMockFactory.SetClientScopeCreateError(credentialsErr)
+
+		req := reconcile.Request{
+			NamespacedName: client.ObjectKey{
+				Name:      testPool.Name,
+				Namespace: testPool.Namespace,
+			},
+		}
+		result, err := poolReconciler.Reconcile(ctx, req)
+
+		Expect(err).To(MatchError(credentialsErr))
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		// Fetch the updated OpenStackFloatingIPPool to verify the condition was set
+		updatedPool := &infrav1alpha1.OpenStackFloatingIPPool{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{Name: testPool.Name, Namespace: testPool.Namespace}, updatedPool)).To(Succeed())
+
+		// Verify OpenStackAuthenticationSucceededCondition is set to False
+		Expect(v1beta1conditions.IsFalse(updatedPool, infrav1.OpenStackAuthenticationSucceeded)).To(BeTrue())
+		condition := v1beta1conditions.Get(updatedPool, infrav1.OpenStackAuthenticationSucceeded)
+		Expect(condition).ToNot(BeNil())
+		Expect(condition.Reason).To(Equal(infrav1.OpenStackAuthenticationFailedReason))
+		Expect(condition.Severity).To(Equal(clusterv1beta1.ConditionSeverityError))
+		Expect(condition.Message).To(ContainSubstring("Failed to create OpenStack client scope"))
+	})
+
+	It("should set OpenStackAuthenticationSucceededCondition to False when namespace is denied access to ClusterIdentity", func() {
+		testPool.SetName("identity-access-denied-pool")
+		testPool.Spec.IdentityRef = infrav1.OpenStackIdentityReference{
+			Type:      "ClusterIdentity",
+			Name:      "test-cluster-identity",
+			CloudName: "openstack",
+		}
+
+		err := k8sClient.Create(ctx, testPool)
+		Expect(err).To(BeNil())
+
+		identityAccessErr := &scope.IdentityAccessDeniedError{
+			IdentityName:       "test-cluster-identity",
+			RequesterNamespace: testNamespace,
+		}
+		poolMockFactory.SetClientScopeCreateError(identityAccessErr)
+
+		req := reconcile.Request{
+			NamespacedName: client.ObjectKey{
+				Name:      testPool.Name,
+				Namespace: testPool.Namespace,
+			},
+		}
+		result, err := poolReconciler.Reconcile(ctx, req)
+
+		Expect(err).To(MatchError(identityAccessErr))
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		// Fetch the updated OpenStackFloatingIPPool to verify the condition was set
+		updatedPool := &infrav1alpha1.OpenStackFloatingIPPool{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{Name: testPool.Name, Namespace: testPool.Namespace}, updatedPool)).To(Succeed())
+
+		// Verify OpenStackAuthenticationSucceededCondition is set to False
+		Expect(v1beta1conditions.IsFalse(updatedPool, infrav1.OpenStackAuthenticationSucceeded)).To(BeTrue())
+		condition := v1beta1conditions.Get(updatedPool, infrav1.OpenStackAuthenticationSucceeded)
+		Expect(condition).ToNot(BeNil())
+		Expect(condition.Reason).To(Equal(infrav1.OpenStackAuthenticationFailedReason))
+		Expect(condition.Severity).To(Equal(clusterv1beta1.ConditionSeverityError))
+		Expect(condition.Message).To(ContainSubstring("Failed to create OpenStack client scope"))
+	})
+})

--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -150,8 +150,10 @@ func (r *OpenStackMachineReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	clientScope, err := r.ScopeFactory.NewClientScopeFromObject(ctx, r.Client, r.CaCertificates, log, openStackMachine, infraCluster)
 	if err != nil {
+		v1beta1conditions.MarkFalse(openStackMachine, infrav1.OpenStackAuthenticationSucceeded, infrav1.OpenStackAuthenticationFailedReason, clusterv1beta1.ConditionSeverityError, "Failed to create OpenStack client scope: %v", err)
 		return reconcile.Result{}, err
 	}
+	v1beta1conditions.MarkTrue(openStackMachine, infrav1.OpenStackAuthenticationSucceeded)
 	scope := scope.NewWithLogger(clientScope, log)
 
 	clusterResourceName := fmt.Sprintf("%s-%s", cluster.Namespace, cluster.Name)


### PR DESCRIPTION
**What this PR does / why we need it**:

- Sets OpenStackAuthenticationSucceededCondition to True/False based on credential validity during reconciliation.
- Adds tests for condition handling on credential errors and missing secrets.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2264

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [x] adds unit tests

/hold
