### PR TITLE
🌱 Bump golangci-lint to v2.10.1

### DIFF
--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -15,7 +15,7 @@
 ROOT_DIR_RELATIVE := ../..
 include $(ROOT_DIR_RELATIVE)/common.mk
 
-GOLANGCI_LINT_VERSION ?= v2.9.0
+GOLANGCI_LINT_VERSION ?= v2.10.1
 
 # GOTESTSUM version without the leading 'v'
 GOTESTSUM_VERSION ?= 1.12.0

--- a/test/e2e/shared/openstack.go
+++ b/test/e2e/shared/openstack.go
@@ -710,7 +710,7 @@ type AuthOpts struct {
 	AuthURL    string `ini:"auth-url"`
 	UserID     string `ini:"user-id"`
 	Username   string `ini:"username"`
-	Password   string `ini:"password"`
+	Password   string `ini:"password"` //nolint:gosec // G117: False positive, this is an INI schema field, not a hardcoded secret.
 	TenantID   string `ini:"tenant-id"`
 	TenantName string `ini:"tenant-name"`
 	DomainID   string `ini:"domain-id"`


### PR DESCRIPTION


**What this PR does / why we need it**:
- Bumps `golangci-lint` from `v2.9.0` to `v2.10.1` (latest version).
- Addresses a new `gosec` `G117` finding by adding a scoped `//nolint:gosec` on `AuthOpts.Password` in `test/e2e/shared/openstack.go` (false positive: schema field, not a hardcoded secret).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3014

**Special notes for your reviewer**:



**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests


