### PR TITLE
🐛 Use lazy evaluation for shell calls in `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ BIN_DIR := bin
 TOOLS_DIR_DEPS := $(TOOLS_DIR)/go.sum $(TOOLS_DIR)/go.mod $(TOOLS_DIR)/Makefile
 TOOLS_BIN_DIR := $(TOOLS_DIR)/$(BIN_DIR)
 
-REPO_ROOT := $(shell git rev-parse --show-toplevel)
+REPO_ROOT = $(shell git rev-parse --show-toplevel)
 GH_REPO ?= kubernetes-sigs/cluster-api-provider-openstack
 TEST_E2E_DIR := test/e2e
 
@@ -58,7 +58,7 @@ GO_APIDIFF_PKG := github.com/joelanford/go-apidiff
 
 # golangci-lint
 GOLANGCI_LINT_BIN := golangci-lint
-GOLANGCI_LINT_VER := $(shell cd hack/tools && go list -m -f '{{.Version}}' github.com/golangci/golangci-lint/v2)
+GOLANGCI_LINT_VER = $(shell cd hack/tools && go list -m -f '{{.Version}}' github.com/golangci/golangci-lint/v2)
 GOLANGCI_LINT_PKG := github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 
 # govulncheck
@@ -134,7 +134,7 @@ RBAC_ROOT ?= $(MANIFEST_ROOT)/rbac
 PULL_POLICY ?= Always
 
 # Set build time variables including version details
-LDFLAGS := $(shell source ./hack/version.sh; version::ldflags)
+LDFLAGS = $(shell source ./hack/version.sh; version::ldflags)
 
 # Extra arguments for govulncheck, e.g. "-show verbose"
 GOVULNCHECK_ARGS ?=


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Variables assigned using `:=` ([simply expanded variable assignment][1]) are expanded once, immediately when the line is read. This can be problematic when the shell function is used, since [that is expanded when make reads the line][2]. Combined, this means any `$(shell ...)` invocations on a `:=` line run at parse time rather than execution time.

Avoid this by assigning these variables using using `=` ([recursively expanded variable assignment][3]), which causes them to be evaluated lazily. This allows us to tab-complete targets without a 2-3 second delay.

[1]: https://www.gnu.org/software/make/manual/html_node/Simple-Assignment.html
[2]: https://www.gnu.org/software/make/manual/make.html#Shell-Function
[3]: https://www.gnu.org/software/make/manual/html_node/Recursive-Assignment.html

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

n/a

**Special notes for your reviewer**:

None.

<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
