### PR TITLE
:seedling: Suppress revive var-naming warning for strings pkg

### DIFF
--- a/pkg/utils/strings/strings.go
+++ b/pkg/utils/strings/strings.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package strings
+package strings //nolint:revive
 
 import (
 	"cmp"


### PR DESCRIPTION
**What this PR does / why we need it**:
Add //nolint:revive to the strings package declaration to avoid conflict warning with the Go standard library package name.

**Special notes for your reviewer**:
This is a follow-up of https://github.com/kubernetes-sigs/cluster-api-provider-openstack/commit/18aa18db7881ecdee8e6a0be30b7e453db030a3e. For some reason this is not picked up when running `make lint` locally but it is occasionally picked up in ci, for example: https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/3020


**TODOs**:

- [X] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
