### PR TITLE
🌱Update missing go version uplift in netlify.toml file

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@ command = "make -C docs/book build"
 publish = "docs/book/book"
 
 [build.environment]
-GO_VERSION = "1.24.13"
+GO_VERSION = "1.25.7"
 
 # Standard Netlify redirects
 [[redirects]]


### PR DESCRIPTION
We missed the uplift of go version 1.25.7 during previous uplift in netlify.toml file.