### PR TITLE
🐛 Ignore description when comparing security group rules

### DIFF
--- a/pkg/cloud/services/networking/securitygroups.go
+++ b/pkg/cloud/services/networking/securitygroups.go
@@ -151,8 +151,7 @@ type resolvedSecurityGroupRuleSpec struct {
 }
 
 func (r resolvedSecurityGroupRuleSpec) Matches(other rules.SecGroupRule) bool {
-	return r.Description == other.Description &&
-		r.Direction == other.Direction &&
+	return r.Direction == other.Direction &&
 		r.EtherType == other.EtherType &&
 		r.PortRangeMin == other.PortRangeMin &&
 		r.PortRangeMax == other.PortRangeMax &&

--- a/pkg/cloud/services/networking/securitygroups_test.go
+++ b/pkg/cloud/services/networking/securitygroups_test.go
@@ -740,3 +740,27 @@ func TestGetSGControlPlaneAdditionalPorts(t *testing.T) {
 		})
 	}
 }
+
+func TestMatchesIgnoresDescription(t *testing.T) {
+	rule1 := resolvedSecurityGroupRuleSpec{
+		Description:    "desc1",
+		Direction:      "ingress",
+		EtherType:      "IPv4",
+		PortRangeMin:   30000,
+		PortRangeMax:   32767,
+		Protocol:       "tcp",
+		RemoteIPPrefix: "10.0.0.0/24",
+	}
+	observed := rules.SecGroupRule{
+		Description:    "desc2",
+		Direction:      "ingress",
+		EtherType:      "IPv4",
+		PortRangeMin:   30000,
+		PortRangeMax:   32767,
+		Protocol:       "tcp",
+		RemoteIPPrefix: "10.0.0.0/24",
+	}
+	if !rule1.Matches(observed) {
+		t.Errorf("Matches should ignore Description and return true for functionally identical rules")
+	}
+}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Without this, security rules while using remoteIPPrefix are not being propagated to workers nodes, but only controlplane nodes.

Any modification to "Description" only, will not be reconciled anymore with this PR.

Fixes #3175 

**Special notes for your reviewer**:

Check the issue for more details 

- if necessary:
  - [ ] includes documentation
  - [X] adds unit tests

/hold
