### PR TITLE
🌱 Add ClusterClass topology tests for ubuntu and bastion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,9 @@ e2e-templates: $(addprefix $(E2E_NO_ARTIFACT_TEMPLATES_DIR)/, \
 		 cluster-template-health-monitor.yaml \
 		 cluster-template-capi-v1beta1.yaml \
 		 cluster-template-cluster-identity.yaml \
-		 cluster-template-topology-autoscaler.yaml)
+		 cluster-template-topology-autoscaler.yaml \
+		 cluster-template-topology-ubuntu.yaml \
+		 cluster-template-topology-bastion.yaml)
 # Currently no templates that require CI artifacts
 # $(addprefix $(E2E_TEMPLATES_DIR)/, add-templates-here.yaml) \
 

--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,9 @@ e2e-templates: $(addprefix $(E2E_NO_ARTIFACT_TEMPLATES_DIR)/, \
 		 cluster-template-health-monitor.yaml \
 		 cluster-template-capi-v1beta1.yaml \
 		 cluster-template-cluster-identity.yaml \
-		 cluster-template-topology-autoscaler.yaml)
+		 cluster-template-topology-autoscaler.yaml \
+		 cluster-template-topology-ubuntu.yaml \
+		 cluster-template-topology-bastion.yaml)
 # Currently no templates that require CI artifacts
 # $(addprefix $(E2E_TEMPLATES_DIR)/, add-templates-here.yaml) \
 

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -165,6 +165,8 @@ providers:
     - sourcePath: "./infrastructure-openstack-no-artifact/cluster-template-without-lb.yaml"
     - sourcePath: "./infrastructure-openstack-no-artifact/cluster-template-cluster-identity.yaml"
     - sourcePath: "./infrastructure-openstack-no-artifact/cluster-template-topology-autoscaler.yaml"
+    - sourcePath: "./infrastructure-openstack-no-artifact/cluster-template-topology-ubuntu.yaml"
+    - sourcePath: "./infrastructure-openstack-no-artifact/cluster-template-topology-bastion.yaml"
     - sourcePath: "../../../templates/clusterclass-dev-test.yaml"
     replacements:
     - old: gcr.io/k8s-staging-capi-openstack/capi-openstack-controller:dev

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -138,6 +138,8 @@ providers:
     - sourcePath: "./infrastructure-openstack-no-artifact/cluster-template-without-lb.yaml"
     - sourcePath: "./infrastructure-openstack-no-artifact/cluster-template-cluster-identity.yaml"
     - sourcePath: "./infrastructure-openstack-no-artifact/cluster-template-topology-autoscaler.yaml"
+    - sourcePath: "./infrastructure-openstack-no-artifact/cluster-template-topology-ubuntu.yaml"
+    - sourcePath: "./infrastructure-openstack-no-artifact/cluster-template-topology-bastion.yaml"
     - sourcePath: "../../../templates/clusterclass-dev-test.yaml"
     replacements:
     - old: gcr.io/k8s-staging-capi-openstack/capi-openstack-controller:dev

--- a/test/e2e/data/kustomize/topology-bastion/cluster.yaml
+++ b/test/e2e/data/kustomize/topology-bastion/cluster.yaml
@@ -1,0 +1,39 @@
+# Topology cluster using a standard ubuntu image with bastion enabled.
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+spec:
+  topology:
+    classRef:
+      name: dev-test
+    version: ${KUBERNETES_VERSION}
+    controlPlane:
+      replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+    workers:
+      machineDeployments:
+      - class: default-worker
+        name: md-0
+        replicas: ${WORKER_MACHINE_COUNT}
+    variables:
+    - name: identityRef
+      value:
+        name: ${CLUSTER_NAME}-cloud-config
+        cloudName: ${OPENSTACK_CLOUD}
+    - name: imageRef
+      value: node-image
+    - name: addImageVersion
+      value: false
+    - name: injectIgnitionSysext
+      value: false
+    - name: allowedCIDRs
+      value: ${OPENSTACK_API_SERVER_ALLOWED_CIDRS:=[]}
+    - name: bastion
+      value:
+        enabled: true
+        spec:
+          flavor: ${OPENSTACK_BASTION_FLAVOR:=m1.small}
+          image:
+            imageRef:
+              name: bastion-image
+          sshKeyName: ${OPENSTACK_SSH_KEY_NAME:=""}

