### PR TITLE
:seedling: Bump cloudbuild image to support go 1.25

### DIFF
--- a/cloudbuild-nightly.yaml
+++ b/cloudbuild-nightly.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-- name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250513-9264efb079'
+- name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:8d6a3a5b895e6776dbe9115b75db1412fbe57299b8db329d45cb54680e462b0b' # v20251211-4c812d4cd8
   entrypoint: make
   env:
   - DOCKER_CLI_EXPERIMENTAL=enabled

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -8,7 +8,7 @@ steps:
 # docker run --rm -it -v $(pwd):/workspace gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:${TAG}
 # make clean # make sure we have something to build
 # make staging-manifests
-- name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250513-9264efb079'
+- name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:8d6a3a5b895e6776dbe9115b75db1412fbe57299b8db329d45cb54680e462b0b' # v20251211-4c812d4cd8
   entrypoint: make
   env:
   - DOCKER_CLI_EXPERIMENTAL=enabled


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump cloudbuild image to support go 1.25

**Special notes for your reviewer**:

Image was taken from cluster-api that is also on go 1.25

**TODOs**:

- [X] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
