### PR TITLE
🌱Bump Go version to 1.25.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 # Build the manager binary
 ARG GO_VERSION
-FROM golang:${GO_VERSION:-1.25.9} AS builder
+FROM golang:${GO_VERSION:-1.25.10} AS builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg goproxy=$(go env GOPROXY) to override the goproxy

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ unexport GOPATH
 TRACE ?= 0
 
 # Go
-GO_VERSION ?= 1.25.9
+GO_VERSION ?= 1.25.10
 
 # Ensure correct toolchain is used
 GOTOOLCHAIN = go$(GO_VERSION)

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@ command = "make -C docs/book build"
 publish = "docs/book/book"
 
 [build.environment]
-GO_VERSION = "1.25.9"
+GO_VERSION = "1.25.10"
 
 # Standard Netlify redirects
 [[redirects]]


### PR DESCRIPTION
Bump go to 1.25.10 to fix the following CVEs
https://github.com/advisories/GHSA-497x-jcxf-m478
https://github.com/advisories/GHSA-qc64-m6c2-v4x7
https://github.com/advisories/GHSA-5m4p-2gjx-p2g8
https://github.com/advisories/GHSA-p9h5-jm8x-mjm5
https://github.com/advisories/GHSA-2283-wf8c-rw8r
https://github.com/advisories/GHSA-h74g-238j-357m
https://github.com/advisories/GHSA-3v2c-x6q9-f697
https://github.com/advisories/GHSA-xq5j-9r39-c3vf
https://github.com/advisories/GHSA-qf3q-3h68-mmh2