### PR TITLE
🌱 Add Kube API Linter with everything excluded

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -1,0 +1,96 @@
+version: "2"
+run:
+  go: "1.25"
+  allow-parallel-runners: true
+linters:
+  default: none
+  enable:
+  - kubeapilinter # linter for Kube API conventions
+  settings:
+    custom:
+      kubeapilinter:
+        type: module
+        description: KAL is the Kube-API-Linter and lints Kube like APIs based on API conventions and best practices.
+        settings:
+          linters:
+            enable:
+            - "commentstart" # Ensure comments start with the serialized version of the field name.
+            - "conditions" # Ensure conditions have the correct json tags and markers.
+            - "conflictingmarkers" # Ensure there are no conflicting markers.
+            - "duplicatemarkers" # Ensure there are no exact duplicate markers for types and fields.
+            - "forbiddenmarkers" # Ensure that types and fields do not contain any markers that are forbidden.
+            - "integers" # Ensure only int32 and int64 are used for integers.
+            - "jsontags" # Ensure every field has a json tag.
+            - "maxlength" # Ensure all strings and arrays have maximum lengths/maximum items.
+            - "nobools" # Bools do not evolve over time, should use enums instead.
+            - "nodurations" # Prevents usage of Duration types.
+            - "nofloats" # Ensure floats are not used.
+            - "nomaps" # Ensure maps are not used.
+            - "nonullable" # Ensure that types and fields do not have the nullable marker.
+            - "notimestamp" # Prevents usage of Timestamp fields.
+            - "optionalfields" # Ensure that all fields marked as optional adhere to being pointers and
+            # having the omitempty value in their json tag where appropriate.
+            - "optionalorrequired" # Every field should be marked as optional or required.
+            - "requiredfields" # Required fields should not be pointers, and should not have omitempty.
+            - "ssatags" # Ensure array fields have the appropriate listType markers.
+            - "statusoptional" # Ensure all first children within status should be optional.
+            - "statussubresource" # All root objects that have a status field should have a status subresource.
+            - "uniquemarkers" # Ensure that types and fields do not contain more than a single definition of a marker that should only be present once.
+
+            # Per discussion in July 2024 in CAPI, phase fields are kept for now.
+            # - "nophase" # Phase fields are discouraged by the Kube API conventions, use conditions instead.
+
+            # Linters below this line are disabled, pending conversation on how and when to enable them.
+            disable:
+            - "*" # We will manually enable new linters after understanding the impact. Disable all by default.
+          lintersConfig:
+            conflictingmarkers:
+              conflicts:
+              - name: "default_vs_required"
+                sets:
+                - ["default", "kubebuilder:default"]
+                - ["required", "kubebuilder:validation:Required", "k8s:required"]
+                description: "A field with a default value cannot be required"
+            forbiddenmarkers:
+              markers:
+              # We do not want to do any defaulting (including OpenAPI) anymore on API fields because we prefer
+              # to have a clear signal on user intent. This also allows us to easily change the default behavior if necessary.
+              - identifier: "kubebuilder:default"
+              - identifier: "default"
+            conditions:
+              isFirstField: Warn # Require conditions to be the first field in the status struct.
+              usePatchStrategy: Forbid # Forbid patchStrategy markers on the Conditions field.
+              useProtobuf: Forbid # We do not use protobuf, so protobuf tags are not required.
+            optionalfields:
+              pointers:
+                preference: WhenRequired # Whether to always require pointers, or only when required. Defaults to Always.
+                policy: SuggestFix # The policy for pointers in optional fields. Defaults to SuggestFix.
+              omitempty:
+                policy: SuggestFix # The policy for omitempty in optional fields. Defaults to SuggestFix.
+
+  exclusions:
+    generated: strict
+    paths:
+    - zz_generated.*\.go$
+    - ".*_test.go" # Exclude test files.
+    rules:
+    ## KAL should only run on API folders.
+    - path-except: "api//*"
+      linters:
+      - kubeapilinter
+
+    ## Exclude all existing API versions for now.
+    ## TODO: Remove exclusions and fix issues incrementally.
+    - path: "api/v1alpha1"
+      linters:
+      - kubeapilinter
+    - path: "api/v1beta1"
+      linters:
+      - kubeapilinter
+    - path: "api/v1beta2"
+      linters:
+      - kubeapilinter
+
+issues:
+  max-same-issues: 0
+  max-issues-per-linter: 0

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ ENVSUBST := $(TOOLS_BIN_DIR)/envsubst
 GINKGO := $(TOOLS_BIN_DIR)/ginkgo
 GOJQ := $(TOOLS_BIN_DIR)/gojq
 GOLANGCI_LINT := $(abspath $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_BIN)-$(GOLANGCI_LINT_VER))
+GOLANGCI_LINT_KAL := $(abspath $(TOOLS_BIN_DIR)/golangci-lint-kube-api-linter)
 GOTESTSUM := $(TOOLS_BIN_DIR)/gotestsum
 KUSTOMIZE := $(TOOLS_BIN_DIR)/kustomize
 MOCKGEN := $(TOOLS_BIN_DIR)/mockgen
@@ -291,20 +292,33 @@ $(GOLANGCI_LINT_BIN): $(GOLANGCI_LINT) ## Build a local copy of golangci-lint.
 $(GOLANGCI_LINT): # Build golangci-lint.
 	GOBIN=$(abspath $(TOOLS_BIN_DIR)) $(GO_INSTALL) $(GOLANGCI_LINT_PKG) $(GOLANGCI_LINT_BIN) $(GOLANGCI_LINT_VER)
 
+$(GOLANGCI_LINT_KAL): $(GOLANGCI_LINT) $(TOOLS_DIR_DEPS) # Build golangci-lint with KAL plugin.
+	cd $(TOOLS_DIR); $(GOLANGCI_LINT) custom
+
 ## --------------------------------------
 ##@ Linting
 ## --------------------------------------
 
 .PHONY: lint
-lint: $(GOLANGCI_LINT) ## Lint codebase
+lint: $(GOLANGCI_LINT) $(GOLANGCI_LINT_KAL) ## Lint codebase
 	$(GOLANGCI_LINT) run -v
+	$(GOLANGCI_LINT_KAL) run -v --config $(ROOT_DIR_RELATIVE)/.golangci-kal.yml
 
 .PHONY: lint-update
-lint-update: $(GOLANGCI_LINT) ## Lint codebase
+lint-update: $(GOLANGCI_LINT) $(GOLANGCI_LINT_KAL) ## Lint and fix issues
 	$(GOLANGCI_LINT) run -v --fix
+	$(GOLANGCI_LINT_KAL) run -v --fix --config $(ROOT_DIR_RELATIVE)/.golangci-kal.yml
 
 lint-fast: $(GOLANGCI_LINT) ## Run only faster linters to detect possible issues
 	$(GOLANGCI_LINT) run -v --fast-only
+
+.PHONY: lint-api
+lint-api: $(GOLANGCI_LINT_KAL) ## Lint API types with KAL
+	$(GOLANGCI_LINT_KAL) run -v --config $(ROOT_DIR_RELATIVE)/.golangci-kal.yml
+
+.PHONY: lint-api-fix
+lint-api-fix: $(GOLANGCI_LINT_KAL) ## Lint API types with KAL and auto-fix issues
+	$(GOLANGCI_LINT_KAL) run -v --fix --config $(ROOT_DIR_RELATIVE)/.golangci-kal.yml
 
 ## --------------------------------------
 ##@ Generate

--- a/hack/tools/.custom-gcl.yaml
+++ b/hack/tools/.custom-gcl.yaml
@@ -1,0 +1,6 @@
+version: v2.11.4
+name: golangci-lint-kube-api-linter
+destination: ./bin
+plugins:
+- module: "sigs.k8s.io/kube-api-linter"
+  version: v0.0.0-20260416084302-2b3d1fe14578


### PR DESCRIPTION
**What this PR does / why we need it**:

Integrate kube-api-linter (KAL) into the project's linting infrastructure
to validate Kubernetes API conventions. This adds:

- New `.golangci-kal.yml` configuration for KAL with API linters
- Build support for golangci-lint with KAL plugin
- New `lint-api` and `lint-api-fix` make targets
- KAL integrated into main `lint` and `lint-update` targets

This is mostly copied from CAPI. We may want to adjust some settings later on after evaluating.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
First part of #3131

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