--- a/test/e2e/data/kustomize/topology-bastion/cluster.yaml
+++ b/test/e2e/data/kustomize/topology-bastion/cluster.yaml
@@ -1,0 +1,41 @@
+# Topology cluster using a standard ubuntu image with bastion enabled.
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+spec:
+  topology:
+    classRef:
+      name: dev-test
+    version: ${KUBERNETES_VERSION}
+    controlPlane:
+      replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+    workers:
+      machineDeployments:
+      - class: default-worker
+        name: md-0
+        replicas: ${WORKER_MACHINE_COUNT}
+    variables:
+    - name: identityRef
+      value:
+        name: ${CLUSTER_NAME}-cloud-config
+        cloudName: ${OPENSTACK_CLOUD}
+    - name: imageRef
+      value: node-image
+    - name: addImageVersion
+      value: false
+    - name: injectIgnitionSysext
+      value: false
+    - name: allowedCIDRs
+      value: ${OPENSTACK_API_SERVER_ALLOWED_CIDRS:=[]}
+    - name: bastion
+      value:
+        enabled: true
+        spec:
+          flavor:
+            filter:
+              name: ${OPENSTACK_BASTION_FLAVOR:=m1.small}
+          image:
+            imageRef:
+              name: bastion-image
+          sshKeyName: ${OPENSTACK_SSH_KEY_NAME:=""}

--- a/test/e2e/data/kustomize/topology-bastion/kustomization.yaml
+++ b/test/e2e/data/kustomize/topology-bastion/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- cluster.yaml
+- secret.yaml
+
+components:
+- ../components/images
+- ../components/cluster-resource-sets

--- a/test/e2e/data/kustomize/topology-bastion/secret.yaml
+++ b/test/e2e/data/kustomize/topology-bastion/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  cacert: ${OPENSTACK_CLOUD_CACERT_B64}
+  clouds.yaml: ${OPENSTACK_CLOUD_YAML_B64}
+kind: Secret
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move: "true"
+  name: ${CLUSTER_NAME}-cloud-config

--- a/test/e2e/data/kustomize/topology-ubuntu/cluster.yaml
+++ b/test/e2e/data/kustomize/topology-ubuntu/cluster.yaml
@@ -1,0 +1,39 @@
+# Topology cluster using a standard ubuntu image without ignition/sysext.
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+spec:
+  topology:
+    classRef:
+      name: dev-test
+    version: ${KUBERNETES_VERSION}
+    controlPlane:
+      replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+    workers:
+      machineDeployments:
+      - class: default-worker
+        name: md-0
+        replicas: ${WORKER_MACHINE_COUNT}
+    variables:
+    - name: identityRef
+      value:
+        name: ${CLUSTER_NAME}-cloud-config
+        cloudName: ${OPENSTACK_CLOUD}
+    - name: imageRef
+      value: node-image
+    - name: addImageVersion
+      value: false
+    - name: injectIgnitionSysext
+      value: false
+    - name: allowedCIDRs
+      value: ${OPENSTACK_API_SERVER_ALLOWED_CIDRS:=[]}
+    - name: bastion
+      value:
+        enabled: ${OPENSTACK_BASTION_ENABLED:=false}
+        spec:
+          flavor: ${OPENSTACK_BASTION_FLAVOR:=m1.small}
+          image:
+            imageRef:
+              name: bastion-image
+          sshKeyName: ${OPENSTACK_SSH_KEY_NAME:=""}

--- a/test/e2e/data/kustomize/topology-ubuntu/cluster.yaml
+++ b/test/e2e/data/kustomize/topology-ubuntu/cluster.yaml
@@ -1,0 +1,41 @@
+# Topology cluster using a standard ubuntu image without ignition/sysext.
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+spec:
+  topology:
+    classRef:
+      name: dev-test
+    version: ${KUBERNETES_VERSION}
+    controlPlane:
+      replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+    workers:
+      machineDeployments:
+      - class: default-worker
+        name: md-0
+        replicas: ${WORKER_MACHINE_COUNT}
+    variables:
+    - name: identityRef
+      value:
+        name: ${CLUSTER_NAME}-cloud-config
+        cloudName: ${OPENSTACK_CLOUD}
+    - name: imageRef
+      value: node-image
+    - name: addImageVersion
+      value: false
+    - name: injectIgnitionSysext
+      value: false
+    - name: allowedCIDRs
+      value: ${OPENSTACK_API_SERVER_ALLOWED_CIDRS:=[]}
+    - name: bastion
+      value:
+        enabled: ${OPENSTACK_BASTION_ENABLED:=false}
+        spec:
+          flavor:
+            filter:
+              name: ${OPENSTACK_BASTION_FLAVOR:=m1.small}
+          image:
+            imageRef:
+              name: bastion-image
+          sshKeyName: ${OPENSTACK_SSH_KEY_NAME:=""}

