### PR TITLE
📖 Replace embedded quick-start with link to upstream CAPI docs

### DIFF
--- a/docs/book/Makefile
+++ b/docs/book/Makefile
@@ -17,7 +17,6 @@ include $(ROOT_DIR_RELATIVE)/common.mk
 
 # Directories.
 MDBOOK := $(TOOLS_BIN_DIR)/mdbook
-MDBOOK_EMBED := $(TOOLS_BIN_DIR)/mdbook-embed
 MDBOOK_RELEASELINK := $(TOOLS_BIN_DIR)/mdbook-releaselink
 MDBOOK_TABULATE := $(TOOLS_BIN_DIR)/mdbook-tabulate
 BOOK_SRCS :=  $(call rwildcard,.,*.*)
@@ -38,11 +37,11 @@ verify: generate ## Verify that dependent artifacts are up to date
 	fi
 
 .PHONY: build
-build: $(BOOK_SRCS) $(MDBOOK) $(MDBOOK_EMBED) $(MDBOOK_RELEASELINK) $(MDBOOK_TABULATE) ## Build the book
+build: $(BOOK_SRCS) $(MDBOOK) $(MDBOOK_RELEASELINK) $(MDBOOK_TABULATE) ## Build the book
 	$(MDBOOK) build
 
 .PHONY: serve
-serve: $(MDBOOK) $(MDBOOK_EMBED) $(MDBOOK_RELEASELINK) $(MDBOOK_TABULATE) ## Run a local webserver with the compiled book
+serve: $(MDBOOK) $(MDBOOK_RELEASELINK) $(MDBOOK_TABULATE) ## Run a local webserver with the compiled book
 	$(MDBOOK) serve
 
 .PHONY: clean

--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -18,8 +18,5 @@ git-repository-url = "https://sigs.k8s.io/cluster-api-provider-openstack"
 [preprocessor.tabulate]
 command = "mdbook-tabulate"
 
-[preprocessor.embed]
-command = "mdbook-embed"
-
 [preprocessor.releaselink]
 command = "mdbook-releaselink"

--- a/docs/book/src/getting-started.md
+++ b/docs/book/src/getting-started.md
@@ -8,4 +8,12 @@
 
 # Getting Started
 
-{{#embed-github repo:"kubernetes-sigs/cluster-api" path:"docs/book/src/user/quick-start.md"}}
+Please refer to the upstream Cluster API [Quick Start guide](https://cluster-api.sigs.k8s.io/user/quick-start) for instructions on how to set up a management cluster and create your first workload cluster.
+
+The quick start guide covers:
+
+- Installing prerequisites (`clusterctl`, `kind`, `kubectl`, etc.)
+- Creating a management cluster
+- Initializing infrastructure providers
+- Generating cluster configurations
+- Creating workload clusters

--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -139,10 +139,6 @@ $(MDBOOK): $(MDBOOK_SHARE) | $(BIN_DIR)
 	chmod +x $@
 	touch -m $@
 
-MDBOOK_EMBED := $(BIN_DIR)/mdbook-embed
-$(MDBOOK_EMBED): go.mod go.sum | $(BIN_DIR)
-	go build -tags=tools -o $(BIN_DIR)/mdbook-embed sigs.k8s.io/cluster-api/hack/tools/mdbook/embed
-
 MDBOOK_RELEASELINK := $(BIN_DIR)/mdbook-releaselink
 $(MDBOOK_RELEASELINK): go.mod go.sum | $(BIN_DIR)
 	go build -tags=tools -o $(BIN_DIR)/mdbook-releaselink sigs.k8s.io/cluster-api/hack/tools/mdbook/releaselink


### PR DESCRIPTION
## What problem does this PR solve?

The docs site at https://cluster-api-openstack.sigs.k8s.io embeds content from external repositories using `mdbook-embed`. For example, the [getting-started page](https://cluster-api-openstack.sigs.k8s.io/getting-started) is embedded directly from CAPI.

Since the site is deployed via Netlify and only rebuilds on push to `main`, the embedded external content becomes stale if no PRs are merged for some time.

Fixes https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/2811

## Solution

Add a weekly scheduled GitHub Actions workflow that triggers a Netlify build via a [build hook](https://docs.netlify.com/configure-builds/build-hooks/). This Add a weekly scheduled GitHub Actions workflow that triggers a Netlify build via a [build hook](https://docs.netlify.com/conmmits.

The workflow also supports `workflow_dispatch` for manual triggering.

## Setup required by maintainers

After merging, a maintainer with Netlify access needs to:
1. Create a **1. Create a **1. Create a **1. Create a **Build & deploy > Build hooks_ (name it e.g. `weekly-docs-rebuild`)
2. Add the hook URL as a GitHub Actions secret named `NETLIFY_BUILD_HOOK`