### PR TITLE
🌱Revert release worflow persist-credentials: false

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,6 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2
       with:
         fetch-depth: 0
-        persist-credentials: false
     - name: Get changed files
       id: changed-files
       uses: tj-actions/changed-files@7dee1b0c1557f278e5c7dc244927139d78c0e22a # v47.0.4
@@ -98,7 +97,6 @@ jobs:
       with:
         fetch-depth: 0
         ref: ${{ env.RELEASE_TAG }}
-        persist-credentials: false
     - name: Calculate go version
       run: echo "go_version=$(make go-version)" >> ${GITHUB_ENV}
     - name: Set up Go


### PR DESCRIPTION
We have noticed, `persist-credentials: false` is not necessary in release workflow. So reverting it.