### PR TITLE
🌱Bump golang version to 1.24.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 # Build the manager binary
 ARG GO_VERSION
-FROM golang:${GO_VERSION:-1.24.12} AS builder
+FROM golang:${GO_VERSION:-1.24.13} AS builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg goproxy=$(go env GOPROXY) to override the goproxy

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ unexport GOPATH
 TRACE ?= 0
 
 # Go
-GO_VERSION ?= 1.24.12
+GO_VERSION ?= 1.24.13
 
 # Directories.
 ARTIFACTS ?= $(REPO_ROOT)/_artifacts

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@ command = "make -C docs/book build"
 publish = "docs/book/book"
 
 [build.environment]
-GO_VERSION = "1.24.12"
+GO_VERSION = "1.24.13"
 
 # Standard Netlify redirects
 [[redirects]]


### PR DESCRIPTION
Bump golang version to 1.24.13 to have fix CVES:
This is CVE-2025-61732 and https://go.dev/issue/76697 .
Also updates CVE-2025-68121 and Go issue https://go.dev/issue/77217.