### PR TITLE
🌱 Enable optionalorrequired linter and add required/optional markers

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -30,7 +30,7 @@ linters:
             - "notimestamp" # Prevents usage of Timestamp fields.
             # - "optionalfields" # Ensure that all fields marked as optional adhere to being pointers and
             # having the omitempty value in their json tag where appropriate.
-            # - "optionalorrequired" # Every field should be marked as optional or required.
+            - "optionalorrequired" # Every field should be marked as optional or required.
             # - "requiredfields" # Required fields should not be pointers, and should not have omitempty.
             # - "ssatags" # Ensure array fields have the appropriate listType markers.
             - "statusoptional" # Ensure all first children within status should be optional.

--- a/api/v1beta2/identity_types.go
+++ b/api/v1beta2/identity_types.go
@@ -23,19 +23,19 @@ type OpenStackIdentityReference struct {
 	// type specifies the identity reference type. Defaults to Secret for backward compatibility.
 	// +kubebuilder:validation:Enum=Secret;ClusterIdentity
 	// +kubebuilder:default=Secret
-	// +kubebuilder:validation:Required
+	// +required
 	Type string `json:"type,omitempty"`
 
 	// name is the name of a Secret (type=Secret) in the same namespace as the resource being provisioned,
 	// or the name of an OpenStackClusterIdentity (type=ClusterIdentity).
 	// The Secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
 	// The Secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
-	// +kubebuilder:validation:Required
+	// +required
 	// +kubebuilder:validation:MinLength=1
 	Name string `json:"name"`
 
 	// cloudName specifies the name of the entry in the clouds.yaml file to use.
-	// +kubebuilder:validation:Required
+	// +required
 	// +kubebuilder:validation:MinLength=1
 	CloudName string `json:"cloudName"`
 

--- a/api/v1beta2/openstackcluster_types.go
+++ b/api/v1beta2/openstackcluster_types.go
@@ -179,13 +179,13 @@ type OpenStackClusterSpec struct {
 	// As a rolling update is not ideal during a bastion host session, we
 	// prevent changes to a running bastion configuration. To make changes, it's required
 	// to first set `enabled: false` which will remove the bastion and then changes can be made.
-	//+optional
+	// +optional
 	Bastion *Bastion `json:"bastion,omitempty"`
 
 	// identityRef is a reference to a secret holding OpenStack credentials
 	// to be used when reconciling this cluster. It is also to reconcile
 	// machines unless overridden in the machine spec.
-	// +kubebuilder:validation:Required
+	// +required
 	IdentityRef OpenStackIdentityReference `json:"identityRef"`
 }
 
@@ -268,11 +268,14 @@ type OpenStackClusterStatus struct {
 type OpenStackCluster struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the standard object metadata.
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of the OpenStackCluster.
+	// +optional
 	Spec OpenStackClusterSpec `json:"spec,omitempty"`
 	// status is the observed state of the OpenStackCluster.
+	// +optional
 	Status OpenStackClusterStatus `json:"status,omitempty"`
 }
 
@@ -282,7 +285,8 @@ type OpenStackCluster struct {
 type OpenStackClusterList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []OpenStackCluster `json:"items"`
+	// +required
+	Items []OpenStackCluster `json:"items"`
 }
 
 // ManagedRouter specifies attributes of the router.
@@ -339,7 +343,7 @@ type ManagedSecurityGroups struct {
 
 	// allowAllInClusterTraffic allows all ingress and egress traffic between cluster nodes when set to true.
 	// +kubebuilder:default=false
-	// +kubebuilder:validation:Required
+	// +required
 	AllowAllInClusterTraffic bool `json:"allowAllInClusterTraffic"`
 }
 

--- a/api/v1beta2/openstackclustertemplate_types.go
+++ b/api/v1beta2/openstackclustertemplate_types.go
@@ -23,12 +23,14 @@ import (
 // OpenStackClusterTemplateResource describes the data needed to create a OpenStackCluster from a template.
 type OpenStackClusterTemplateResource struct {
 	// spec is the desired state of the OpenStackCluster.
+	// +required
 	Spec OpenStackClusterSpec `json:"spec"`
 }
 
 // OpenStackClusterTemplateSpec defines the desired state of OpenStackClusterTemplate.
 type OpenStackClusterTemplateSpec struct {
 	// template is the OpenStackClusterTemplate resource data.
+	// +required
 	Template OpenStackClusterTemplateResource `json:"template"`
 }
 
@@ -41,9 +43,11 @@ type OpenStackClusterTemplateSpec struct {
 type OpenStackClusterTemplate struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the standard object metadata.
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of the OpenStackClusterTemplate.
+	// +optional
 	Spec OpenStackClusterTemplateSpec `json:"spec,omitempty"`
 }
 
@@ -53,7 +57,8 @@ type OpenStackClusterTemplate struct {
 type OpenStackClusterTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []OpenStackClusterTemplate `json:"items"`
+	// +required
+	Items []OpenStackClusterTemplate `json:"items"`
 }
 
 func init() {

--- a/api/v1beta2/openstackmachine_types.go
+++ b/api/v1beta2/openstackmachine_types.go
@@ -51,23 +51,26 @@ const (
 type SchedulerHintAdditionalValue struct {
 	// type represents the type of the value.
 	// Valid values are Bool, String, and Number.
-	// +kubebuilder:validation:Required
+	// +required
 	// +unionDiscriminator
 	Type SchedulerHintValueType `json:"type"`
 
 	// bool is the boolean value of the scheduler hint, used when Type is "Bool".
 	// This field is required if type is 'Bool', and must not be set otherwise.
 	// +unionMember,optional
+	// +optional
 	Bool *bool `json:"bool,omitempty"`
 
 	// number is the integer value of the scheduler hint, used when Type is "Number".
 	// This field is required if type is 'Number', and must not be set otherwise.
 	// +unionMember,optional
+	// +optional
 	Number *int `json:"number,omitempty"`
 
 	// string is the string value of the scheduler hint, used when Type is "String".
 	// This field is required if type is 'String', and must not be set otherwise.
 	// +unionMember,optional
+	// +optional
 	// +kubebuilder:validation:MinLength:=1
 	// +kubebuilder:validation:MaxLength:=255
 	String *string `json:"string,omitempty"`
@@ -79,18 +82,19 @@ type SchedulerHintAdditionalProperty struct {
 	// name is the name of the scheduler hint property.
 	// It is a unique identifier for the property.
 	// +kubebuilder:validation:MinLength:=1
-	// +kubebuilder:validation:Required
+	// +required
 	Name string `json:"name"`
 
 	// value is the value of the scheduler hint property, which can be of various types
 	// (e.g., bool, string, int). The type is indicated by the Value.Type field.
-	// +kubebuilder:validation:Required
+	// +required
 	Value SchedulerHintAdditionalValue `json:"value"`
 }
 
 // OpenStackMachineSpec defines the desired state of OpenStackMachine.
 type OpenStackMachineSpec struct {
 	// providerID is the unique identifier as specified by the cloud provider.
+	// +optional
 	ProviderID *string `json:"providerID,omitempty"`
 
 	// flavor is the flavor to use for this machine.
@@ -103,16 +107,20 @@ type OpenStackMachineSpec struct {
 	Image ImageParam `json:"image"`
 
 	// sshKeyName is the name of the SSH key to inject in the instance.
+	// +optional
 	SSHKeyName string `json:"sshKeyName,omitempty"`
 
 	// ports to be attached to the server instance. They are created if a port with the given name does not already exist.
 	// If not specified a default port will be added for the default cluster network.
+	// +optional
 	Ports []PortOpts `json:"ports,omitempty"`
 
 	// securityGroups is a list of security groups to assign to the instance.
+	// +optional
 	SecurityGroups []SecurityGroupParam `json:"securityGroups,omitempty"`
 
 	// trunk specifies whether the server instance is created on a trunk port or not.
+	// +optional
 	Trunk bool `json:"trunk,omitempty"`
 
 	// tags which will be added to the machine and all dependent resources
@@ -120,17 +128,21 @@ type OpenStackMachineSpec struct {
 	// cluster.
 	// Requires Nova api 2.52 minimum!
 	// +listType=set
+	// +optional
 	Tags []string `json:"tags,omitempty"`
 
 	// serverMetadata is a list of key/value pairs to add to the server instance.
 	// +listType=map
 	// +listMapKey=key
+	// +optional
 	ServerMetadata []ServerMetadata `json:"serverMetadata,omitempty"`
 
 	// configDrive enables config drive support.
+	// +optional
 	ConfigDrive *bool `json:"configDrive,omitempty"`
 
 	// rootVolume is the volume metadata to boot from.
+	// +optional
 	RootVolume *RootVolume `json:"rootVolume,omitempty"`
 
 	// additionalBlockDevices is a list of specifications for additional block devices to attach to the server instance
@@ -167,12 +179,12 @@ type OpenStackMachineSpec struct {
 type ServerMetadata struct {
 	// key is the server metadata key
 	// +kubebuilder:validation:MaxLength:=255
-	// +kubebuilder:validation:Required
+	// +required
 	Key string `json:"key"`
 
 	// value is the server metadata value
 	// +kubebuilder:validation:MaxLength:=255
-	// +kubebuilder:validation:Required
+	// +required
 	Value string `json:"value"`
 }
 
@@ -237,11 +249,14 @@ type OpenStackMachineStatus struct {
 type OpenStackMachine struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the standard object metadata.
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of the OpenStackMachine.
+	// +optional
 	Spec OpenStackMachineSpec `json:"spec,omitempty"`
 	// status is the observed state of the OpenStackMachine.
+	// +optional
 	Status OpenStackMachineStatus `json:"status,omitempty"`
 }
 
@@ -251,7 +266,8 @@ type OpenStackMachine struct {
 type OpenStackMachineList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []OpenStackMachine `json:"items"`
+	// +required
+	Items []OpenStackMachine `json:"items"`
 }
 
 // GetConditions returns the observations of the operational state of the OpenStackMachine resource.

--- a/api/v1beta2/openstackmachinetemplate_types.go
+++ b/api/v1beta2/openstackmachinetemplate_types.go
@@ -24,6 +24,7 @@ import (
 // OpenStackMachineTemplateSpec defines the desired state of OpenStackMachineTemplate.
 type OpenStackMachineTemplateSpec struct {
 	// template is the OpenStackMachineTemplate resource data.
+	// +required
 	Template OpenStackMachineTemplateResource `json:"template"`
 }
 
@@ -66,11 +67,14 @@ type NodeInfo struct {
 type OpenStackMachineTemplate struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the standard object metadata.
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of the OpenStackMachineTemplate.
+	// +optional
 	Spec OpenStackMachineTemplateSpec `json:"spec,omitempty"`
 	// status is the observed state of the OpenStackMachineTemplate.
+	// +optional
 	Status OpenStackMachineTemplateStatus `json:"status,omitempty"`
 }
 
@@ -80,7 +84,8 @@ type OpenStackMachineTemplate struct {
 type OpenStackMachineTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []OpenStackMachineTemplate `json:"items"`
+	// +required
+	Items []OpenStackMachineTemplate `json:"items"`
 }
 
 // GetIdentityRef returns the object's namespace and IdentityRef if it has an IdentityRef, or nulls if it does not.

--- a/api/v1beta2/types.go
+++ b/api/v1beta2/types.go
@@ -27,11 +27,13 @@ import (
 // OpenStackMachineTemplateResource describes the data needed to create a OpenStackMachine from a template.
 type OpenStackMachineTemplateResource struct {
 	// spec is the specification of the desired behavior of the machine.
+	// +required
 	Spec OpenStackMachineSpec `json:"spec"`
 }
 
 type ResourceReference struct {
 	// name is the name of the referenced resource
+	// +required
 	Name string `json:"name"`
 }
 
@@ -110,8 +112,10 @@ func (f *FlavorFilter) IsZero() bool {
 
 type ExternalRouterIPParam struct {
 	// fixedIP is the FixedIP in the corresponding subnet.
+	// +optional
 	FixedIP string `json:"fixedIP,omitempty"`
 	// subnet is the subnet in which the FixedIP is used for the Gateway of this router.
+	// +required
 	Subnet SubnetParam `json:"subnet"`
 }
 
@@ -170,10 +174,13 @@ type SecurityGroupParam struct {
 // +kubebuilder:validation:MinProperties:=1
 type SecurityGroupFilter struct {
 	// name filters security groups by name.
+	// +optional
 	Name string `json:"name,omitempty"`
 	// description filters security groups by description.
+	// +optional
 	Description string `json:"description,omitempty"`
 	// projectID filters security groups by project ID.
+	// +optional
 	ProjectID string `json:"projectID,omitempty"`
 
 	FilterByNeutronTags `json:",inline"`
@@ -207,10 +214,13 @@ type NetworkParam struct {
 // +kubebuilder:validation:MinProperties:=1
 type NetworkFilter struct {
 	// name filters networks by name.
+	// +optional
 	Name string `json:"name,omitempty"`
 	// description filters networks by description.
+	// +optional
 	Description string `json:"description,omitempty"`
 	// projectID filters networks by project ID.
+	// +optional
 	ProjectID string `json:"projectID,omitempty"`
 
 	FilterByNeutronTags `json:",inline"`
@@ -244,20 +254,28 @@ type SubnetParam struct {
 // +kubebuilder:validation:MinProperties:=1
 type SubnetFilter struct {
 	// name filters subnets by name.
+	// +optional
 	Name string `json:"name,omitempty"`
 	// description filters subnets by description.
+	// +optional
 	Description string `json:"description,omitempty"`
 	// projectID filters subnets by project ID.
+	// +optional
 	ProjectID string `json:"projectID,omitempty"`
 	// ipVersion filters subnets by IP version.
+	// +optional
 	IPVersion int `json:"ipVersion,omitempty"`
 	// gatewayIP filters subnets by gateway IP.
+	// +optional
 	GatewayIP string `json:"gatewayIP,omitempty"`
 	// cidr filters subnets by CIDR.
+	// +optional
 	CIDR string `json:"cidr,omitempty"`
 	// ipv6AddressMode filters subnets by IPv6 address mode.
+	// +optional
 	IPv6AddressMode string `json:"ipv6AddressMode,omitempty"`
 	// ipv6RAMode filters subnets by IPv6 Router Advertisement mode.
+	// +optional
 	IPv6RAMode string `json:"ipv6RAMode,omitempty"`
 
 	FilterByNeutronTags `json:",inline"`
@@ -288,6 +306,7 @@ type RouterParam struct {
 	ID optional.String `json:"id,omitempty"`
 
 	// filter specifies a filter to select an OpenStack router. If provided, cannot be empty.
+	// +optional
 	Filter *RouterFilter `json:"filter,omitempty"`
 }
 
@@ -295,10 +314,13 @@ type RouterParam struct {
 // +kubebuilder:validation:MinProperties:=1
 type RouterFilter struct {
 	// name filters routers by name.
+	// +optional
 	Name string `json:"name,omitempty"`
 	// description filters routers by description.
+	// +optional
 	Description string `json:"description,omitempty"`
 	// projectID filters routers by project ID.
+	// +optional
 	ProjectID string `json:"projectID,omitempty"`
 
 	FilterByNeutronTags `json:",inline"`
@@ -322,11 +344,13 @@ type SubnetSpec struct {
 
 	// dnsNameservers holds a list of DNS server addresses that will be provided when creating
 	// the subnet. These addresses need to have the same IP version as CIDR.
+	// +optional
 	DNSNameservers []string `json:"dnsNameservers,omitempty"`
 
 	// allocationPools is an array of AllocationPool objects that will be applied to OpenStack Subnet being created.
 	// If set, OpenStack will only allocate these IPs for Machines. It will still be possible to create ports from
 	// outside of these ranges manually.
+	// +optional
 	AllocationPools []AllocationPool `json:"allocationPools,omitempty"`
 }
 
@@ -445,12 +469,15 @@ type ResolvedPortSpecFields struct {
 // ResolvedPortSpec is a PortOpts with all contained references fully resolved.
 type ResolvedPortSpec struct {
 	// name is the name of the port.
+	// +required
 	Name string `json:"name"`
 
 	// description is a human-readable description for the port.
+	// +optional
 	Description string `json:"description"`
 
 	// networkID is the ID of the network the port will be created in.
+	// +required
 	NetworkID string `json:"networkID"`
 
 	// tags applied to the port (and corresponding trunk, if a trunk is configured.)
@@ -525,7 +552,7 @@ type AddressPair struct {
 	// ipAddress is the IP address of the allowed address pair. Depending on
 	// the configuration of Neutron, it may be supported to specify a CIDR
 	// instead of a specific IP address.
-	// +kubebuilder:validation:Required
+	// +required
 	IPAddress string `json:"ipAddress"`
 
 	// macAddress is the MAC address of the allowed address pair. If not
@@ -536,16 +563,22 @@ type AddressPair struct {
 
 type BastionStatus struct {
 	// id is the unique identifier of the bastion.
+	// +optional
 	ID string `json:"id,omitempty"`
 	// name is the name of the bastion.
+	// +optional
 	Name string `json:"name,omitempty"`
 	// sshKeyName is the name of the SSH key used for the bastion.
+	// +optional
 	SSHKeyName string `json:"sshKeyName,omitempty"`
 	// state is the current state of the bastion.
+	// +optional
 	State InstanceState `json:"state,omitempty"`
 	// ip is the IP address of the bastion.
+	// +optional
 	IP string `json:"ip,omitempty"`
 	// floatingIP is the floating IP address of the bastion.
+	// +optional
 	FloatingIP string `json:"floatingIP,omitempty"`
 
 	// resolved contains parts of the bastion's machine spec with all
@@ -560,7 +593,7 @@ type BastionStatus struct {
 
 type RootVolume struct {
 	// sizeGiB is the size of the block device in gibibytes (GiB).
-	// +kubebuilder:validation:Required
+	// +required
 	// +kubebuilder:validation:Minimum:=1
 	SizeGiB int `json:"sizeGiB"`
 
@@ -576,6 +609,7 @@ type BlockDeviceStorage struct {
 	// type is the type of block device to create.
 	// This can be either "Volume" or "Local".
 	// +unionDiscriminator
+	// +required
 	Type BlockDeviceType `json:"type"`
 
 	// volume contains additional storage options for a volume block device.
@@ -641,16 +675,17 @@ type AdditionalBlockDevice struct {
 	// Information about the block device tag can be obtained from the OpenStack
 	// metadata API or the config drive.
 	// Name cannot be 'root', which is reserved for the root volume.
-	// +kubebuilder:validation:Required
+	// +required
 	Name string `json:"name"`
 
 	// sizeGiB is the size of the block device in gibibytes (GiB).
-	// +kubebuilder:validation:Required
+	// +required
 	// +kubebuilder:validation:Minimum:=1
 	SizeGiB int `json:"sizeGiB"`
 
 	// storage specifies the storage type of the block device and
 	// additional storage options.
+	// +required
 	Storage BlockDeviceStorage `json:"storage"`
 }
 
@@ -660,9 +695,11 @@ type AdditionalBlockDevice struct {
 type ServerGroupParam struct {
 	// id is the ID of the server group to use.
 	// +kubebuilder:validation:Format:=uuid
+	// +optional
 	ID optional.String `json:"id,omitempty"`
 
 	// filter specifies a query to select an OpenStack server group. If provided, it cannot be empty.
+	// +optional
 	Filter *ServerGroupFilter `json:"filter,omitempty"`
 }
 
@@ -670,6 +707,7 @@ type ServerGroupParam struct {
 // +kubebuilder:validation:MinProperties:=1
 type ServerGroupFilter struct {
 	// name is the name of a server group to look for.
+	// +optional
 	Name optional.String `json:"name,omitempty"`
 }
 
@@ -694,8 +732,10 @@ const (
 // NetworkStatus contains basic information about an existing neutron network.
 type NetworkStatus struct {
 	// name is the name of the network.
+	// +required
 	Name string `json:"name"`
 	// id is the unique identifier of the network.
+	// +required
 	ID string `json:"id"`
 
 	// tags is a list of tags on the network.
@@ -708,17 +748,21 @@ type NetworkStatusWithSubnets struct {
 	NetworkStatus `json:",inline"`
 
 	// subnets is a list of subnets associated with the default cluster network. Machines which use the default cluster network will get an address from all of these subnets.
+	// +optional
 	Subnets []Subnet `json:"subnets,omitempty"`
 }
 
 // Subnet represents basic information about the associated OpenStack Neutron Subnet.
 type Subnet struct {
 	// name is the name of the subnet.
+	// +required
 	Name string `json:"name"`
 	// id is the unique identifier of the subnet.
+	// +required
 	ID string `json:"id"`
 
 	// cidr is the CIDR of the subnet.
+	// +required
 	CIDR string `json:"cidr"`
 
 	// tags is a list of tags on the subnet.
@@ -729,8 +773,10 @@ type Subnet struct {
 // Router represents basic information about the associated OpenStack Neutron Router.
 type Router struct {
 	// name is the name of the router.
+	// +required
 	Name string `json:"name"`
 	// id is the unique identifier of the router.
+	// +required
 	ID string `json:"id"`
 	// tags is a list of tags on the router.
 	// +optional
@@ -743,12 +789,16 @@ type Router struct {
 // LoadBalancer represents basic information about the associated OpenStack LoadBalancer.
 type LoadBalancer struct {
 	// name is the name of the load balancer.
+	// +required
 	Name string `json:"name"`
 	// id is the unique identifier of the load balancer.
+	// +required
 	ID string `json:"id"`
 	// ip is the IP address of the load balancer.
+	// +required
 	IP string `json:"ip"`
 	// internalIP is the internal IP address of the load balancer.
+	// +required
 	InternalIP string `json:"internalIP"`
 	// allowedCIDRs is a list of CIDRs that are allowed to access the load balancer.
 	// +optional
@@ -768,11 +818,11 @@ type LoadBalancer struct {
 // OpenStack Neutron Security Group.
 type SecurityGroupStatus struct {
 	// name of the security group
-	// +kubebuilder:validation:Required
+	// +required
 	Name string `json:"name"`
 
 	// id of the security group
-	// +kubebuilder:validation:Required
+	// +required
 	ID string `json:"id"`
 }
 
@@ -784,7 +834,7 @@ type SecurityGroupStatus struct {
 type SecurityGroupRuleSpec struct {
 	// name of the security group rule.
 	// It's used to identify the rule so it can be patched and will not be sent to the OpenStack API.
-	// +kubebuilder:validation:Required
+	// +required
 	Name string `json:"name"`
 
 	// description of the security group rule.
@@ -795,7 +845,7 @@ type SecurityGroupRuleSpec struct {
 	// allowed are "ingress" or "egress". For a compute instance, an ingress
 	// security group rule is applied to incoming (ingress) traffic for that
 	// instance. An egress rule is applied to traffic leaving the instance.
-	// +kubebuilder:validation:Required
+	// +required
 	// +kubebuilder:validation:Enum=ingress;egress
 	Direction string `json:"direction"`
 
@@ -889,16 +939,17 @@ type Bastion struct {
 	Enabled *bool `json:"enabled,omitempty"`
 
 	// spec for the bastion itself
+	// +optional
 	Spec *OpenStackMachineSpec `json:"spec,omitempty"`
 
 	// availabilityZone is the failure domain that will be used to create the Bastion Spec.
-	//+optional
+	// +optional
 	AvailabilityZone optional.String `json:"availabilityZone,omitempty"`
 
 	// floatingIP which will be associated to the bastion machine. It's the IP address, not UUID.
 	// The floating IP should already exist and should not be associated with a port. If FIP of this address does not
 	// exist, CAPO will try to create it, but by default only OpenStack administrators have privileges to do so.
-	//+optional
+	// +optional
 	//+kubebuilder:validation:Format:=ipv4
 	FloatingIP optional.String `json:"floatingIP,omitempty"`
 }
@@ -918,7 +969,7 @@ type APIServerLoadBalancer struct {
 	// API server loadbalancer, omit the APIServerLoadBalancer field in the
 	// cluster spec instead.
 	//
-	// +kubebuilder:validation:Required
+	// +required
 	// +kubebuilder:default:=true
 	Enabled *bool `json:"enabled"`
 
@@ -939,7 +990,7 @@ type APIServerLoadBalancer struct {
 	Provider optional.String `json:"provider,omitempty"`
 
 	// network defines which network should the load balancer be allocated on.
-	//+optional
+	// +optional
 	Network *NetworkParam `json:"network,omitempty"`
 
 	// subnets define which subnets should the load balancer be allocated on.
@@ -951,44 +1002,44 @@ type APIServerLoadBalancer struct {
 	Subnets []SubnetParam `json:"subnets,omitempty"`
 
 	// availabilityZone is the failure domain that will be used to create the APIServerLoadBalancer Spec.
-	//+optional
+	// +optional
 	AvailabilityZone optional.String `json:"availabilityZone,omitempty"`
 
 	// flavor is the flavor name that will be used to create the APIServerLoadBalancer Spec.
-	//+optional
+	// +optional
 	Flavor optional.String `json:"flavor,omitempty"`
 
 	// monitor contains configuration for the load balancer health monitor.
-	//+optional
+	// +optional
 	Monitor *APIServerLoadBalancerMonitor `json:"monitor,omitempty"`
 }
 
 // APIServerLoadBalancerMonitor contains configuration for the load balancer health monitor.
 type APIServerLoadBalancerMonitor struct {
 	// delay is the time in seconds between sending probes to members.
-	//+optional
-	//+kubebuilder:validation:Minimum=0
-	//+kubebuilder:default:10
+	// +optional
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:default:10
 	Delay int `json:"delay,omitempty"`
 
 	// timeout is the maximum time in seconds for a monitor to wait for a connection to be established before it times out.
-	//+optional
-	//+kubebuilder:validation:Minimum=0
-	//+kubebuilder:default:5
+	// +optional
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:default:5
 	Timeout int `json:"timeout,omitempty"`
 
 	// maxRetries is the number of successful checks before changing the operating status of the member to ONLINE.
-	//+optional
-	//+kubebuilder:validation:Minimum=0
-	//+kubebuilder:validation:Maximum=10
-	//+kubebuilder:default:5
+	// +optional
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=10
+	// +kubebuilder:default:5
 	MaxRetries int `json:"maxRetries,omitempty"`
 
 	// maxRetriesDown is the number of allowed check failures before changing the operating status of the member to ERROR.
-	//+optional
-	//+kubebuilder:validation:Minimum=1
-	//+kubebuilder:validation:Maximum=10
-	//+kubebuilder:default:3
+	// +optional
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=10
+	// +kubebuilder:default:3
 	MaxRetriesDown int `json:"maxRetriesDown,omitempty"`
 }
 
@@ -1030,13 +1081,13 @@ type MachineResources struct {
 type ValueSpec struct {
 	// name is the name of the key-value pair.
 	// This is just for identifying the pair and will not be sent to the OpenStack API.
-	// +kubebuilder:validation:Required
+	// +required
 	Name string `json:"name"`
 	// key is the key in the key-value pair.
-	// +kubebuilder:validation:Required
+	// +required
 	Key string `json:"key"`
 	// value is the value in the key-value pair.
-	// +kubebuilder:validation:Required
+	// +required
 	Value string `json:"value"`
 }
 

--- a/cmd/models-schema/zz_generated.openapi.go
+++ b/cmd/models-schema/zz_generated.openapi.go
@@ -24006,7 +24006,7 @@ func schema_sigsk8sio_cluster_api_provider_openstack_api_v1beta2_OpenStackIdenti
 						},
 					},
 				},
-				Required: []string{"name", "cloudName"},
+				Required: []string{"type", "name", "cloudName"},
 			},
 		},
 	}
@@ -25056,7 +25056,7 @@ func schema_sigsk8sio_cluster_api_provider_openstack_api_v1beta2_ResolvedPortSpe
 						},
 					},
 				},
-				Required: []string{"name", "description", "networkID"},
+				Required: []string{"name", "networkID"},
 			},
 		},
 		Dependencies: []string{

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -5223,7 +5223,6 @@ spec:
                                 deployments. If not specified, the Neutron default value is used.
                               type: string
                           required:
-                          - description
                           - name
                           - networkID
                           type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
@@ -2526,7 +2526,6 @@ spec:
                             deployments. If not specified, the Neutron default value is used.
                           type: string
                       required:
-                      - description
                       - name
                       - networkID
                       type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackservers.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackservers.yaml
@@ -1246,7 +1246,6 @@ spec:
                             deployments. If not specified, the Neutron default value is used.
                           type: string
                       required:
-                      - description
                       - name
                       - networkID
                       type: object

--- a/docs/book/src/api/v1beta2/api.md
+++ b/docs/book/src/api/v1beta2/api.md
@@ -50,6 +50,7 @@ Kubernetes meta/v1.ObjectMeta
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>metadata is the standard object metadata.</p>
 Refer to the Kubernetes API documentation for the fields of the
 <code>metadata</code> field.
@@ -65,6 +66,7 @@ OpenStackClusterSpec
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>spec is the desired state of the OpenStackCluster.</p>
 <br/>
 <br/>
@@ -406,6 +408,7 @@ OpenStackClusterStatus
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>status is the observed state of the OpenStackCluster.</p>
 </td>
 </tr>
@@ -449,6 +452,7 @@ Kubernetes meta/v1.ObjectMeta
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>metadata is the standard object metadata.</p>
 Refer to the Kubernetes API documentation for the fields of the
 <code>metadata</code> field.
@@ -464,6 +468,7 @@ OpenStackClusterTemplateSpec
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>spec is the desired state of the OpenStackClusterTemplate.</p>
 <br/>
 <br/>
@@ -524,6 +529,7 @@ Kubernetes meta/v1.ObjectMeta
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>metadata is the standard object metadata.</p>
 Refer to the Kubernetes API documentation for the fields of the
 <code>metadata</code> field.
@@ -539,6 +545,7 @@ OpenStackMachineSpec
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>spec is the desired state of the OpenStackMachine.</p>
 <br/>
 <br/>
@@ -551,6 +558,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>providerID is the unique identifier as specified by the cloud provider.</p>
 </td>
 </tr>
@@ -589,6 +597,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>sshKeyName is the name of the SSH key to inject in the instance.</p>
 </td>
 </tr>
@@ -602,6 +611,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>ports to be attached to the server instance. They are created if a port with the given name does not already exist.
 If not specified a default port will be added for the default cluster network.</p>
 </td>
@@ -616,6 +626,7 @@ If not specified a default port will be added for the default cluster network.</
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>securityGroups is a list of security groups to assign to the instance.</p>
 </td>
 </tr>
@@ -627,6 +638,7 @@ bool
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>trunk specifies whether the server instance is created on a trunk port or not.</p>
 </td>
 </tr>
@@ -638,6 +650,7 @@ bool
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>tags which will be added to the machine and all dependent resources
 which support them. These are in addition to Tags defined on the
 cluster.
@@ -654,6 +667,7 @@ Requires Nova api 2.52 minimum!</p>
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>serverMetadata is a list of key/value pairs to add to the server instance.</p>
 </td>
 </tr>
@@ -665,6 +679,7 @@ bool
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>configDrive enables config drive support.</p>
 </td>
 </tr>
@@ -678,6 +693,7 @@ RootVolume
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>rootVolume is the volume metadata to boot from.</p>
 </td>
 </tr>
@@ -768,6 +784,7 @@ OpenStackMachineStatus
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>status is the observed state of the OpenStackMachine.</p>
 </td>
 </tr>
@@ -811,6 +828,7 @@ Kubernetes meta/v1.ObjectMeta
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>metadata is the standard object metadata.</p>
 Refer to the Kubernetes API documentation for the fields of the
 <code>metadata</code> field.
@@ -826,6 +844,7 @@ OpenStackMachineTemplateSpec
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>spec is the desired state of the OpenStackMachineTemplate.</p>
 <br/>
 <br/>
@@ -856,6 +875,7 @@ OpenStackMachineTemplateStatus
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>status is the observed state of the OpenStackMachineTemplate.</p>
 </td>
 </tr>
@@ -1257,6 +1277,7 @@ OpenStackMachineSpec
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>spec for the bastion itself</p>
 <br/>
 <br/>
@@ -1316,6 +1337,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>id is the unique identifier of the bastion.</p>
 </td>
 </tr>
@@ -1327,6 +1349,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>name is the name of the bastion.</p>
 </td>
 </tr>
@@ -1338,6 +1361,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>sshKeyName is the name of the SSH key used for the bastion.</p>
 </td>
 </tr>
@@ -1351,6 +1375,7 @@ InstanceState
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>state is the current state of the bastion.</p>
 </td>
 </tr>
@@ -1362,6 +1387,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>ip is the IP address of the bastion.</p>
 </td>
 </tr>
@@ -1373,6 +1399,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>floatingIP is the floating IP address of the bastion.</p>
 </td>
 </tr>
@@ -1629,6 +1656,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>fixedIP is the FixedIP in the corresponding subnet.</p>
 </td>
 </tr>
@@ -2332,6 +2360,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>name filters networks by name.</p>
 </td>
 </tr>
@@ -2343,6 +2372,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>description filters networks by description.</p>
 </td>
 </tr>
@@ -2354,6 +2384,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>projectID filters networks by project ID.</p>
 </td>
 </tr>
@@ -2518,6 +2549,7 @@ NetworkStatus
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>subnets is a list of subnets associated with the default cluster network. Machines which use the default cluster network will get an address from all of these subnets.</p>
 </td>
 </tr>
@@ -3577,6 +3609,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>providerID is the unique identifier as specified by the cloud provider.</p>
 </td>
 </tr>
@@ -3615,6 +3648,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>sshKeyName is the name of the SSH key to inject in the instance.</p>
 </td>
 </tr>
@@ -3628,6 +3662,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>ports to be attached to the server instance. They are created if a port with the given name does not already exist.
 If not specified a default port will be added for the default cluster network.</p>
 </td>
@@ -3642,6 +3677,7 @@ If not specified a default port will be added for the default cluster network.</
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>securityGroups is a list of security groups to assign to the instance.</p>
 </td>
 </tr>
@@ -3653,6 +3689,7 @@ bool
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>trunk specifies whether the server instance is created on a trunk port or not.</p>
 </td>
 </tr>
@@ -3664,6 +3701,7 @@ bool
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>tags which will be added to the machine and all dependent resources
 which support them. These are in addition to Tags defined on the
 cluster.
@@ -3680,6 +3718,7 @@ Requires Nova api 2.52 minimum!</p>
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>serverMetadata is a list of key/value pairs to add to the server instance.</p>
 </td>
 </tr>
@@ -3691,6 +3730,7 @@ bool
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>configDrive enables config drive support.</p>
 </td>
 </tr>
@@ -3704,6 +3744,7 @@ RootVolume
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>rootVolume is the volume metadata to boot from.</p>
 </td>
 </tr>
@@ -3941,6 +3982,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>providerID is the unique identifier as specified by the cloud provider.</p>
 </td>
 </tr>
@@ -3979,6 +4021,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>sshKeyName is the name of the SSH key to inject in the instance.</p>
 </td>
 </tr>
@@ -3992,6 +4035,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>ports to be attached to the server instance. They are created if a port with the given name does not already exist.
 If not specified a default port will be added for the default cluster network.</p>
 </td>
@@ -4006,6 +4050,7 @@ If not specified a default port will be added for the default cluster network.</
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>securityGroups is a list of security groups to assign to the instance.</p>
 </td>
 </tr>
@@ -4017,6 +4062,7 @@ bool
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>trunk specifies whether the server instance is created on a trunk port or not.</p>
 </td>
 </tr>
@@ -4028,6 +4074,7 @@ bool
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>tags which will be added to the machine and all dependent resources
 which support them. These are in addition to Tags defined on the
 cluster.
@@ -4044,6 +4091,7 @@ Requires Nova api 2.52 minimum!</p>
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>serverMetadata is a list of key/value pairs to add to the server instance.</p>
 </td>
 </tr>
@@ -4055,6 +4103,7 @@ bool
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>configDrive enables config drive support.</p>
 </td>
 </tr>
@@ -4068,6 +4117,7 @@ RootVolume
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>rootVolume is the volume metadata to boot from.</p>
 </td>
 </tr>
@@ -4553,6 +4603,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>description is a human-readable description for the port.</p>
 </td>
 </tr>
@@ -4953,6 +5004,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>name filters routers by name.</p>
 </td>
 </tr>
@@ -4964,6 +5016,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>description filters routers by description.</p>
 </td>
 </tr>
@@ -4975,6 +5028,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>projectID filters routers by project ID.</p>
 </td>
 </tr>
@@ -5034,6 +5088,7 @@ RouterFilter
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>filter specifies a filter to select an OpenStack router. If provided, cannot be empty.</p>
 </td>
 </tr>
@@ -5126,6 +5181,7 @@ bool
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>bool is the boolean value of the scheduler hint, used when Type is &ldquo;Bool&rdquo;.
 This field is required if type is &lsquo;Bool&rsquo;, and must not be set otherwise.</p>
 </td>
@@ -5138,6 +5194,7 @@ int
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>number is the integer value of the scheduler hint, used when Type is &ldquo;Number&rdquo;.
 This field is required if type is &lsquo;Number&rsquo;, and must not be set otherwise.</p>
 </td>
@@ -5150,6 +5207,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>string is the string value of the scheduler hint, used when Type is &ldquo;String&rdquo;.
 This field is required if type is &lsquo;String&rsquo;, and must not be set otherwise.</p>
 </td>
@@ -5205,6 +5263,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>name filters security groups by name.</p>
 </td>
 </tr>
@@ -5216,6 +5275,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>description filters security groups by description.</p>
 </td>
 </tr>
@@ -5227,6 +5287,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>projectID filters security groups by project ID.</p>
 </td>
 </tr>
@@ -5514,6 +5575,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>name is the name of a server group to look for.</p>
 </td>
 </tr>
@@ -5544,6 +5606,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>id is the ID of the server group to use.</p>
 </td>
 </tr>
@@ -5557,6 +5620,7 @@ ServerGroupFilter
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>filter specifies a query to select an OpenStack server group. If provided, it cannot be empty.</p>
 </td>
 </tr>
@@ -5691,6 +5755,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>name filters subnets by name.</p>
 </td>
 </tr>
@@ -5702,6 +5767,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>description filters subnets by description.</p>
 </td>
 </tr>
@@ -5713,6 +5779,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>projectID filters subnets by project ID.</p>
 </td>
 </tr>
@@ -5724,6 +5791,7 @@ int
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>ipVersion filters subnets by IP version.</p>
 </td>
 </tr>
@@ -5735,6 +5803,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>gatewayIP filters subnets by gateway IP.</p>
 </td>
 </tr>
@@ -5746,6 +5815,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>cidr filters subnets by CIDR.</p>
 </td>
 </tr>
@@ -5757,6 +5827,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>ipv6AddressMode filters subnets by IPv6 address mode.</p>
 </td>
 </tr>
@@ -5768,6 +5839,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>ipv6RAMode filters subnets by IPv6 Router Advertisement mode.</p>
 </td>
 </tr>
@@ -5872,6 +5944,7 @@ This field is required when defining a subnet.</p>
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>dnsNameservers holds a list of DNS server addresses that will be provided when creating
 the subnet. These addresses need to have the same IP version as CIDR.</p>
 </td>
@@ -5886,6 +5959,7 @@ the subnet. These addresses need to have the same IP version as CIDR.</p>
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>allocationPools is an array of AllocationPool objects that will be applied to OpenStack Subnet being created.
 If set, OpenStack will only allocate these IPs for Machines. It will still be possible to create ports from
 outside of these ranges manually.</p>


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit enables the `optionalorrequired` linter in `.golangci-kal.yml` and updates all API type definitions in v1beta2 to use the standardized `+required` and `+optional` markers instead of `+kubebuilder:validation:Required`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
