### PR TITLE
:seedling: Bump golangci-lint to 2.9.0

### DIFF
--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -15,7 +15,7 @@
 ROOT_DIR_RELATIVE := ../..
 include $(ROOT_DIR_RELATIVE)/common.mk
 
-GOLANGCI_LINT_VERSION ?= v2.8.0
+GOLANGCI_LINT_VERSION ?= v2.9.0
 
 # GOTESTSUM version without the leading 'v'
 GOTESTSUM_VERSION ?= 1.12.0

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package metrics
+package metrics //nolint:revive
 
 import (
 	"sync"

--- a/pkg/utils/strings/strings_test.go
+++ b/pkg/utils/strings/strings_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package strings
+package strings //nolint:revive
 
 import (
 	"slices"

--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package version
+package version //nolint:revive
 
 import (
 	"fmt"


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump golangci-lint to 2.9.0

**Special notes for your reviewer**:
Had some errors like:
```
pkg/utils/strings/strings_test.go:17:9: var-naming: avoid package names that conflict with Go standard library package names (revive)
package strings
```
opted to use `//nolint:revive` on these lines as i though we probably:
- dont want to rename packages now
- do want to avoid this issue in future packages

(different option would be to use `skip-package-name-collision-with-go-std` in the revive lint [settings](https://golangci-lint.run/docs/linters/configuration/#revive))

**TODOs**:

- [X] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
