### PR TITLE
🌱uplift go version to 1.25.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 # Build the manager binary
 ARG GO_VERSION
-FROM golang:${GO_VERSION:-1.25.7} AS builder
+FROM golang:${GO_VERSION:-1.25.8} AS builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg goproxy=$(go env GOPROXY) to override the goproxy

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ unexport GOPATH
 TRACE ?= 0
 
 # Go
-GO_VERSION ?= 1.25.7
+GO_VERSION ?= 1.25.8
 
 # Directories.
 ARTIFACTS ?= $(REPO_ROOT)/_artifacts

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@ command = "make -C docs/book build"
 publish = "docs/book/book"
 
 [build.environment]
-GO_VERSION = "1.25.7"
+GO_VERSION = "1.25.8"
 
 # Standard Netlify redirects
 [[redirects]]


### PR DESCRIPTION
This addresses:

https://osv.dev/GO-2026-4601
https://osv.dev/GO-2026-4602
https://osv.dev/GO-2026-4603