### PR TITLE
🌱 Add metadata for v0.15 and update e2e

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -31,3 +31,6 @@ releaseSeries:
 - major: 0
   minor: 14
   contract: v1beta1
+- major: 0
+  minor: 15
+  contract: v1beta2

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -10,7 +10,7 @@ images:
 # Use local dev images built source tree;
 - name: gcr.io/k8s-staging-capi-openstack/capi-openstack-controller:e2e
   loadBehavior: mustLoad
-- name: quay.io/orc/openstack-resource-controller:v2.4.0
+- name: quay.io/orc/openstack-resource-controller:v2.5.0
   loadBehavior: tryLoad
 
 providers:
@@ -31,6 +31,15 @@ providers:
     value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.12}/core-components.yaml"
     type: "url"
     contract: v1beta2
+    replacements:
+    - old: --metrics-addr=127.0.0.1:8080
+      new: --metrics-addr=:8080
+    files:
+    - sourcePath: "../data/shared/capi/metadata.yaml"
+  - name: "{go://sigs.k8s.io/cluster-api@v1.10}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.10}/core-components.yaml"
+    type: "url"
+    contract: v1beta1
     replacements:
     - old: --metrics-addr=127.0.0.1:8080
       new: --metrics-addr=:8080
@@ -58,6 +67,15 @@ providers:
       new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/capi/metadata.yaml"
+  - name: "{go://sigs.k8s.io/cluster-api@v1.10}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.10}/bootstrap-components.yaml"
+    type: "url"
+    contract: v1beta1
+    replacements:
+    - old: --metrics-addr=127.0.0.1:8080
+      new: --metrics-addr=:8080
+    files:
+    - sourcePath: "../data/shared/capi/metadata.yaml"
 - name: kubeadm
   type: ControlPlaneProvider
   versions:
@@ -75,6 +93,15 @@ providers:
     value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.12}/control-plane-components.yaml"
     type: "url"
     contract: v1beta2
+    replacements:
+    - old: --metrics-addr=127.0.0.1:8080
+      new: --metrics-addr=:8080
+    files:
+    - sourcePath: "../data/shared/capi/metadata.yaml"
+  - name: "{go://sigs.k8s.io/cluster-api@v1.10}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.10}/control-plane-components.yaml"
+    type: "url"
+    contract: v1beta1
     replacements:
     - old: --metrics-addr=127.0.0.1:8080
       new: --metrics-addr=:8080
@@ -131,7 +158,7 @@ providers:
   - name: v0.15.99
     value: ../../../config/default
     # This is the upcoming version.
-    contract: v1beta1
+    contract: v1beta2
     files:
     - sourcePath: "../data/shared/provider/metadata.yaml"
     - sourcePath: "./infrastructure-openstack-no-artifact/cluster-template.yaml"
@@ -151,9 +178,9 @@ providers:
 - name: openstack-resource-controller
   type: RuntimeExtensionProvider # ORC isn't a provider but we fake it so it can be handled by the clusterctl machinery.
   versions:
-  - name: v2.4.0
+  - name: v2.5.0
     value: ../../../../cluster-api-provider-openstack/test/infrastructure/openstack-resource-controller/config/default
-    contract: v1beta1
+    contract: v1beta2
     files:
     - sourcePath: "../data/shared/openstack-resource-controller/metadata.yaml"
     replacements:

--- a/test/e2e/data/shared/openstack-resource-controller/metadata.yaml
+++ b/test/e2e/data/shared/openstack-resource-controller/metadata.yaml
@@ -17,3 +17,6 @@ releaseSeries:
 - major: 2
   minor: 4
   contract: v1beta1
+- major: 2
+  minor: 5
+  contract: v1beta2

--- a/test/e2e/data/shared/provider/metadata.yaml
+++ b/test/e2e/data/shared/provider/metadata.yaml
@@ -33,4 +33,4 @@ releaseSeries:
   contract: v1beta1
 - major: 0
   minor: 15
-  contract: v1beta1
+  contract: v1beta2

--- a/test/e2e/suites/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/suites/e2e/clusterctl_upgrade_test.go
@@ -20,10 +20,15 @@ package e2e
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
+	capi_framework "sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 
 	shared "sigs.k8s.io/cluster-api-provider-openstack/test/e2e/shared"
