### PR TITLE
🌱 Bump CI go version to 1.26.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 # Build the manager binary
 ARG GO_VERSION
-FROM golang:${GO_VERSION:-1.25.10} AS builder
+FROM golang:${GO_VERSION:-1.26.3} AS builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg goproxy=$(go env GOPROXY) to override the goproxy

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ unexport GOPATH
 TRACE ?= 0
 
 # Go
-GO_VERSION ?= 1.25.10
+GO_VERSION ?= 1.26.3
 
 # Ensure correct toolchain is used
 GOTOOLCHAIN = go$(GO_VERSION)

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@ command = "make -C docs/book build"
 publish = "docs/book/book"
 
 [build.environment]
-GO_VERSION = "1.25.10"
+GO_VERSION = "1.26.3"
 
 # Standard Netlify redirects
 [[redirects]]


### PR DESCRIPTION
**What this PR does / why we need it**:

Some dependencies are bumping the required version to 1.26 now so we will need to bump also. See for example https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/3179.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