--- a/test/e2e/data/kustomize/topology-ubuntu/kustomization.yaml
+++ b/test/e2e/data/kustomize/topology-ubuntu/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- cluster.yaml
+- secret.yaml
+
+components:
+- ../components/images
+- ../components/cluster-resource-sets

--- a/test/e2e/data/kustomize/topology-ubuntu/secret.yaml
+++ b/test/e2e/data/kustomize/topology-ubuntu/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  cacert: ${OPENSTACK_CLOUD_CACERT_B64}
+  clouds.yaml: ${OPENSTACK_CLOUD_YAML_B64}
+kind: Secret
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move: "true"
+  name: ${CLUSTER_NAME}-cloud-config

--- a/test/e2e/shared/defaults.go
+++ b/test/e2e/shared/defaults.go
@@ -66,6 +66,8 @@ const (
 	FlavorCapiV1Beta1          = "capi-v1beta1"
 	FlavorClusterIdentity      = "cluster-identity"
 	FlavorTopologyAutoscaler   = "topology-autoscaler"
+	FlavorTopologyUbuntu       = "topology-ubuntu"
+	FlavorTopologyBastion      = "topology-bastion"
 )
 
 // DefaultScheme returns the default scheme to use for testing.

--- a/test/e2e/shared/defaults.go
+++ b/test/e2e/shared/defaults.go
@@ -67,6 +67,8 @@ const (
 	FlavorCapiV1Beta1            = "capi-v1beta1"
 	FlavorClusterIdentity        = "cluster-identity"
 	FlavorTopologyAutoscaler     = "topology-autoscaler"
+	FlavorTopologyUbuntu         = "topology-ubuntu"
+	FlavorTopologyBastion        = "topology-bastion"
 )
 
 // DefaultScheme returns the default scheme to use for testing.

--- a/test/e2e/suites/e2e/clusterclass_test.go
+++ b/test/e2e/suites/e2e/clusterclass_test.go
@@ -1,0 +1,55 @@
+//go:build e2e
+
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	"k8s.io/utils/ptr"
+	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
+
+	shared "sigs.k8s.io/cluster-api-provider-openstack/test/e2e/shared"
+)
+
+var _ = Describe("ClusterClass with ubuntu image [ClusterClass]", func() {
+	capi_e2e.QuickStartSpec(context.TODO(), func() capi_e2e.QuickStartSpecInput {
+		return capi_e2e.QuickStartSpecInput{
+			E2EConfig:             e2eCtx.E2EConfig,
+			ClusterctlConfigPath:  e2eCtx.Environment.ClusterctlConfigPath,
+			BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
+			ArtifactFolder:        e2eCtx.Settings.ArtifactFolder,
+			SkipCleanup:           false,
+			Flavor:                ptr.To(shared.FlavorTopologyUbuntu),
+		}
+	})
+})
+
+var _ = Describe("ClusterClass with bastion [ClusterClass]", func() {
+	capi_e2e.QuickStartSpec(context.TODO(), func() capi_e2e.QuickStartSpecInput {
+		return capi_e2e.QuickStartSpecInput{
+			E2EConfig:             e2eCtx.E2EConfig,
+			ClusterctlConfigPath:  e2eCtx.Environment.ClusterctlConfigPath,
+			BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
+			ArtifactFolder:        e2eCtx.Settings.ArtifactFolder,
+			SkipCleanup:           false,
+			Flavor:                ptr.To(shared.FlavorTopologyBastion),
+		}
+	})
+})


### PR DESCRIPTION
## What issue does this PR address?

Issue #2796

## What does this PR do?

Adds two new non-PR-blocking ClusterClass test variants to the e2e test suite:

1. **topology-ubuntu**: Tests the ClusterClass with a standard ubuntu image without ignition/sysext configuration (`injectIgnitionSysext: false`)
2. **topology-bastion**: Tests the ClusterClass with a standard ubuntu image and bastion enabled (`bastion.enabled: true`)

These complement the existing `[PR-Blocking]` topology test (which uses flatcar + ignition/sysext) by exercising additional variable combinations of the `dev-test` ClusterClass.

### Changes

- New kustomize overlays: `topology-ubuntu/` and `topology-bastion/`
- New test file: `clusterclass_test.go` with two `QuickStartSpec` tests tagged `[ClusterClass]` only (not `[PR-Blocking]`)
- New flavor constants: `FlavorTopologyUbuntu` and `FlavorTopologyBastion`
- Updated `Makefile` and `e2e_conf.yaml` to register the new templates

### Why not PR-blocking?

As noted in the issue, these tests should run in the periodic/full suite only to avoid adding to PR verification time. They are tagged with `[ClusterClass]` but intentionally omit the `[PR-Blocking]` tag.
