### PR TITLE
🐛 Use port_trusted_vif extension for trusted VF when available

### DIFF
--- a/pkg/cloud/services/networking/port.go
+++ b/pkg/cloud/services/networking/port.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/portsbinding"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/portsecurity"
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/portstrustedvif"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/ports"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -240,13 +241,32 @@ func (s *Service) EnsurePort(eventObject runtime.Object, portSpec *infrav1.Resol
 		builder = portSecurityOpts
 	}
 
+	// Determine if port_trusted_vif extension is available when TrustedVF is requested.
+	// If available, we use the dedicated port attribute instead of binding:profile.
+	var usePortTrustedVIF bool
+	if portSpec.Profile != nil && ptr.Deref(portSpec.Profile.TrustedVF, false) {
+		usePortTrustedVIF, err = s.HasPortTrustedVIFExtension()
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	portsBindingOpts := portsbinding.CreateOptsExt{
 		CreateOptsBuilder: builder,
 		HostID:            ptr.Deref(portSpec.HostID, ""),
 		VNICType:          ptr.Deref(portSpec.VNICType, ""),
-		Profile:           getPortProfile(portSpec.Profile),
+		Profile:           getPortProfile(portSpec.Profile, usePortTrustedVIF),
 	}
 	builder = portsBindingOpts
+
+	// If the port_trusted_vif extension is available, set trusted mode via the
+	// dedicated port attribute rather than through binding:profile.
+	if usePortTrustedVIF {
+		builder = portstrustedvif.PortCreateOptsExt{
+			CreateOptsBuilder: builder,
+			PortTrustedVIF:    portSpec.Profile.TrustedVF,
+		}
+	}
 
 	port, err := s.client.CreatePort(builder)
 	if err != nil {
@@ -262,7 +282,7 @@ func (s *Service) EnsurePort(eventObject runtime.Object, portSpec *infrav1.Resol
 	return port, nil
 }
 
-func getPortProfile(p *infrav1.BindingProfile) map[string]interface{} {
+func getPortProfile(p *infrav1.BindingProfile, usePortTrustedVIF bool) map[string]interface{} {
 	if p == nil {
 		return nil
 	}
@@ -274,7 +294,10 @@ func getPortProfile(p *infrav1.BindingProfile) map[string]interface{} {
 	if ptr.Deref(p.OVSHWOffload, false) {
 		portProfile["capabilities"] = []string{"switchdev"}
 	}
-	if ptr.Deref(p.TrustedVF, false) {
+	// Only set trusted in binding:profile if the port_trusted_vif extension
+	// is not available. When the extension is available, trusted mode is set
+	// via the dedicated port attribute instead.
+	if !usePortTrustedVIF && ptr.Deref(p.TrustedVF, false) {
 		portProfile["trusted"] = true
 	}
 
@@ -605,6 +628,24 @@ func (s *Service) IsTrunkExtSupported() (trunknSupported bool, err error) {
 		return false, nil
 	}
 	return true, nil
+}
+
+// HasPortTrustedVIFExtension checks whether the Neutron port_trusted_vif
+// extension is available. When this extension is present, trusted VF mode
+// should be set via the dedicated port attribute rather than through
+// binding:profile.
+func (s *Service) HasPortTrustedVIFExtension() (bool, error) {
+	allExts, err := s.client.ListExtensions()
+	if err != nil {
+		return false, err
+	}
+
+	for _, ext := range allExts {
+		if ext.Alias == "port-trusted-vif" {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // AdoptPortsServer looks for ports in desiredPorts which were previously created, and adds them to resources.Ports.

--- a/pkg/cloud/services/networking/port_test.go
+++ b/pkg/cloud/services/networking/port_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/attributestags"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/portsbinding"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/portsecurity"
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/portstrustedvif"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/security/groups"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/trunks"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/networks"
@@ -161,12 +162,58 @@ func Test_EnsurePort(t *testing.T) {
 					Name:      "foo-port-1",
 					NetworkID: netID,
 				}).Return(nil, nil)
+				// Extension not available, so trusted goes into binding:profile
+				m.ListExtensions().Return([]extensions.Extension{}, nil)
 				// The following allows us to use gomega to
 				// compare the argument instead of gomock.
 				// Gomock's output in the case of a mismatch is
 				// not usable for this struct.
 				m.CreatePort(gomock.Any()).DoAndReturn(func(builder ports.CreateOptsBuilder) (*ports.Port, error) {
 					gotCreateOpts := builder.(portsbinding.CreateOptsExt)
+					g.Expect(gotCreateOpts).To(Equal(expectedCreateOpts), cmp.Diff(gotCreateOpts, expectedCreateOpts))
+					return &ports.Port{ID: portID}, nil
+				})
+			},
+			want: &ports.Port{ID: portID},
+		},
+		{
+			name: "uses port_trusted_vif extension when available instead of binding:profile",
+			port: infrav1.ResolvedPortSpec{
+				Name:      "test-port",
+				NetworkID: netID,
+				ResolvedPortSpecFields: infrav1.ResolvedPortSpecFields{
+					VNICType: ptr.To("direct"),
+					Profile: &infrav1.BindingProfile{
+						TrustedVF: ptr.To(true),
+					},
+				},
+			},
+			expect: func(m *mock.MockNetworkClientMockRecorder, g Gomega) {
+				var expectedCreateOpts ports.CreateOptsBuilder
+				expectedCreateOpts = ports.CreateOpts{
+					Name:      "test-port",
+					NetworkID: netID,
+				}
+				// When extension is available, trusted is NOT in binding:profile
+				expectedCreateOpts = portsbinding.CreateOptsExt{
+					CreateOptsBuilder: expectedCreateOpts,
+					VNICType:          "direct",
+				}
+				expectedCreateOpts = portstrustedvif.PortCreateOptsExt{
+					CreateOptsBuilder: expectedCreateOpts,
+					PortTrustedVIF:    ptr.To(true),
+				}
+
+				m.ListPort(ports.ListOpts{
+					Name:      "test-port",
+					NetworkID: netID,
+				}).Return(nil, nil)
+				// Extension is available
+				trustedVIFExt := extensions.Extension{}
+				trustedVIFExt.Alias = "port-trusted-vif"
+				m.ListExtensions().Return([]extensions.Extension{trustedVIFExt}, nil)
+				m.CreatePort(gomock.Any()).DoAndReturn(func(builder ports.CreateOptsBuilder) (*ports.Port, error) {
+					gotCreateOpts := builder.(portstrustedvif.PortCreateOptsExt)
 					g.Expect(gotCreateOpts).To(Equal(expectedCreateOpts), cmp.Diff(gotCreateOpts, expectedCreateOpts))
 					return &ports.Port{ID: portID}, nil
 				})


### PR DESCRIPTION
## What this PR does / why we need it

In recent Neutron (2024.2+), setting `trusted` directly in a port's `binding:profile` has been deprecated. A new API extension `port-trusted-vif` adds a dedicated `trusted` boolean field to the port resource, which should be used instead.

This PR adapts CAPO to use the new extension when available, with backward compatibility for older Neutron deployments.

**Which issue(s) this PR fixes:**
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/2172

## Changes

### Port creation (`pkg/cloud/services/networking/port.go`)

- Added `HasPortTrustedVIFExtension()` method that checks if the `port-trusted-vif` Neutron extension is available (follows the same pattern as `GetTrunkSupport()`)
- Modified `EnsurePort` to check for the extension when `TrustedVF` is set. If available, wraps the create opts with `portstrustedvif.PortCreateOptsExt` instead of putting `trusted` in `binding:profile`
- Modified `getPortProfile` to accept a `usePortTrustedVIF` flag so it skips adding `trusted` to the binding:profile when the extension handles it

### Tests (`pkg/cloud/services/networking/port_test.go`)

- Updated existing test to mock `ListExtensions` returning no `port-trusted-vif` extension (backward compatibility path)
- Added new test case "uses port_trusted_vif extension when available instead of binding:profile" that verifies the new code path

### Behavior

| Neutron version | `port-trusted-vif` available? | Behavior |
|---|---|---|
| < 2024.2 | No | `trusted: true` set in `binding:profile` (unchanged) |
| >= 2024.2 | Yes | `trusted: true` set via dedicated port attribute |

## Special notes for your reviewer

1. This PR does NOT change any image versions.
2. The gophercloud v2 library already includes the `portstrustedvif` package, so no dependency updates are needed.
3. The extension availability check uses `ListExtensions()`, the same API used for trunk support checking.

## References

- Neutron change: https://review.opendev.org/c/openstack/neutron/+/926068
- neutron-lib API definition: `ALIAS = 'port-trusted-vif'` in `neutron_lib/api/definitions/port_trusted_vif.py`
- gophercloud support: `gophercloud/v2/openstack/networking/v2/extensions/portstrustedvif`