@@ -33,8 +38,26 @@ var (
 	capoRelease012 string
 	capoRelease013 string
 	capoRelease014 string
+	capiRelease110 string
 	capiRelease112 string
 )
+
+// NOTE: clusterctl v1.10 cannot handle RuntimeExtensionProvider in the local
+// filesystem repository created by the CAPI v1.13 test framework. And clusterctl
+// v1.12 refuses to operate against v1beta1 management clusters. Therefore, we
+// cannot install ORC as a RuntimeExtension and have to use hooks instead.
+//
+// CAPO v0.13 was compiled against CAPI v1.11, and CAPO v0.14 against CAPI v1.12.
+// Both CAPI v1.11 and v1.12 use the v1beta2 contract and promote the IPAM API
+// from exp/ipam (v1alpha1) to api/ipam (v1beta2). This means neither v0.13 nor
+// v0.14 can run against CAPI v1.10 (the last v1beta1 release). Therefore:
+//   - The v0.13 upgrade test uses CAPI v1.11 as the starting point.
+//   - The v0.14 upgrade test uses CAPI v1.12 as the starting point.
+
+// orcInitVersion is the ORC version installed alongside the old CAPO release in
+// PreInit. v1.0.2 is the version the v0.12/v0.13/v0.14 CAPO releases were tested
+// against (see the previous InitWithRuntimeExtensionProviders entry).
+const orcInitVersion = "v1.0.2"
 
 var _ = Describe("When testing clusterctl upgrades for CAPO (v0.12=>current) and ORC (v1.0.2=>current)[clusterctl-upgrade]", func() {
 	BeforeEach(func(ctx context.Context) {
@@ -43,33 +66,44 @@ var _ = Describe("When testing clusterctl upgrades for CAPO (v0.12=>current) and
 		Expect(err).ToNot(HaveOccurred(), "failed to get stable release of CAPO")
 		capoRelease012 = "v" + capoRelease012
 		// Note: This gives the version without the 'v' prefix, so we need to add it below.
-		capiRelease112, err = capi_e2e.GetStableReleaseOfMinor(ctx, "1.12")
+		capiRelease110, err = capi_e2e.GetStableReleaseOfMinor(ctx, "1.10")
 		Expect(err).ToNot(HaveOccurred(), "failed to get stable release of CAPI")
-		capiRelease112 = "v" + capiRelease112
+		capiRelease110 = "v" + capiRelease110
 	})
 
 	capi_e2e.ClusterctlUpgradeSpec(context.TODO(), func() capi_e2e.ClusterctlUpgradeSpecInput {
 		return capi_e2e.ClusterctlUpgradeSpecInput{
-			E2EConfig:                         e2eCtx.E2EConfig,
-			ClusterctlConfigPath:              e2eCtx.Environment.ClusterctlConfigPath,
-			BootstrapClusterProxy:             e2eCtx.Environment.BootstrapClusterProxy,
-			ArtifactFolder:                    e2eCtx.Settings.ArtifactFolder,
-			SkipCleanup:                       false,
-			InitWithBinary:                    "https://github.com/kubernetes-sigs/cluster-api/releases/download/" + capiRelease112 + "/clusterctl-{OS}-{ARCH}",
-			InitWithProvidersContract:         "v1beta2",
-			InitWithInfrastructureProviders:   []string{"openstack:" + capoRelease012},
-			InitWithCoreProvider:              "cluster-api:" + capiRelease112,
-			InitWithBootstrapProviders:        []string{"kubeadm:" + capiRelease112},
-			InitWithControlPlaneProviders:     []string{"kubeadm:" + capiRelease112},
+			E2EConfig:                       e2eCtx.E2EConfig,
+			ClusterctlConfigPath:            e2eCtx.Environment.ClusterctlConfigPath,
+			BootstrapClusterProxy:           e2eCtx.Environment.BootstrapClusterProxy,
+			ArtifactFolder:                  e2eCtx.Settings.ArtifactFolder,
+			SkipCleanup:                     false,
+			InitWithBinary:                  "https://github.com/kubernetes-sigs/cluster-api/releases/download/" + capiRelease110 + "/clusterctl-{OS}-{ARCH}",
+			InitWithProvidersContract:       "v1beta1",
+			InitWithInfrastructureProviders: []string{"openstack:" + capoRelease012},
+			InitWithCoreProvider:            "cluster-api:" + capiRelease110,
+			InitWithBootstrapProviders:      []string{"kubeadm:" + capiRelease110},
+			InitWithControlPlaneProviders:   []string{"kubeadm:" + capiRelease110},
+			// Explicit empty slice: we install ORC manually via PreInit/PreUpgrade
+			// hooks rather than via clusterctl.
+			InitWithRuntimeExtensionProviders: []string{},
 			MgmtFlavor:                        shared.FlavorDefault,
 			WorkloadFlavor:                    shared.FlavorCapiV1Beta1,
 			InitWithKubernetesVersion:         e2eCtx.E2EConfig.MustGetVariable(shared.KubernetesKindVersion),
-			InitWithRuntimeExtensionProviders: []string{"openstack-resource-controller:v1.0.2"},
 			UseKindForManagementCluster:       true,
+			// Install ORC v1.0.2 before clusterctl init
+			PreInit: func(managementClusterProxy capi_framework.ClusterProxy) {
+				installORC(context.Background(), managementClusterProxy, orcInitVersion)
+			},
+			// Upgrade ORC to the current version before clusterctl upgrade
+			PreUpgrade: func(managementClusterProxy capi_framework.ClusterProxy) {
+				installLatestORC(context.Background(), managementClusterProxy, e2eCtx.E2EConfig)
+			},
 		}
 	})
 })
 
+// CAPO v0.13 is built against CAPI v1beta2 and therefore cannot run against CAPI v1.10.
 var _ = Describe("When testing clusterctl upgrades for CAPO (v0.13=>current) and ORC (v1.0.2=>current)[clusterctl-upgrade]", func() {
 	BeforeEach(func(ctx context.Context) {
 		// Note: This gives the version without the 'v' prefix, so we need to add it below.
@@ -90,15 +124,14 @@ var _ = Describe("When testing clusterctl upgrades for CAPO (v0.13=>current) and
 			ArtifactFolder:                    e2eCtx.Settings.ArtifactFolder,
 			SkipCleanup:                       false,
 			InitWithBinary:                    "https://github.com/kubernetes-sigs/cluster-api/releases/download/" + capiRelease112 + "/clusterctl-{OS}-{ARCH}",
-			InitWithProvidersContract:         "v1beta2",
 			InitWithInfrastructureProviders:   []string{"openstack:" + capoRelease013},
 			InitWithCoreProvider:              "cluster-api:" + capiRelease112,
 			InitWithBootstrapProviders:        []string{"kubeadm:" + capiRelease112},
 			InitWithControlPlaneProviders:     []string{"kubeadm:" + capiRelease112},
+			InitWithRuntimeExtensionProviders: []string{"openstack-resource-controller:v1.0.2"},
 			MgmtFlavor:                        shared.FlavorDefault,
 			WorkloadFlavor:                    shared.FlavorCapiV1Beta1,
 			InitWithKubernetesVersion:         e2eCtx.E2EConfig.MustGetVariable(shared.KubernetesKindVersion),
-			InitWithRuntimeExtensionProviders: []string{"openstack-resource-controller:v1.0.2"},
 			UseKindForManagementCluster:       true,
 		}
 	})
@@ -124,16 +157,65 @@ var _ = Describe("When testing clusterctl upgrades for CAPO (v0.14=>current) and
 			ArtifactFolder:                    e2eCtx.Settings.ArtifactFolder,
 			SkipCleanup:                       false,
 			InitWithBinary:                    "https://github.com/kubernetes-sigs/cluster-api/releases/download/" + capiRelease112 + "/clusterctl-{OS}-{ARCH}",
-			InitWithProvidersContract:         "v1beta2",
 			InitWithInfrastructureProviders:   []string{"openstack:" + capoRelease014},
 			InitWithCoreProvider:              "cluster-api:" + capiRelease112,
 			InitWithBootstrapProviders:        []string{"kubeadm:" + capiRelease112},
 			InitWithControlPlaneProviders:     []string{"kubeadm:" + capiRelease112},
+			InitWithRuntimeExtensionProviders: []string{"openstack-resource-controller:v1.0.2"},
 			MgmtFlavor:                        shared.FlavorDefault,
 			WorkloadFlavor:                    shared.FlavorCapiV1Beta1,
 			InitWithKubernetesVersion:         e2eCtx.E2EConfig.MustGetVariable(shared.KubernetesKindVersion),
-			InitWithRuntimeExtensionProviders: []string{"openstack-resource-controller:v1.0.2"},
 			UseKindForManagementCluster:       true,
 		}
 	})
 })
