### PR TITLE
🌱 Dependabot: Ignore ORC on release-0.14

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -99,6 +99,9 @@ updates:
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
   - dependency-name: "sigs.k8s.io/controller-tools"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  # Ignore ORC major and minor bumps to prevent cascading Go version requirements
+  - dependency-name: "github.com/k-orc/openstack-resource-controller*"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
   # Ignore golang.org/x minor and major bumps to prevent cascading Go version requirements
   - dependency-name: "golang.org/x/*"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]


### PR DESCRIPTION
**What this PR does / why we need it**:

ORC 2.5.0 requires go 1.25.0 which we consider a breaking change. Configure dependabot to ignore.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

