### PR TITLE
✨ Propagate OpenStackServer dependency errors to OpenStackMachine

### DIFF
--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -366,10 +366,20 @@ func (r *OpenStackMachineReconciler) reconcileNormal(ctx context.Context, scope 
 
 	scope.Logger().Info("Reconciling Machine")
 
-	machineServer, waitingForServer, err := r.reconcileMachineServer(ctx, scope, openStackMachine, openStackCluster, machine)
-	if err != nil || waitingForServer {
+	machineServer, err := r.reconcileMachineServer(ctx, scope, openStackMachine, openStackCluster, machine)
+	if err != nil {
 		return ctrl.Result{}, err
 	}
+
+	// Reconcile machine state early to propagate any errors from the OpenStackServer
+	// (e.g., image not found, instance creation failed) to the OpenStackMachine.
+	// This must happen before checking server readiness to ensure error states are visible.
+	result := r.reconcileMachineState(scope, openStackMachine, machine, machineServer)
+	if result != nil {
+		return *result, nil
+	}
+
+	// At this point the instance is ACTIVE. We can proceed with the rest of the reconciliation.
 
 	computeService, err := compute.NewService(scope)
 	if err != nil {
@@ -415,19 +425,34 @@ func (r *OpenStackMachineReconciler) reconcileNormal(ctx context.Context, scope 
 		v1beta1conditions.MarkTrue(openStackMachine, infrav1.APIServerIngressReadyCondition)
 	}
 
-	result := r.reconcileMachineState(scope, openStackMachine, machine, machineServer)
-	if result != nil {
-		return *result, nil
-	}
-
 	scope.Logger().Info("Reconciled Machine create successfully")
 	return ctrl.Result{}, nil
 }
 
 // reconcileMachineState updates the conditions of the OpenStackMachine instance based on the instance state
 // and sets the ProviderID and Ready fields when the instance is active.
-// It returns a reconcile request if the instance is not yet active.
+// It returns a reconcile request if the instance is not yet active or in an error state.
 func (r *OpenStackMachineReconciler) reconcileMachineState(scope *scope.WithLogger, openStackMachine *infrav1.OpenStackMachine, machine *clusterv1.Machine, openStackServer *infrav1alpha1.OpenStackServer) *ctrl.Result {
+	// Handle the case where the instance state is not yet available.
+	// This can happen when the server is still being created or when
+	// there was an error during resource resolution (e.g., image not found).
+	if openStackServer.Status.InstanceState == nil {
+		scope.Logger().Info("Waiting for OpenStackServer instance state", "name", openStackServer.Name)
+
+		// Check if there's a condition on the OpenStackServer that we should propagate.
+		// This helps surface errors like "image not found" or status like "waiting for dependencies" to the OpenStackMachine.
+		if condition := v1beta1conditions.Get(openStackServer, infrav1.InstanceReadyCondition); condition != nil && condition.Status == corev1.ConditionFalse {
+			// Propagate the condition from OpenStackServer with its severity
+			v1beta1conditions.MarkFalse(openStackMachine, infrav1.InstanceReadyCondition, condition.Reason, condition.Severity, "%s", condition.Message)
+			v1beta1conditions.MarkFalse(openStackMachine, clusterv1beta1.ReadyCondition, condition.Reason, condition.Severity, "%s", condition.Message)
+			return &ctrl.Result{RequeueAfter: waitForBuildingInstanceToReconcile}
+		}
+
+		v1beta1conditions.MarkFalse(openStackMachine, infrav1.InstanceReadyCondition, infrav1.InstanceNotReadyReason, clusterv1beta1.ConditionSeverityInfo, "Waiting for instance to be created")
+		v1beta1conditions.MarkFalse(openStackMachine, clusterv1beta1.ReadyCondition, infrav1.InstanceNotReadyReason, clusterv1beta1.ConditionSeverityInfo, "Waiting for instance to be created")
+		return &ctrl.Result{RequeueAfter: waitForBuildingInstanceToReconcile}
+	}
+
 	switch *openStackServer.Status.InstanceState {
 	case infrav1.InstanceStateActive:
 		scope.Logger().Info("Machine instance state is ACTIVE", "id", openStackServer.Status.InstanceID)
@@ -463,11 +488,19 @@ func (r *OpenStackMachineReconciler) reconcileMachineState(scope *scope.WithLogg
 		// If not, it is more likely a configuration error so we set failure and never retry.
 		scope.Logger().Info("Machine instance state is ERROR", "id", openStackServer.Status.InstanceID)
 		if !machine.Status.NodeRef.IsDefined() {
-			err := fmt.Errorf("instance state %v is unexpected", openStackServer.Status.InstanceState)
+			// Include the instance state in the error message for better debugging
+			err := fmt.Errorf("instance state %v is unexpected", *openStackServer.Status.InstanceState)
 			openStackMachine.SetFailure(capoerrors.DeprecatedCAPIUpdateMachineError, err)
 		}
-		v1beta1conditions.MarkFalse(openStackMachine, infrav1.InstanceReadyCondition, infrav1.InstanceStateErrorReason, clusterv1beta1.ConditionSeverityError, "")
-		v1beta1conditions.MarkFalse(openStackMachine, clusterv1beta1.ReadyCondition, infrav1.InstanceStateErrorReason, clusterv1beta1.ConditionSeverityError, "Instance is in ERROR state")
+		// Propagate the error message from the InstanceReady condition on the OpenStackServer if available
+		var errorMessage string
+		if condition := v1beta1conditions.Get(openStackServer, infrav1.InstanceReadyCondition); condition != nil && condition.Message != "" {
+			errorMessage = condition.Message
+		} else {
+			errorMessage = "Instance is in ERROR state"
+		}
+		v1beta1conditions.MarkFalse(openStackMachine, infrav1.InstanceReadyCondition, infrav1.InstanceStateErrorReason, clusterv1beta1.ConditionSeverityError, "%s", errorMessage)
+		v1beta1conditions.MarkFalse(openStackMachine, clusterv1beta1.ReadyCondition, infrav1.InstanceStateErrorReason, clusterv1beta1.ConditionSeverityError, "%s", errorMessage)
 		return &ctrl.Result{}
 	case infrav1.InstanceStateDeleted:
 		// we should avoid further actions for DELETED VM
@@ -600,22 +633,18 @@ func openStackMachineSpecToOpenStackServerSpec(openStackMachineSpec *infrav1.Ope
 }
 
 // reconcileMachineServer reconciles the OpenStackServer object for the OpenStackMachine.
-// It returns the OpenStackServer object and a boolean indicating if the OpenStackServer is ready.
-func (r *OpenStackMachineReconciler) reconcileMachineServer(ctx context.Context, scope *scope.WithLogger, openStackMachine *infrav1.OpenStackMachine, openStackCluster *infrav1.OpenStackCluster, machine *clusterv1.Machine) (*infrav1alpha1.OpenStackServer, bool, error) {
-	var server *infrav1alpha1.OpenStackServer
+// It returns the OpenStackServer object. The caller should check the server status
+// using reconcileMachineState to handle different server states appropriately.
+func (r *OpenStackMachineReconciler) reconcileMachineServer(ctx context.Context, scope *scope.WithLogger, openStackMachine *infrav1.OpenStackMachine, openStackCluster *infrav1.OpenStackCluster, machine *clusterv1.Machine) (*infrav1alpha1.OpenStackServer, error) {
 	server, err := r.getOrCreateMachineServer(ctx, openStackCluster, openStackMachine, machine)
 	if err != nil {
 		// If an error occurs while getting or creating the OpenStackServer,
 		// we won't requeue the request so reconcileNormal can add conditions to the OpenStackMachine
 		// and we can see the error in the logs.
 		scope.Logger().Error(err, "Failed to get or create OpenStackServer")
-		return server, false, err
+		return server, err
 	}
-	if !server.Status.Ready {
-		scope.Logger().Info("Waiting for OpenStackServer to be ready", "name", server.Name)
-		return server, true, nil
-	}
-	return server, false, nil
+	return server, nil
 }
 
 // getOrCreateMachineServer gets or creates the OpenStackServer object for the OpenStackMachine.

--- a/controllers/openstackmachine_controller_test.go
+++ b/controllers/openstackmachine_controller_test.go
@@ -446,11 +446,12 @@ func TestGetPortIDs(t *testing.T) {
 	}
 }
 
-func TestReconcileMachineState(t *testing.T) {
+func TestReconcileMachineState(t *testing.T) { //nolint:gocyclo,cyclop // this is test code
 	tests := []struct {
 		name                            string
-		instanceState                   infrav1.InstanceState
+		instanceState                   *infrav1.InstanceState
 		machineHasNodeRef               bool
+		serverConditions                []clusterv1beta1.Condition
 		expectRequeue                   bool
 		expectedInstanceReadyCondition  *clusterv1beta1.Condition
 		expectedReadyCondition          *clusterv1beta1.Condition
@@ -458,8 +459,83 @@ func TestReconcileMachineState(t *testing.T) {
 		expectFailureSet                bool
 	}{
 		{
+			name:          "Nil InstanceState with DependencyFailed condition propagates error to machine",
+			instanceState: nil,
+			serverConditions: []clusterv1beta1.Condition{
+				{
+					Type:     infrav1.InstanceReadyCondition,
+					Status:   corev1.ConditionFalse,
+					Severity: clusterv1beta1.ConditionSeverityError,
+					Reason:   infrav1.DependencyFailedReason,
+					Message:  "Failed to resolve server spec: image not found",
+				},
+			},
+			expectRequeue: true,
+			expectedInstanceReadyCondition: &clusterv1beta1.Condition{
+				Type:     infrav1.InstanceReadyCondition,
+				Status:   corev1.ConditionFalse,
+				Severity: clusterv1beta1.ConditionSeverityError,
+				Reason:   infrav1.DependencyFailedReason,
+				Message:  "Failed to resolve server spec: image not found",
+			},
+			expectedReadyCondition: &clusterv1beta1.Condition{
+				Type:     clusterv1beta1.ReadyCondition,
+				Status:   corev1.ConditionFalse,
+				Severity: clusterv1beta1.ConditionSeverityError,
+				Reason:   infrav1.DependencyFailedReason,
+				Message:  "Failed to resolve server spec: image not found",
+			},
+		},
+		{
+			name:          "Nil InstanceState with InstanceNotReady condition propagates info to machine",
+			instanceState: nil,
+			serverConditions: []clusterv1beta1.Condition{
+				{
+					Type:     infrav1.InstanceReadyCondition,
+					Status:   corev1.ConditionFalse,
+					Severity: clusterv1beta1.ConditionSeverityInfo,
+					Reason:   infrav1.InstanceNotReadyReason,
+					Message:  "Waiting for dependencies",
+				},
+			},
+			expectRequeue: true,
+			expectedInstanceReadyCondition: &clusterv1beta1.Condition{
+				Type:     infrav1.InstanceReadyCondition,
+				Status:   corev1.ConditionFalse,
+				Severity: clusterv1beta1.ConditionSeverityInfo,
+				Reason:   infrav1.InstanceNotReadyReason,
+				Message:  "Waiting for dependencies",
+			},
+			expectedReadyCondition: &clusterv1beta1.Condition{
+				Type:     clusterv1beta1.ReadyCondition,
+				Status:   corev1.ConditionFalse,
+				Severity: clusterv1beta1.ConditionSeverityInfo,
+				Reason:   infrav1.InstanceNotReadyReason,
+				Message:  "Waiting for dependencies",
+			},
+		},
+		{
+			name:          "Nil InstanceState with no server condition sets default waiting conditions",
+			instanceState: nil,
+			expectRequeue: true,
+			expectedInstanceReadyCondition: &clusterv1beta1.Condition{
+				Type:     infrav1.InstanceReadyCondition,
+				Status:   corev1.ConditionFalse,
+				Severity: clusterv1beta1.ConditionSeverityInfo,
+				Reason:   infrav1.InstanceNotReadyReason,
+				Message:  "Waiting for instance to be created",
+			},
+			expectedReadyCondition: &clusterv1beta1.Condition{
+				Type:     clusterv1beta1.ReadyCondition,
+				Status:   corev1.ConditionFalse,
+				Severity: clusterv1beta1.ConditionSeverityInfo,
+				Reason:   infrav1.InstanceNotReadyReason,
+				Message:  "Waiting for instance to be created",
+			},
+		},
+		{
 			name:          "Instance state ACTIVE sets conditions to True and initialization.provisioned",
-			instanceState: infrav1.InstanceStateActive,
+			instanceState: ptr.To(infrav1.InstanceStateActive),
 			expectRequeue: false,
 			expectedInstanceReadyCondition: &clusterv1beta1.Condition{
 				Type:   infrav1.InstanceReadyCondition,
@@ -473,7 +549,7 @@ func TestReconcileMachineState(t *testing.T) {
 		},
 		{
 			name:              "Instance state ERROR sets conditions to False without NodeRef",
-			instanceState:     infrav1.InstanceStateError,
+			instanceState:     ptr.To(infrav1.InstanceStateError),
 			machineHasNodeRef: false,
 			expectRequeue:     true,
 			expectedInstanceReadyCondition: &clusterv1beta1.Condition{
@@ -492,7 +568,7 @@ func TestReconcileMachineState(t *testing.T) {
 		},
 		{
 			name:              "Instance state ERROR with NodeRef does not set failure",
-			instanceState:     infrav1.InstanceStateError,
+			instanceState:     ptr.To(infrav1.InstanceStateError),
 			machineHasNodeRef: true,
 			expectRequeue:     true,
 			expectedInstanceReadyCondition: &clusterv1beta1.Condition{
@@ -510,8 +586,38 @@ func TestReconcileMachineState(t *testing.T) {
 			expectFailureSet: false,
 		},
 		{
+			name:              "Instance state ERROR propagates error message from server condition",
+			instanceState:     ptr.To(infrav1.InstanceStateError),
+			machineHasNodeRef: false,
+			serverConditions: []clusterv1beta1.Condition{
+				{
+					Type:     infrav1.InstanceReadyCondition,
+					Status:   corev1.ConditionFalse,
+					Severity: clusterv1beta1.ConditionSeverityError,
+					Reason:   infrav1.InstanceStateErrorReason,
+					Message:  "Server entered ERROR state: No valid host was found",
+				},
+			},
+			expectRequeue: true,
+			expectedInstanceReadyCondition: &clusterv1beta1.Condition{
+				Type:     infrav1.InstanceReadyCondition,
+				Status:   corev1.ConditionFalse,
+				Severity: clusterv1beta1.ConditionSeverityError,
+				Reason:   infrav1.InstanceStateErrorReason,
+				Message:  "Server entered ERROR state: No valid host was found",
+			},
+			expectedReadyCondition: &clusterv1beta1.Condition{
+				Type:     clusterv1beta1.ReadyCondition,
+				Status:   corev1.ConditionFalse,
+				Severity: clusterv1beta1.ConditionSeverityError,
+				Reason:   infrav1.InstanceStateErrorReason,
+				Message:  "Server entered ERROR state: No valid host was found",
+			},
+			expectFailureSet: true,
+		},
+		{
 			name:          "Instance state DELETED sets conditions to False",
-			instanceState: infrav1.InstanceStateDeleted,
+			instanceState: ptr.To(infrav1.InstanceStateDeleted),
 			expectRequeue: true,
 			expectedInstanceReadyCondition: &clusterv1beta1.Condition{
 				Type:     infrav1.InstanceReadyCondition,
@@ -528,7 +634,7 @@ func TestReconcileMachineState(t *testing.T) {
 		},
 		{
 			name:          "Instance state BUILD sets ReadyCondition to False",
-			instanceState: infrav1.InstanceStateBuild,
+			instanceState: ptr.To(infrav1.InstanceStateBuild),
 			expectRequeue: true,
 			expectedReadyCondition: &clusterv1beta1.Condition{
 				Type:     clusterv1beta1.ReadyCondition,
@@ -539,7 +645,7 @@ func TestReconcileMachineState(t *testing.T) {
 		},
 		{
 			name:          "Instance state SHUTOFF sets conditions to Unknown",
-			instanceState: infrav1.InstanceStateShutoff,
+			instanceState: ptr.To(infrav1.InstanceStateShutoff),
 			expectRequeue: true,
 			expectedInstanceReadyCondition: &clusterv1beta1.Condition{
 				Type:   infrav1.InstanceReadyCondition,
@@ -590,8 +696,13 @@ func TestReconcileMachineState(t *testing.T) {
 				},
 				Status: infrav1alpha1.OpenStackServerStatus{
 					InstanceID:    ptr.To(testInstanceID),
-					InstanceState: ptr.To(tt.instanceState),
+					InstanceState: tt.instanceState,
 				},
+			}
+
+			// Set any pre-existing conditions on the OpenStackServer
+			for i := range tt.serverConditions {
+				v1beta1conditions.Set(openStackServer, &tt.serverConditions[i])
 			}
 
 			r := &OpenStackMachineReconciler{}
@@ -620,6 +731,9 @@ func TestReconcileMachineState(t *testing.T) {
 					if tt.expectedInstanceReadyCondition.Severity != "" && condition.Severity != tt.expectedInstanceReadyCondition.Severity {
 						t.Errorf("expected %s severity %s, got %s", tt.expectedInstanceReadyCondition.Type, tt.expectedInstanceReadyCondition.Severity, condition.Severity)
 					}
+					if tt.expectedInstanceReadyCondition.Message != "" && condition.Message != tt.expectedInstanceReadyCondition.Message {
+						t.Errorf("expected %s message %q, got %q", tt.expectedInstanceReadyCondition.Type, tt.expectedInstanceReadyCondition.Message, condition.Message)
+					}
 				}
 			}
 
@@ -637,6 +751,9 @@ func TestReconcileMachineState(t *testing.T) {
 					}
 					if tt.expectedReadyCondition.Severity != "" && condition.Severity != tt.expectedReadyCondition.Severity {
 						t.Errorf("expected %s severity %s, got %s", tt.expectedReadyCondition.Type, tt.expectedReadyCondition.Severity, condition.Severity)
+					}
+					if tt.expectedReadyCondition.Message != "" && condition.Message != tt.expectedReadyCondition.Message {
+						t.Errorf("expected %s message %q, got %q", tt.expectedReadyCondition.Type, tt.expectedReadyCondition.Message, condition.Message)
 					}
 				}
 			}

--- a/pkg/cloud/services/compute/referenced_resources.go
+++ b/pkg/cloud/services/compute/referenced_resources.go
@@ -37,7 +37,12 @@ import (
 // external dependencies, and does not require any complex logic on creation.
 // Note that we only set the fields in ResolvedServerSpec that are not set yet. This is ok because
 // OpenStackServer is immutable, so we can't change the spec after the machine is created.
-func ResolveServerSpec(ctx context.Context, scope *scope.WithLogger, k8sClient client.Client, openStackServer *infrav1alpha1.OpenStackServer) (bool, bool, error) {
+// Returns: (changed, done, pendingDependencies, error)
+// - changed: true if the resolved spec was modified
+// - done: true if all dependencies are resolved
+// - pendingDependencies: list of dependency names that are not yet resolved (only meaningful when done=false and error=nil)
+// - error: any error that occurred during resolution.
+func ResolveServerSpec(ctx context.Context, scope *scope.WithLogger, k8sClient client.Client, openStackServer *infrav1alpha1.OpenStackServer) (bool, bool, []string, error) {
 	resolved := openStackServer.Status.Resolved
 	if resolved == nil {
 		resolved = &infrav1alpha1.ResolvedServerSpec{}
@@ -45,10 +50,6 @@ func ResolveServerSpec(ctx context.Context, scope *scope.WithLogger, k8sClient c
 	}
 
 	spec := &openStackServer.Spec
-	if resolved == nil {
-		resolved = &infrav1alpha1.ResolvedServerSpec{}
-		openStackServer.Status.Resolved = resolved
-	}
 
 	// If the server is bound to a cluster, we use the cluster name to generate the port description.
 	var clusterName string
@@ -58,102 +59,122 @@ func ResolveServerSpec(ctx context.Context, scope *scope.WithLogger, k8sClient c
 
 	computeService, err := NewService(scope)
 	if err != nil {
-		return false, false, err
+		return false, false, nil, err
 	}
 
 	networkingService, err := networking.NewService(scope)
 	if err != nil {
-		return false, false, err
+		return false, false, nil, err
 	}
 
 	// A setter returns: done, changed, error
-	type setterFn func() (bool, bool, error)
-
-	serverGroup := func() (bool, bool, error) {
-		if spec.ServerGroup == nil || resolved.ServerGroupID != "" {
-			return true, false, nil
-		}
-		serverGroupID, err := computeService.GetServerGroupID(spec.ServerGroup)
-		if err != nil {
-			return false, false, err
-		}
-		resolved.ServerGroupID = serverGroupID
-		return true, true, nil
+	// The name is used for reporting which dependencies are pending
+	type setterFn struct {
+		name string
+		fn   func() (bool, bool, error)
 	}
 
-	imageID := func() (bool, bool, error) {
-		if resolved.ImageID != "" {
-			return true, false, nil
-		}
-
-		imageID, err := computeService.GetImageID(ctx, k8sClient, openStackServer.Namespace, spec.Image)
-		if err != nil {
-			return false, false, err
-		}
-
-		// If we didn't get an imageID it means we're waiting on a dependency.
-		// Wait to be called again.
-		if imageID == nil {
-			return false, false, nil
-		}
-		resolved.ImageID = *imageID
-		return true, true, nil
+	serverGroup := setterFn{
+		name: "ServerGroup",
+		fn: func() (bool, bool, error) {
+			if spec.ServerGroup == nil || resolved.ServerGroupID != "" {
+				return true, false, nil
+			}
+			serverGroupID, err := computeService.GetServerGroupID(spec.ServerGroup)
+			if err != nil {
+				return false, false, err
+			}
+			resolved.ServerGroupID = serverGroupID
+			return true, true, nil
+		},
 	}
 
-	flavorID := func() (bool, bool, error) {
-		if resolved.FlavorID != "" {
-			return true, false, nil
-		}
+	imageID := setterFn{
+		name: "Image",
+		fn: func() (bool, bool, error) {
+			if resolved.ImageID != "" {
+				return true, false, nil
+			}
 
-		flavorID, err := computeService.GetFlavorID(spec.FlavorID, spec.Flavor)
-		if err != nil {
-			return false, false, err
-		}
+			imageID, err := computeService.GetImageID(ctx, k8sClient, openStackServer.Namespace, spec.Image)
+			if err != nil {
+				return false, false, err
+			}
 
-		resolved.FlavorID = flavorID
-		return true, true, nil
+			// If we didn't get an imageID it means we're waiting on a dependency.
+			// Wait to be called again.
+			if imageID == nil {
+				return false, false, nil
+			}
+			resolved.ImageID = *imageID
+			return true, true, nil
+		},
 	}
 
-	ports := func() (bool, bool, error) {
-		if len(resolved.Ports) > 0 {
-			return true, false, nil
-		}
+	flavorID := setterFn{
+		name: "Flavor",
+		fn: func() (bool, bool, error) {
+			if resolved.FlavorID != "" {
+				return true, false, nil
+			}
 
-		// Network resources are required in order to get ports options.
-		// Notes:
-		// - clusterResourceName is not used in this context, so we pass an empty string. In the future,
-		// we may want to remove that (it's only used for the port description) or allow a user to pass
-		// a custom description.
-		// - managedSecurityGroup is not used in this context, so we pass nil. The security groups are
-		//   passed in the spec.SecurityGroups and spec.Ports.
-		// - We run a safety check to ensure that the resolved.Ports has the same length as the spec.Ports.
-		//   This is to ensure that we don't accidentally add ports to the resolved.Ports that are not in the spec.
-		specTrunk := ptr.Deref(spec.Trunk, false)
-		portsOpts, err := networkingService.ConstructPorts(spec.Ports, spec.SecurityGroups, specTrunk, clusterName, openStackServer.Name, nil, nil, spec.Tags)
-		if err != nil {
-			return false, false, err
-		}
-		if portsOpts != nil && len(portsOpts) != len(spec.Ports) {
-			return false, false, fmt.Errorf("resolved.Ports has a different length than spec.Ports")
-		}
-		resolved.Ports = portsOpts
-		return true, true, nil
+			flavorID, err := computeService.GetFlavorID(spec.FlavorID, spec.Flavor)
+			if err != nil {
+				return false, false, err
+			}
+
+			resolved.FlavorID = flavorID
+			return true, true, nil
+		},
+	}
+
+	ports := setterFn{
+		name: "Ports",
+		fn: func() (bool, bool, error) {
+			if len(resolved.Ports) > 0 {
+				return true, false, nil
+			}
+
+			// Network resources are required in order to get ports options.
+			// Notes:
+			// - clusterResourceName is not used in this context, so we pass an empty string. In the future,
+			// we may want to remove that (it's only used for the port description) or allow a user to pass
+			// a custom description.
+			// - managedSecurityGroup is not used in this context, so we pass nil. The security groups are
+			//   passed in the spec.SecurityGroups and spec.Ports.
+			// - We run a safety check to ensure that the resolved.Ports has the same length as the spec.Ports.
+			//   This is to ensure that we don't accidentally add ports to the resolved.Ports that are not in the spec.
+			specTrunk := ptr.Deref(spec.Trunk, false)
+			portsOpts, err := networkingService.ConstructPorts(spec.Ports, spec.SecurityGroups, specTrunk, clusterName, openStackServer.Name, nil, nil, spec.Tags)
+			if err != nil {
+				return false, false, err
+			}
+			if portsOpts != nil && len(portsOpts) != len(spec.Ports) {
+				return false, false, fmt.Errorf("resolved.Ports has a different length than spec.Ports")
+			}
+			resolved.Ports = portsOpts
+			return true, true, nil
+		},
 	}
 
 	// Execute all setters and collate their return values
 	var errs []error
+	var pendingDependencies []string
 	changed := false
 	done := true
 	for _, setter := range []setterFn{serverGroup, imageID, flavorID, ports} {
-		thisDone, thisChanged, err := setter()
+		thisDone, thisChanged, err := setter.fn()
 		changed = changed || thisChanged
 		done = done && thisDone
 		if err != nil {
 			errs = append(errs, err)
 		}
+		if !thisDone && err == nil {
+			pendingDependencies = append(pendingDependencies, setter.name)
+		}
 	}
 
-	return changed, done, errors.Join(errs...)
+	return changed, done, pendingDependencies, errors.Join(errs...)
 }
 
 // InstanceTags returns the tags that should be applied to an instance.

--- a/pkg/cloud/services/compute/referenced_resources_test.go
+++ b/pkg/cloud/services/compute/referenced_resources_test.go
@@ -186,7 +186,7 @@ func Test_ResolveServerSpec(t *testing.T) {
 			fakeClient := fake.NewFakeClient()
 
 			scope := scope.NewWithLogger(mockScopeFactory, log)
-			_, _, err := ResolveServerSpec(context.TODO(), scope, fakeClient, openStackServer)
+			_, _, _, err := ResolveServerSpec(context.TODO(), scope, fakeClient, openStackServer)
 			if tt.wantErr {
 				g.Expect(err).Error()
 				return


### PR DESCRIPTION
**What this PR does / why we need it**:

- Improve error and pending dependency reporting in server spec resolution
- Surface dependency errors and pending states as conditions on OpenStackServer
- Propagate OpenStackServer error and waiting states to OpenStackMachine
- Refactor ResolveServerSpec to return pending dependencies for better diagnostics

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2265

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