+
+// installLatestORC downloads and applies the install manifest for the current/latest version of
+// the OpenStack Resource Controller (ORC) to the management cluster.
+//
+// The ORC version is derived from the e2e config (the latest version with contract v1beta2), so no
+// version hardcoding is required here — updating the provider entry in the e2e config is sufficient.
+func installLatestORC(ctx context.Context, proxy capi_framework.ClusterProxy, e2eConfig *clusterctl.E2EConfig) {
+	// GetProviderLatestVersionsByContract returns strings in the format "provider-name:version",
+	// e.g. "openstack-resource-controller:v2.5.0".
+	orcVersionStrings := e2eConfig.GetProviderLatestVersionsByContract("v1beta2", "openstack-resource-controller")
+	Expect(orcVersionStrings).ToNot(BeEmpty(),
+		"No ORC version with v1beta2 contract found in e2e config; cannot install ORC for upgrade")
+
+	parts := strings.SplitN(orcVersionStrings[0], ":", 2)
+	Expect(parts).To(HaveLen(2),
+		"Unexpected ORC provider version string format (expected 'name:version'): %q", orcVersionStrings[0])
+	orcVersion := parts[1]
+
+	installORC(ctx, proxy, orcVersion)
+}
+
+// installORC downloads and applies the upstream install manifest for the given version of the
+// OpenStack Resource Controller (ORC) to the management cluster.
+func installORC(ctx context.Context, proxy capi_framework.ClusterProxy, orcVersion string) {
+	By(fmt.Sprintf("Installing ORC %s on the management cluster", orcVersion))
+
+	orcInstallURL := fmt.Sprintf(
+		"https://github.com/k-orc/openstack-resource-controller/releases/download/%s/install.yaml",
+		orcVersion,
+	)
+	By(fmt.Sprintf("Downloading ORC %s install manifest from %s", orcVersion, orcInstallURL))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, orcInstallURL, http.NoBody)
+	Expect(err).ToNot(HaveOccurred(), "Failed to create HTTP request for ORC install manifest")
+
+	resp, err := http.DefaultClient.Do(req) //nolint:bodyclose // closed below via defer
+	Expect(err).ToNot(HaveOccurred(),
+		"Failed to download ORC %s install manifest from %s", orcVersion, orcInstallURL)
+	defer resp.Body.Close()
+
+	Expect(resp.StatusCode).To(Equal(http.StatusOK),
+		"Unexpected HTTP status %d when downloading ORC install manifest from %s", resp.StatusCode, orcInstallURL)
+
+	orcManifest, err := io.ReadAll(resp.Body)
+	Expect(err).ToNot(HaveOccurred(), "Failed to read ORC install manifest response body")
+
+	By(fmt.Sprintf("Applying ORC %s install manifest to the management cluster", orcVersion))
+	Expect(proxy.CreateOrUpdate(ctx, orcManifest)).To(Succeed(),
+		"Failed to apply ORC %s install manifest to management cluster", orcVersion)
+}

--- a/test/infrastructure/openstack-resource-controller/config/default/kustomization.yaml
+++ b/test/infrastructure/openstack-resource-controller/config/default/kustomization.yaml
@@ -8,4 +8,4 @@ labels:
     cluster.x-k8s.io/provider: "runtime-extension-openstack-resource-controller"
 
 resources:
-- https://github.com/k-orc/openstack-resource-controller/releases/download/v2.4.0/install.yaml
+- https://github.com/k-orc/openstack-resource-controller/releases/download/v2.5.0/install.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump ORC used in e2e tests to 2.5.0.
Set correct metadata and contract versions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests
