### PR TITLE
:warning: V1beta2 Switch to positive polarity for bool fields

### DIFF
--- a/api/v1beta1/conversion.go
+++ b/api/v1beta1/conversion.go
@@ -378,8 +378,10 @@ func Convert_v1beta1_OpenStackClusterSpec_To_v1beta2_OpenStackClusterSpec(
 
 	if in.NetworkMTU != nil || in.DisablePortSecurity != nil {
 		out.ManagedNetwork = &infrav1.ManagedNetwork{
-			MTU:                 in.NetworkMTU,
-			DisablePortSecurity: in.DisablePortSecurity,
+			MTU: in.NetworkMTU,
+		}
+		if in.DisablePortSecurity != nil {
+			out.ManagedNetwork.EnablePortSecurity = ptr.To(!*in.DisablePortSecurity)
 		}
 	}
 
@@ -432,7 +434,9 @@ func Convert_v1beta2_OpenStackClusterSpec_To_v1beta1_OpenStackClusterSpec(
 
 	if in.ManagedNetwork != nil {
 		out.NetworkMTU = in.ManagedNetwork.MTU
-		out.DisablePortSecurity = in.ManagedNetwork.DisablePortSecurity
+		if in.ManagedNetwork.EnablePortSecurity != nil {
+			out.DisablePortSecurity = ptr.To(!*in.ManagedNetwork.EnablePortSecurity)
+		}
 	}
 
 	// ExternalRouterIPs and ExternalRouterIPParam are structurally identical between versions,

--- a/api/v1beta1/conversion.go
+++ b/api/v1beta1/conversion.go
@@ -385,6 +385,10 @@ func Convert_v1beta1_OpenStackClusterSpec_To_v1beta2_OpenStackClusterSpec(
 		}
 	}
 
+	if in.DisableExternalNetwork != nil {
+		out.EnableExternalNetwork = ptr.To(!*in.DisableExternalNetwork)
+	}
+
 	// ExternalRouterIPs and ExternalRouterIPParam are structurally identical between versions,
 	// but the nested SubnetParam is a different Go type per package, preventing a direct cast.
 	// Loop and convert element-wise.
@@ -437,6 +441,10 @@ func Convert_v1beta2_OpenStackClusterSpec_To_v1beta1_OpenStackClusterSpec(
 		if in.ManagedNetwork.EnablePortSecurity != nil {
 			out.DisablePortSecurity = ptr.To(!*in.ManagedNetwork.EnablePortSecurity)
 		}
+	}
+
+	if in.EnableExternalNetwork != nil {
+		out.DisableExternalNetwork = ptr.To(!*in.EnableExternalNetwork)
 	}
 
 	// ExternalRouterIPs and ExternalRouterIPParam are structurally identical between versions,

--- a/api/v1beta1/conversion.go
+++ b/api/v1beta1/conversion.go
@@ -588,3 +588,27 @@ func ConvertAllTagsFrom(neutronTags *FilterByNeutronTags, tags, tagsAny, notTags
 	*notTags = JoinTags(neutronTags.NotTags)
 	*notTagsAny = JoinTags(neutronTags.NotTagsAny)
 }
+
+func Convert_v1beta1_ResolvedPortSpecFields_To_v1beta2_ResolvedPortSpecFields(in *ResolvedPortSpecFields, out *infrav1.ResolvedPortSpecFields, s apiconversion.Scope) error {
+	if err := autoConvert_v1beta1_ResolvedPortSpecFields_To_v1beta2_ResolvedPortSpecFields(in, out, s); err != nil {
+		return err
+	}
+
+	if in.DisablePortSecurity != nil {
+		out.EnablePortSecurity = ptr.To(!*in.DisablePortSecurity)
+	}
+
+	return nil
+}
+
+func Convert_v1beta2_ResolvedPortSpecFields_To_v1beta1_ResolvedPortSpecFields(in *infrav1.ResolvedPortSpecFields, out *ResolvedPortSpecFields, s apiconversion.Scope) error {
+	if err := autoConvert_v1beta2_ResolvedPortSpecFields_To_v1beta1_ResolvedPortSpecFields(in, out, s); err != nil {
+		return err
+	}
+
+	if in.EnablePortSecurity != nil {
+		out.DisablePortSecurity = ptr.To(!*in.EnablePortSecurity)
+	}
+
+	return nil
+}

--- a/api/v1beta1/conversion.go
+++ b/api/v1beta1/conversion.go
@@ -412,10 +412,12 @@ func Convert_v1beta1_OpenStackClusterSpec_To_v1beta2_OpenStackClusterSpec(
 		in.APIServerFixedIP != nil ||
 		in.APIServerPort != nil {
 		out.APIServer = &infrav1.APIServer{
-			DisableFloatingIP: in.DisableAPIServerFloatingIP,
-			FloatingIP:        in.APIServerFloatingIP,
-			FixedIP:           in.APIServerFixedIP,
-			Port:              in.APIServerPort,
+			FloatingIP: in.APIServerFloatingIP,
+			FixedIP:    in.APIServerFixedIP,
+			Port:       in.APIServerPort,
+		}
+		if in.DisableAPIServerFloatingIP != nil {
+			out.APIServer.EnableFloatingIP = ptr.To(!*in.DisableAPIServerFloatingIP)
 		}
 		// APIServerLoadBalancer is structurally identical between versions,
 		// so an unsafe cast is safe here (same field layout).
@@ -462,10 +464,12 @@ func Convert_v1beta2_OpenStackClusterSpec_To_v1beta1_OpenStackClusterSpec(
 
 	// Expand the v1beta2 APIServer struct back into the flat v1beta1 fields.
 	if in.APIServer != nil {
-		out.DisableAPIServerFloatingIP = in.APIServer.DisableFloatingIP
 		out.APIServerFloatingIP = in.APIServer.FloatingIP
 		out.APIServerFixedIP = in.APIServer.FixedIP
 		out.APIServerPort = in.APIServer.Port
+		if in.APIServer.EnableFloatingIP != nil {
+			out.DisableAPIServerFloatingIP = ptr.To(!*in.APIServer.EnableFloatingIP)
+		}
 
 		if in.APIServer.ManagedLoadBalancer != nil {
 			out.APIServerLoadBalancer = (*APIServerLoadBalancer)(unsafe.Pointer(in.APIServer.ManagedLoadBalancer))

--- a/api/v1beta1/conversion_test.go
+++ b/api/v1beta1/conversion_test.go
@@ -1512,3 +1512,51 @@ func TestOpenStackCluster_RoundTrip_ExternalNetwork(t *testing.T) {
 		})
 	}
 }
+
+func TestResolvedPortSpecFields_RoundTrip_PortSecurity(t *testing.T) {
+	tests := []struct {
+		name             string
+		in               ResolvedPortSpecFields
+		expectedEnablePS *bool
+	}{
+		{
+			name: "DisablePortSecurity explicitly true",
+			in: ResolvedPortSpecFields{
+				DisablePortSecurity: ptr.To(true),
+			},
+			expectedEnablePS: ptr.To(false), // disable=true → enable=false
+		},
+		{
+			name: "DisablePortSecurity explicitly false",
+			in: ResolvedPortSpecFields{
+				DisablePortSecurity: ptr.To(false),
+			},
+			expectedEnablePS: ptr.To(true), // disable=false → enable=true
+		},
+		{
+			name:             "DisablePortSecurity unset — EnablePortSecurity stays nil",
+			in:               ResolvedPortSpecFields{},
+			expectedEnablePS: nil, // unset stays unset, inherits from network level
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			// --- Convert to v1beta2 ---
+			out := &infrav1.ResolvedPortSpecFields{}
+			g.Expect(Convert_v1beta1_ResolvedPortSpecFields_To_v1beta2_ResolvedPortSpecFields(&tt.in, out, nil)).To(Succeed())
+
+			// --- Verify intermediate v1beta2 state ---
+			g.Expect(out.EnablePortSecurity).To(Equal(tt.expectedEnablePS))
+
+			// --- Convert back to v1beta1 ---
+			restored := &ResolvedPortSpecFields{}
+			g.Expect(Convert_v1beta2_ResolvedPortSpecFields_To_v1beta1_ResolvedPortSpecFields(out, restored, nil)).To(Succeed())
+
+			// --- Verify full round-trip ---
+			g.Expect(restored.DisablePortSecurity).To(Equal(tt.in.DisablePortSecurity))
+		})
+	}
+}

--- a/api/v1beta1/conversion_test.go
+++ b/api/v1beta1/conversion_test.go
@@ -977,8 +977,9 @@ func TestOpenStackCluster_RoundTrip_ManagedNetwork(t *testing.T) {
 	disablePS := optional.Bool(ptr.To(true))
 
 	tests := []struct {
-		name string
-		in   OpenStackCluster
+		name             string
+		in               OpenStackCluster
+		expectedEnablePS optional.Bool
 	}{
 		{
 			name: "both fields set",
@@ -988,22 +989,33 @@ func TestOpenStackCluster_RoundTrip_ManagedNetwork(t *testing.T) {
 					DisablePortSecurity: disablePS,
 				},
 			},
+			expectedEnablePS: optional.Bool(ptr.To(false)), // disablePS=true → enablePS=false
 		},
 		{
 			name: "only MTU set",
 			in: OpenStackCluster{
 				Spec: OpenStackClusterSpec{NetworkMTU: mtu},
 			},
+			expectedEnablePS: nil, // unset stays unset
 		},
 		{
-			name: "only DisablePortSecurity set",
+			name: "only DisablePortSecurity set to true",
 			in: OpenStackCluster{
 				Spec: OpenStackClusterSpec{DisablePortSecurity: disablePS},
 			},
+			expectedEnablePS: optional.Bool(ptr.To(false)), // disablePS=true → enablePS=false
 		},
 		{
-			name: "neither set — ManagedNetwork stays nil",
-			in:   OpenStackCluster{},
+			name: "DisablePortSecurity explicitly false",
+			in: OpenStackCluster{
+				Spec: OpenStackClusterSpec{DisablePortSecurity: optional.Bool(ptr.To(false))},
+			},
+			expectedEnablePS: optional.Bool(ptr.To(true)), // disablePS=false → enablePS=true
+		},
+		{
+			name:             "neither set — ManagedNetwork stays nil",
+			in:               OpenStackCluster{},
+			expectedEnablePS: nil,
 		},
 	}
 
@@ -1020,13 +1032,13 @@ func TestOpenStackCluster_RoundTrip_ManagedNetwork(t *testing.T) {
 			} else {
 				g.Expect(hub.Spec.ManagedNetwork).NotTo(BeNil())
 				g.Expect(hub.Spec.ManagedNetwork.MTU).To(Equal(tt.in.Spec.NetworkMTU))
-				g.Expect(hub.Spec.ManagedNetwork.DisablePortSecurity).To(Equal(tt.in.Spec.DisablePortSecurity))
+				g.Expect(hub.Spec.ManagedNetwork.EnablePortSecurity).To(Equal(tt.expectedEnablePS))
 			}
 
 			restored := &OpenStackCluster{}
 			g.Expect(restored.ConvertFrom(hub)).To(Succeed())
 
-			// Verify final v1beta1 state
+			// Verify final v1beta1 state round-trips correctly
 			g.Expect(restored.Spec.NetworkMTU).To(Equal(tt.in.Spec.NetworkMTU))
 			g.Expect(restored.Spec.DisablePortSecurity).To(Equal(tt.in.Spec.DisablePortSecurity))
 		})

--- a/api/v1beta1/conversion_test.go
+++ b/api/v1beta1/conversion_test.go
@@ -1236,8 +1236,9 @@ func TestOpenStackCluster_RoundTrip_APIServer(t *testing.T) {
 	disable := optional.Bool(ptr.To(true))
 
 	tests := []struct {
-		name string
-		in   OpenStackCluster
+		name                     string
+		in                       OpenStackCluster
+		expectedEnableFloatingIP optional.Bool
 	}{
 		{
 			name: "all fields set",
@@ -1252,6 +1253,7 @@ func TestOpenStackCluster_RoundTrip_APIServer(t *testing.T) {
 					},
 				},
 			},
+			expectedEnableFloatingIP: optional.Bool(ptr.To(false)), // disable=true → enable=false
 		},
 		{
 			name: "only floatingIP set",
@@ -1260,6 +1262,7 @@ func TestOpenStackCluster_RoundTrip_APIServer(t *testing.T) {
 					APIServerFloatingIP: floatingIP,
 				},
 			},
+			expectedEnableFloatingIP: nil,
 		},
 		{
 			name: "only fixedIP set",
@@ -1268,6 +1271,7 @@ func TestOpenStackCluster_RoundTrip_APIServer(t *testing.T) {
 					APIServerFixedIP: fixedIP,
 				},
 			},
+			expectedEnableFloatingIP: nil,
 		},
 		{
 			name: "only port set",
@@ -1276,14 +1280,25 @@ func TestOpenStackCluster_RoundTrip_APIServer(t *testing.T) {
 					APIServerPort: port,
 				},
 			},
+			expectedEnableFloatingIP: nil,
 		},
 		{
-			name: "only disableFloatingIP set",
+			name: "DisableAPIServerFloatingIP explicitly true",
 			in: OpenStackCluster{
 				Spec: OpenStackClusterSpec{
 					DisableAPIServerFloatingIP: disable,
 				},
 			},
+			expectedEnableFloatingIP: optional.Bool(ptr.To(false)), // disable=true → enable=false
+		},
+		{
+			name: "DisableAPIServerFloatingIP explicitly false",
+			in: OpenStackCluster{
+				Spec: OpenStackClusterSpec{
+					DisableAPIServerFloatingIP: optional.Bool(ptr.To(false)),
+				},
+			},
+			expectedEnableFloatingIP: optional.Bool(ptr.To(true)), // disable=false → enable=true
 		},
 		{
 			name: "only loadBalancer set",
@@ -1294,6 +1309,7 @@ func TestOpenStackCluster_RoundTrip_APIServer(t *testing.T) {
 					},
 				},
 			},
+			expectedEnableFloatingIP: nil,
 		},
 		{
 			name: "loadBalancer disabled explicitly",
@@ -1304,6 +1320,7 @@ func TestOpenStackCluster_RoundTrip_APIServer(t *testing.T) {
 					},
 				},
 			},
+			expectedEnableFloatingIP: nil,
 		},
 		{
 			name: "disableFloatingIP with fixedIP (no-LB VIP case)",
@@ -1313,10 +1330,12 @@ func TestOpenStackCluster_RoundTrip_APIServer(t *testing.T) {
 					APIServerFixedIP:           fixedIP,
 				},
 			},
+			expectedEnableFloatingIP: optional.Bool(ptr.To(false)), // disable=true → enable=false
 		},
 		{
-			name: "no APIServer fields set — APIServer stays nil",
-			in:   OpenStackCluster{},
+			name:                     "no APIServer fields set — APIServer stays nil",
+			in:                       OpenStackCluster{},
+			expectedEnableFloatingIP: nil,
 		},
 	}
 
@@ -1343,7 +1362,7 @@ func TestOpenStackCluster_RoundTrip_APIServer(t *testing.T) {
 				g.Expect(hub.Spec.APIServer.FloatingIP).To(Equal(src.APIServerFloatingIP))
 				g.Expect(hub.Spec.APIServer.FixedIP).To(Equal(src.APIServerFixedIP))
 				g.Expect(hub.Spec.APIServer.Port).To(Equal(src.APIServerPort))
-				g.Expect(hub.Spec.APIServer.DisableFloatingIP).To(Equal(src.DisableAPIServerFloatingIP))
+				g.Expect(hub.Spec.APIServer.EnableFloatingIP).To(Equal(tt.expectedEnableFloatingIP))
 
 				if src.APIServerLoadBalancer == nil {
 					g.Expect(hub.Spec.APIServer.ManagedLoadBalancer).To(BeNil())

--- a/api/v1beta1/conversion_test.go
+++ b/api/v1beta1/conversion_test.go
@@ -1443,3 +1443,53 @@ func TestOpenStackClusterStatusAPIServerLoadBalancerNilConversion(t *testing.T) 
 	// Verify round-trip preserves nil
 	g.Expect(restored.Status.APIServerLoadBalancer).To(BeNil())
 }
+
+func TestOpenStackCluster_RoundTrip_ExternalNetwork(t *testing.T) {
+	tests := []struct {
+		name             string
+		in               OpenStackCluster
+		expectedEnableEN optional.Bool
+	}{
+		{
+			name: "DisableExternalNetwork explicitly true",
+			in: OpenStackCluster{
+				Spec: OpenStackClusterSpec{
+					DisableExternalNetwork: optional.Bool(ptr.To(true)),
+				},
+			},
+			expectedEnableEN: optional.Bool(ptr.To(false)), // disable=true → enable=false
+		},
+		{
+			name: "DisableExternalNetwork explicitly false",
+			in: OpenStackCluster{
+				Spec: OpenStackClusterSpec{
+					DisableExternalNetwork: optional.Bool(ptr.To(false)),
+				},
+			},
+			expectedEnableEN: optional.Bool(ptr.To(true)), // disable=false → enable=true
+		},
+		{
+			name:             "DisableExternalNetwork unset — EnableExternalNetwork stays nil",
+			in:               OpenStackCluster{},
+			expectedEnableEN: nil, // unset stays unset, controller applies default
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			hub := &infrav1.OpenStackCluster{}
+			g.Expect(tt.in.ConvertTo(hub)).To(Succeed())
+
+			// --- Verify intermediate v1beta2 state ---
+			g.Expect(hub.Spec.EnableExternalNetwork).To(Equal(tt.expectedEnableEN))
+
+			// --- Verify full round-trip back to v1beta1 ---
+			restored := &OpenStackCluster{}
+			g.Expect(restored.ConvertFrom(hub)).To(Succeed())
+
+			g.Expect(restored.Spec.DisableExternalNetwork).To(Equal(tt.in.Spec.DisableExternalNetwork))
+		})
+	}
+}

--- a/api/v1beta1/zz_generated.conversion.go
+++ b/api/v1beta1/zz_generated.conversion.go
@@ -1452,7 +1452,7 @@ func autoConvert_v1beta1_OpenStackClusterSpec_To_v1beta2_OpenStackClusterSpec(in
 	// WARNING: in.NetworkMTU requires manual conversion: does not exist in peer-type
 	// WARNING: in.ExternalRouterIPs requires manual conversion: does not exist in peer-type
 	out.ExternalNetwork = (*v1beta2.NetworkParam)(unsafe.Pointer(in.ExternalNetwork))
-	out.DisableExternalNetwork = (optional.Bool)(unsafe.Pointer(in.DisableExternalNetwork))
+	// WARNING: in.DisableExternalNetwork requires manual conversion: does not exist in peer-type
 	// WARNING: in.APIServerLoadBalancer requires manual conversion: does not exist in peer-type
 	// WARNING: in.DisableAPIServerFloatingIP requires manual conversion: does not exist in peer-type
 	// WARNING: in.APIServerFloatingIP requires manual conversion: does not exist in peer-type
@@ -1495,7 +1495,7 @@ func autoConvert_v1beta2_OpenStackClusterSpec_To_v1beta1_OpenStackClusterSpec(in
 	// WARNING: in.ManagedNetwork requires manual conversion: does not exist in peer-type
 	out.Network = (*NetworkParam)(unsafe.Pointer(in.Network))
 	out.ExternalNetwork = (*NetworkParam)(unsafe.Pointer(in.ExternalNetwork))
-	out.DisableExternalNetwork = (optional.Bool)(unsafe.Pointer(in.DisableExternalNetwork))
+	// WARNING: in.EnableExternalNetwork requires manual conversion: does not exist in peer-type
 	// WARNING: in.APIServer requires manual conversion: does not exist in peer-type
 	if in.ManagedSecurityGroups != nil {
 		in, out := &in.ManagedSecurityGroups, &out.ManagedSecurityGroups

--- a/api/v1beta1/zz_generated.conversion.go
+++ b/api/v1beta1/zz_generated.conversion.go
@@ -471,16 +471,6 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*ResolvedPortSpecFields)(nil), (*v1beta2.ResolvedPortSpecFields)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta1_ResolvedPortSpecFields_To_v1beta2_ResolvedPortSpecFields(a.(*ResolvedPortSpecFields), b.(*v1beta2.ResolvedPortSpecFields), scope)
-	}); err != nil {
-		return err
-	}
-	if err := s.AddGeneratedConversionFunc((*v1beta2.ResolvedPortSpecFields)(nil), (*ResolvedPortSpecFields)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta2_ResolvedPortSpecFields_To_v1beta1_ResolvedPortSpecFields(a.(*v1beta2.ResolvedPortSpecFields), b.(*ResolvedPortSpecFields), scope)
-	}); err != nil {
-		return err
-	}
 	if err := s.AddGeneratedConversionFunc((*ResourceReference)(nil), (*v1beta2.ResourceReference)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1beta1_ResourceReference_To_v1beta2_ResourceReference(a.(*ResourceReference), b.(*v1beta2.ResourceReference), scope)
 	}); err != nil {
@@ -716,6 +706,11 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
+	if err := s.AddConversionFunc((*ResolvedPortSpecFields)(nil), (*v1beta2.ResolvedPortSpecFields)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta1_ResolvedPortSpecFields_To_v1beta2_ResolvedPortSpecFields(a.(*ResolvedPortSpecFields), b.(*v1beta2.ResolvedPortSpecFields), scope)
+	}); err != nil {
+		return err
+	}
 	if err := s.AddConversionFunc((*v1beta2.ManagedSecurityGroups)(nil), (*ManagedSecurityGroups)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1beta2_ManagedSecurityGroups_To_v1beta1_ManagedSecurityGroups(a.(*v1beta2.ManagedSecurityGroups), b.(*ManagedSecurityGroups), scope)
 	}); err != nil {
@@ -738,6 +733,11 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}
 	if err := s.AddConversionFunc((*v1beta2.OpenStackMachineStatus)(nil), (*OpenStackMachineStatus)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1beta2_OpenStackMachineStatus_To_v1beta1_OpenStackMachineStatus(a.(*v1beta2.OpenStackMachineStatus), b.(*OpenStackMachineStatus), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*v1beta2.ResolvedPortSpecFields)(nil), (*ResolvedPortSpecFields)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta2_ResolvedPortSpecFields_To_v1beta1_ResolvedPortSpecFields(a.(*v1beta2.ResolvedPortSpecFields), b.(*ResolvedPortSpecFields), scope)
 	}); err != nil {
 		return err
 	}
@@ -927,7 +927,15 @@ func autoConvert_v1beta1_BastionStatus_To_v1beta2_BastionStatus(in *BastionStatu
 	out.State = v1beta2.InstanceState(in.State)
 	out.IP = in.IP
 	out.FloatingIP = in.FloatingIP
-	out.Resolved = (*v1beta2.ResolvedMachineSpec)(unsafe.Pointer(in.Resolved))
+	if in.Resolved != nil {
+		in, out := &in.Resolved, &out.Resolved
+		*out = new(v1beta2.ResolvedMachineSpec)
+		if err := Convert_v1beta1_ResolvedMachineSpec_To_v1beta2_ResolvedMachineSpec(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.Resolved = nil
+	}
 	out.Resources = (*v1beta2.MachineResources)(unsafe.Pointer(in.Resources))
 	return nil
 }
@@ -944,7 +952,15 @@ func autoConvert_v1beta2_BastionStatus_To_v1beta1_BastionStatus(in *v1beta2.Bast
 	out.State = InstanceState(in.State)
 	out.IP = in.IP
 	out.FloatingIP = in.FloatingIP
-	out.Resolved = (*ResolvedMachineSpec)(unsafe.Pointer(in.Resolved))
+	if in.Resolved != nil {
+		in, out := &in.Resolved, &out.Resolved
+		*out = new(ResolvedMachineSpec)
+		if err := Convert_v1beta2_ResolvedMachineSpec_To_v1beta1_ResolvedMachineSpec(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.Resolved = nil
+	}
 	out.Resources = (*MachineResources)(unsafe.Pointer(in.Resources))
 	return nil
 }
@@ -1536,7 +1552,15 @@ func autoConvert_v1beta1_OpenStackClusterStatus_To_v1beta2_OpenStackClusterStatu
 	out.ControlPlaneSecurityGroup = (*v1beta2.SecurityGroupStatus)(unsafe.Pointer(in.ControlPlaneSecurityGroup))
 	out.WorkerSecurityGroup = (*v1beta2.SecurityGroupStatus)(unsafe.Pointer(in.WorkerSecurityGroup))
 	out.BastionSecurityGroup = (*v1beta2.SecurityGroupStatus)(unsafe.Pointer(in.BastionSecurityGroup))
-	out.Bastion = (*v1beta2.BastionStatus)(unsafe.Pointer(in.Bastion))
+	if in.Bastion != nil {
+		in, out := &in.Bastion, &out.Bastion
+		*out = new(v1beta2.BastionStatus)
+		if err := Convert_v1beta1_BastionStatus_To_v1beta2_BastionStatus(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.Bastion = nil
+	}
 	// WARNING: in.FailureReason requires manual conversion: does not exist in peer-type
 	// WARNING: in.FailureMessage requires manual conversion: does not exist in peer-type
 	if in.Conditions != nil {
@@ -1574,7 +1598,15 @@ func autoConvert_v1beta2_OpenStackClusterStatus_To_v1beta1_OpenStackClusterStatu
 	out.ControlPlaneSecurityGroup = (*SecurityGroupStatus)(unsafe.Pointer(in.ControlPlaneSecurityGroup))
 	out.WorkerSecurityGroup = (*SecurityGroupStatus)(unsafe.Pointer(in.WorkerSecurityGroup))
 	out.BastionSecurityGroup = (*SecurityGroupStatus)(unsafe.Pointer(in.BastionSecurityGroup))
-	out.Bastion = (*BastionStatus)(unsafe.Pointer(in.Bastion))
+	if in.Bastion != nil {
+		in, out := &in.Bastion, &out.Bastion
+		*out = new(BastionStatus)
+		if err := Convert_v1beta2_BastionStatus_To_v1beta1_BastionStatus(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.Bastion = nil
+	}
 	return nil
 }
 
@@ -1802,7 +1834,17 @@ func autoConvert_v1beta1_OpenStackMachineSpec_To_v1beta2_OpenStackMachineSpec(in
 		return err
 	}
 	out.SSHKeyName = in.SSHKeyName
-	out.Ports = *(*[]v1beta2.PortOpts)(unsafe.Pointer(&in.Ports))
+	if in.Ports != nil {
+		in, out := &in.Ports, &out.Ports
+		*out = make([]v1beta2.PortOpts, len(*in))
+		for i := range *in {
+			if err := Convert_v1beta1_PortOpts_To_v1beta2_PortOpts(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Ports = nil
+	}
 	out.SecurityGroups = *(*[]v1beta2.SecurityGroupParam)(unsafe.Pointer(&in.SecurityGroups))
 	out.Trunk = in.Trunk
 	out.Tags = *(*[]string)(unsafe.Pointer(&in.Tags))
@@ -1824,7 +1866,17 @@ func autoConvert_v1beta2_OpenStackMachineSpec_To_v1beta1_OpenStackMachineSpec(in
 		return err
 	}
 	out.SSHKeyName = in.SSHKeyName
-	out.Ports = *(*[]PortOpts)(unsafe.Pointer(&in.Ports))
+	if in.Ports != nil {
+		in, out := &in.Ports, &out.Ports
+		*out = make([]PortOpts, len(*in))
+		for i := range *in {
+			if err := Convert_v1beta2_PortOpts_To_v1beta1_PortOpts(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Ports = nil
+	}
 	out.SecurityGroups = *(*[]SecurityGroupParam)(unsafe.Pointer(&in.SecurityGroups))
 	out.Trunk = in.Trunk
 	out.Tags = *(*[]string)(unsafe.Pointer(&in.Tags))
@@ -1845,7 +1897,15 @@ func autoConvert_v1beta1_OpenStackMachineStatus_To_v1beta2_OpenStackMachineStatu
 	out.InstanceID = (optional.String)(unsafe.Pointer(in.InstanceID))
 	out.Addresses = *(*[]corev1.NodeAddress)(unsafe.Pointer(&in.Addresses))
 	out.InstanceState = (*v1beta2.InstanceState)(unsafe.Pointer(in.InstanceState))
-	out.Resolved = (*v1beta2.ResolvedMachineSpec)(unsafe.Pointer(in.Resolved))
+	if in.Resolved != nil {
+		in, out := &in.Resolved, &out.Resolved
+		*out = new(v1beta2.ResolvedMachineSpec)
+		if err := Convert_v1beta1_ResolvedMachineSpec_To_v1beta2_ResolvedMachineSpec(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.Resolved = nil
+	}
 	out.Resources = (*v1beta2.MachineResources)(unsafe.Pointer(in.Resources))
 	// WARNING: in.FailureReason requires manual conversion: does not exist in peer-type
 	// WARNING: in.FailureMessage requires manual conversion: does not exist in peer-type
@@ -1879,7 +1939,15 @@ func autoConvert_v1beta2_OpenStackMachineStatus_To_v1beta1_OpenStackMachineStatu
 	out.InstanceID = (optional.String)(unsafe.Pointer(in.InstanceID))
 	out.Addresses = *(*[]corev1.NodeAddress)(unsafe.Pointer(&in.Addresses))
 	out.InstanceState = (*InstanceState)(unsafe.Pointer(in.InstanceState))
-	out.Resolved = (*ResolvedMachineSpec)(unsafe.Pointer(in.Resolved))
+	if in.Resolved != nil {
+		in, out := &in.Resolved, &out.Resolved
+		*out = new(ResolvedMachineSpec)
+		if err := Convert_v1beta2_ResolvedMachineSpec_To_v1beta1_ResolvedMachineSpec(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.Resolved = nil
+	}
 	out.Resources = (*MachineResources)(unsafe.Pointer(in.Resources))
 	return nil
 }
@@ -2138,7 +2206,17 @@ func autoConvert_v1beta1_ResolvedMachineSpec_To_v1beta2_ResolvedMachineSpec(in *
 	out.ServerGroupID = in.ServerGroupID
 	out.ImageID = in.ImageID
 	out.FlavorID = in.FlavorID
-	out.Ports = *(*[]v1beta2.ResolvedPortSpec)(unsafe.Pointer(&in.Ports))
+	if in.Ports != nil {
+		in, out := &in.Ports, &out.Ports
+		*out = make([]v1beta2.ResolvedPortSpec, len(*in))
+		for i := range *in {
+			if err := Convert_v1beta1_ResolvedPortSpec_To_v1beta2_ResolvedPortSpec(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Ports = nil
+	}
 	return nil
 }
 
@@ -2151,7 +2229,17 @@ func autoConvert_v1beta2_ResolvedMachineSpec_To_v1beta1_ResolvedMachineSpec(in *
 	out.ServerGroupID = in.ServerGroupID
 	out.ImageID = in.ImageID
 	out.FlavorID = in.FlavorID
-	out.Ports = *(*[]ResolvedPortSpec)(unsafe.Pointer(&in.Ports))
+	if in.Ports != nil {
+		in, out := &in.Ports, &out.Ports
+		*out = make([]ResolvedPortSpec, len(*in))
+		for i := range *in {
+			if err := Convert_v1beta2_ResolvedPortSpec_To_v1beta1_ResolvedPortSpec(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Ports = nil
+	}
 	return nil
 }
 
@@ -2205,15 +2293,10 @@ func autoConvert_v1beta1_ResolvedPortSpecFields_To_v1beta2_ResolvedPortSpecField
 	out.HostID = (optional.String)(unsafe.Pointer(in.HostID))
 	out.VNICType = (optional.String)(unsafe.Pointer(in.VNICType))
 	out.Profile = (*v1beta2.BindingProfile)(unsafe.Pointer(in.Profile))
-	out.DisablePortSecurity = (*bool)(unsafe.Pointer(in.DisablePortSecurity))
+	// WARNING: in.DisablePortSecurity requires manual conversion: does not exist in peer-type
 	out.PropagateUplinkStatus = (*bool)(unsafe.Pointer(in.PropagateUplinkStatus))
 	out.ValueSpecs = *(*[]v1beta2.ValueSpec)(unsafe.Pointer(&in.ValueSpecs))
 	return nil
-}
-
-// Convert_v1beta1_ResolvedPortSpecFields_To_v1beta2_ResolvedPortSpecFields is an autogenerated conversion function.
-func Convert_v1beta1_ResolvedPortSpecFields_To_v1beta2_ResolvedPortSpecFields(in *ResolvedPortSpecFields, out *v1beta2.ResolvedPortSpecFields, s conversion.Scope) error {
-	return autoConvert_v1beta1_ResolvedPortSpecFields_To_v1beta2_ResolvedPortSpecFields(in, out, s)
 }
 
 func autoConvert_v1beta2_ResolvedPortSpecFields_To_v1beta1_ResolvedPortSpecFields(in *v1beta2.ResolvedPortSpecFields, out *ResolvedPortSpecFields, s conversion.Scope) error {
@@ -2223,15 +2306,10 @@ func autoConvert_v1beta2_ResolvedPortSpecFields_To_v1beta1_ResolvedPortSpecField
 	out.HostID = (optional.String)(unsafe.Pointer(in.HostID))
 	out.VNICType = (optional.String)(unsafe.Pointer(in.VNICType))
 	out.Profile = (*BindingProfile)(unsafe.Pointer(in.Profile))
-	out.DisablePortSecurity = (*bool)(unsafe.Pointer(in.DisablePortSecurity))
+	// WARNING: in.EnablePortSecurity requires manual conversion: does not exist in peer-type
 	out.PropagateUplinkStatus = (*bool)(unsafe.Pointer(in.PropagateUplinkStatus))
 	out.ValueSpecs = *(*[]ValueSpec)(unsafe.Pointer(&in.ValueSpecs))
 	return nil
-}
-
-// Convert_v1beta2_ResolvedPortSpecFields_To_v1beta1_ResolvedPortSpecFields is an autogenerated conversion function.
-func Convert_v1beta2_ResolvedPortSpecFields_To_v1beta1_ResolvedPortSpecFields(in *v1beta2.ResolvedPortSpecFields, out *ResolvedPortSpecFields, s conversion.Scope) error {
-	return autoConvert_v1beta2_ResolvedPortSpecFields_To_v1beta1_ResolvedPortSpecFields(in, out, s)
 }
 
 func autoConvert_v1beta1_ResourceReference_To_v1beta2_ResourceReference(in *ResourceReference, out *v1beta2.ResourceReference, s conversion.Scope) error {

--- a/api/v1beta2/openstackcluster_types.go
+++ b/api/v1beta2/openstackcluster_types.go
@@ -31,7 +31,7 @@ const (
 
 // OpenStackClusterSpec defines the desired state of OpenStackCluster.
 // +kubebuilder:validation:XValidation:rule="has(self.enableExternalNetwork) && !self.enableExternalNetwork ? !has(self.bastion) || !has(self.bastion.floatingIP) : true",message="bastion floating IP cannot be set when enableExternalNetwork is false"
-// +kubebuilder:validation:XValidation:rule="has(self.enableExternalNetwork) && !self.enableExternalNetwork ? has(self.apiServer) && has(self.apiServer.disableFloatingIP) && self.apiServer.disableFloatingIP : true",message="apiServer.disableFloatingIP cannot be false when enableExternalNetwork is false"
+// +kubebuilder:validation:XValidation:rule="has(self.enableExternalNetwork) && !self.enableExternalNetwork ? has(self.apiServer) && has(self.apiServer.enableFloatingIP) && !self.apiServer.enableFloatingIP : true",message="apiServer.enableFloatingIP cannot be true when enableExternalNetwork is false"
 type OpenStackClusterSpec struct {
 	// managedSubnets describe OpenStack Subnets to be created. Cluster actuator will create a network,
 	// subnets with the defined CIDR, and a router connected to these subnets. Currently only one IPv4
@@ -171,14 +171,13 @@ type APIServer struct {
 	// floatingIP is the floating IP which will be associated with the API server.
 	// The floating IP will be created if it does not already exist.
 	// If not specified, a new floating IP is allocated.
-	// This field is not used if DisableFloatingIP is set to true.
+	// This field is not used if EnableFloatingIP is set to false.
 	// +optional
 	FloatingIP optional.String `json:"floatingIP,omitempty"`
 
-	// disableFloatingIP determines whether or not to attempt to attach a
-	// floating IP to the API server.
+	// enableFloatingIP determines whether to attach a floating IP to the API server.
 	// +optional
-	DisableFloatingIP optional.Bool `json:"disableFloatingIP,omitempty"`
+	EnableFloatingIP optional.Bool `json:"enableFloatingIP,omitempty"`
 
 	// managedLoadBalancer configures the optional LoadBalancer for the API server.
 	// If not specified, no load balancer will be created.
@@ -369,11 +368,11 @@ func (a *APIServer) GetManagedLoadBalancer() *APIServerLoadBalancer {
 	return a.ManagedLoadBalancer
 }
 
-func (a *APIServer) GetDisableFloatingIP() *bool {
+func (a *APIServer) GetEnableFloatingIP() *bool {
 	if a == nil {
 		return nil
 	}
-	return a.DisableFloatingIP
+	return a.EnableFloatingIP
 }
 
 func (a *APIServer) GetFloatingIP() *string {

--- a/api/v1beta2/openstackcluster_types.go
+++ b/api/v1beta2/openstackcluster_types.go
@@ -64,7 +64,7 @@ type OpenStackClusterSpec struct {
 
 	// managedNetwork specifies attributes of the network. The values are used only
 	// if the Cluster actuator creates the network.
-	// +kubebuilder:validation:XValidation:rule="self == null || has(self.mtu) || has(self.disablePortSecurity)",message="managedNetwork must not be empty if set"
+	// +kubebuilder:validation:XValidation:rule="self == null || has(self.mtu) || has(self.enablePortSecurity)",message="managedNetwork must not be empty if set"
 	// +optional
 	ManagedNetwork *ManagedNetwork `json:"managedNetwork,omitempty"`
 
@@ -302,10 +302,11 @@ type ManagedNetwork struct {
 	// +optional
 	MTU optional.Int `json:"mtu,omitempty"`
 
-	// disablePortSecurity disables the port security of the network created for the
-	// Kubernetes cluster, which also disables SecurityGroups
+	// enablePortSecurity enables port security for the network created for the
+	// Kubernetes cluster, which also enables SecurityGroups.
+	// If left empty, the network will have port security setting enabled.
 	// +optional
-	DisablePortSecurity optional.Bool `json:"disablePortSecurity,omitempty"`
+	EnablePortSecurity optional.Bool `json:"enablePortSecurity,omitempty"`
 }
 
 // ManagedSecurityGroups defines the desired state of security groups and rules for the cluster.

--- a/api/v1beta2/openstackcluster_types.go
+++ b/api/v1beta2/openstackcluster_types.go
@@ -84,7 +84,7 @@ type OpenStackClusterSpec struct {
 	// external networks unless EnableExternalNetwork is also set to false.
 	//
 	// If ExternalNetwork is not defined and there are no external networks
-	// the controller will proceed as though EnableExternalNetwork was set to true.
+	// the controller will proceed as though EnableExternalNetwork was set to false.
 	// +optional
 	ExternalNetwork *NetworkParam `json:"externalNetwork,omitempty"`
 

--- a/api/v1beta2/openstackcluster_types.go
+++ b/api/v1beta2/openstackcluster_types.go
@@ -30,8 +30,8 @@ const (
 )
 
 // OpenStackClusterSpec defines the desired state of OpenStackCluster.
-// +kubebuilder:validation:XValidation:rule="has(self.disableExternalNetwork) && self.disableExternalNetwork ? !has(self.bastion) || !has(self.bastion.floatingIP) : true",message="bastion floating IP cannot be set when disableExternalNetwork is true"
-// +kubebuilder:validation:XValidation:rule="has(self.disableExternalNetwork) && self.disableExternalNetwork ? has(self.apiServer) && has(self.apiServer.disableFloatingIP) && self.apiServer.disableFloatingIP : true",message="apiServer.disableFloatingIP cannot be false when disableExternalNetwork is true"
+// +kubebuilder:validation:XValidation:rule="has(self.enableExternalNetwork) && !self.enableExternalNetwork ? !has(self.bastion) || !has(self.bastion.floatingIP) : true",message="bastion floating IP cannot be set when enableExternalNetwork is false"
+// +kubebuilder:validation:XValidation:rule="has(self.enableExternalNetwork) && !self.enableExternalNetwork ? has(self.apiServer) && has(self.apiServer.disableFloatingIP) && self.apiServer.disableFloatingIP : true",message="apiServer.disableFloatingIP cannot be false when enableExternalNetwork is false"
 type OpenStackClusterSpec struct {
 	// managedSubnets describe OpenStack Subnets to be created. Cluster actuator will create a network,
 	// subnets with the defined CIDR, and a router connected to these subnets. Currently only one IPv4
@@ -74,25 +74,25 @@ type OpenStackClusterSpec struct {
 	Network *NetworkParam `json:"network,omitempty"`
 
 	// externalNetwork is the OpenStack Network to be used to get public internet to the VMs.
-	// This option is ignored if DisableExternalNetwork is set to true.
+	// This option is ignored if EnableExternalNetwork is set to false.
 	//
 	// If ExternalNetwork is defined it must refer to exactly one external network.
 	//
 	// If ExternalNetwork is not defined or is empty the controller will use any
 	// existing external network as long as there is only one. It is an
 	// error if ExternalNetwork is not defined and there are multiple
-	// external networks unless DisableExternalNetwork is also set.
+	// external networks unless EnableExternalNetwork is also set to false.
 	//
 	// If ExternalNetwork is not defined and there are no external networks
-	// the controller will proceed as though DisableExternalNetwork was set.
+	// the controller will proceed as though EnableExternalNetwork was set to true.
 	// +optional
 	ExternalNetwork *NetworkParam `json:"externalNetwork,omitempty"`
 
-	// disableExternalNetwork specifies whether or not to attempt to connect the cluster
-	// to an external network. This allows for the creation of clusters when connecting
-	// to an external network is not possible or desirable, e.g. if using a provider network.
+	// enableExternalNetwork specifies whether to connect the cluster to an external network.
+	// Set this to false when connecting to an external network is not possible or desirable,
+	// e.g. if using a provider network.
 	// +optional
-	DisableExternalNetwork optional.Bool `json:"disableExternalNetwork,omitempty"`
+	EnableExternalNetwork optional.Bool `json:"enableExternalNetwork,omitempty"`
 
 	// apiServer configures the API server endpoint and its associated
 	// load balancer and floating IP.

--- a/api/v1beta2/types.go
+++ b/api/v1beta2/types.go
@@ -424,10 +424,10 @@ type ResolvedPortSpecFields struct {
 	// +optional
 	Profile *BindingProfile `json:"profile,omitempty"`
 
-	// disablePortSecurity enables or disables the port security when set.
+	// enablePortSecurity enables or disables the port security when set.
 	// When not set, it takes the value of the corresponding field at the network level.
 	// +optional
-	DisablePortSecurity *bool `json:"disablePortSecurity,omitempty"`
+	EnablePortSecurity *bool `json:"enablePortSecurity,omitempty"`
 
 	// propagateUplinkStatus enables or disables the propagate uplink status on the port.
 	// +optional

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -859,8 +859,8 @@ func (in *OpenStackClusterSpec) DeepCopyInto(out *OpenStackClusterSpec) {
 		*out = new(NetworkParam)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.DisableExternalNetwork != nil {
-		in, out := &in.DisableExternalNetwork, &out.DisableExternalNetwork
+	if in.EnableExternalNetwork != nil {
+		in, out := &in.EnableExternalNetwork, &out.EnableExternalNetwork
 		*out = new(bool)
 		**out = **in
 	}

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -45,8 +45,8 @@ func (in *APIServer) DeepCopyInto(out *APIServer) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.DisableFloatingIP != nil {
-		in, out := &in.DisableFloatingIP, &out.DisableFloatingIP
+	if in.EnableFloatingIP != nil {
+		in, out := &in.EnableFloatingIP, &out.EnableFloatingIP
 		*out = new(bool)
 		**out = **in
 	}

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -1598,8 +1598,8 @@ func (in *ResolvedPortSpecFields) DeepCopyInto(out *ResolvedPortSpecFields) {
 		*out = new(BindingProfile)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.DisablePortSecurity != nil {
-		in, out := &in.DisablePortSecurity, &out.DisablePortSecurity
+	if in.EnablePortSecurity != nil {
+		in, out := &in.EnablePortSecurity, &out.EnablePortSecurity
 		*out = new(bool)
 		**out = **in
 	}

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -584,8 +584,8 @@ func (in *ManagedNetwork) DeepCopyInto(out *ManagedNetwork) {
 		*out = new(int)
 		**out = **in
 	}
-	if in.DisablePortSecurity != nil {
-		in, out := &in.DisablePortSecurity, &out.DisablePortSecurity
+	if in.EnablePortSecurity != nil {
+		in, out := &in.EnablePortSecurity, &out.EnablePortSecurity
 		*out = new(bool)
 		**out = **in
 	}

--- a/cmd/models-schema/zz_generated.openapi.go
+++ b/cmd/models-schema/zz_generated.openapi.go
@@ -23067,9 +23067,9 @@ func schema_sigsk8sio_cluster_api_provider_openstack_api_v1beta2_ManagedNetwork(
 							Format:      "int32",
 						},
 					},
-					"disablePortSecurity": {
+					"enablePortSecurity": {
 						SchemaProps: spec.SchemaProps{
-							Description: "disablePortSecurity disables the port security of the network created for the Kubernetes cluster, which also disables SecurityGroups",
+							Description: "enablePortSecurity enables port security for the network created for the Kubernetes cluster, which also enables SecurityGroups. If left empty, the network will have port security setting enabled.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/cmd/models-schema/zz_generated.openapi.go
+++ b/cmd/models-schema/zz_generated.openapi.go
@@ -23648,7 +23648,7 @@ func schema_sigsk8sio_cluster_api_provider_openstack_api_v1beta2_OpenStackCluste
 					},
 					"externalNetwork": {
 						SchemaProps: spec.SchemaProps{
-							Description: "externalNetwork is the OpenStack Network to be used to get public internet to the VMs. This option is ignored if EnableExternalNetwork is set to false.\n\nIf ExternalNetwork is defined it must refer to exactly one external network.\n\nIf ExternalNetwork is not defined or is empty the controller will use any existing external network as long as there is only one. It is an error if ExternalNetwork is not defined and there are multiple external networks unless EnableExternalNetwork is also set to false.\n\nIf ExternalNetwork is not defined and there are no external networks the controller will proceed as though EnableExternalNetwork was set to true.",
+							Description: "externalNetwork is the OpenStack Network to be used to get public internet to the VMs. This option is ignored if EnableExternalNetwork is set to false.\n\nIf ExternalNetwork is defined it must refer to exactly one external network.\n\nIf ExternalNetwork is not defined or is empty the controller will use any existing external network as long as there is only one. It is an error if ExternalNetwork is not defined and there are multiple external networks unless EnableExternalNetwork is also set to false.\n\nIf ExternalNetwork is not defined and there are no external networks the controller will proceed as though EnableExternalNetwork was set to false.",
 							Ref:         ref("sigs.k8s.io/cluster-api-provider-openstack/api/v1beta2.NetworkParam"),
 						},
 					},
@@ -24753,9 +24753,9 @@ func schema_sigsk8sio_cluster_api_provider_openstack_api_v1beta2_PortOpts(ref co
 							Ref:         ref("sigs.k8s.io/cluster-api-provider-openstack/api/v1beta2.BindingProfile"),
 						},
 					},
-					"disablePortSecurity": {
+					"enablePortSecurity": {
 						SchemaProps: spec.SchemaProps{
-							Description: "disablePortSecurity enables or disables the port security when set. When not set, it takes the value of the corresponding field at the network level.",
+							Description: "enablePortSecurity enables or disables the port security when set. When not set, it takes the value of the corresponding field at the network level.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -25040,9 +25040,9 @@ func schema_sigsk8sio_cluster_api_provider_openstack_api_v1beta2_ResolvedPortSpe
 							Ref:         ref("sigs.k8s.io/cluster-api-provider-openstack/api/v1beta2.BindingProfile"),
 						},
 					},
-					"disablePortSecurity": {
+					"enablePortSecurity": {
 						SchemaProps: spec.SchemaProps{
-							Description: "disablePortSecurity enables or disables the port security when set. When not set, it takes the value of the corresponding field at the network level.",
+							Description: "enablePortSecurity enables or disables the port security when set. When not set, it takes the value of the corresponding field at the network level.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -25140,9 +25140,9 @@ func schema_sigsk8sio_cluster_api_provider_openstack_api_v1beta2_ResolvedPortSpe
 							Ref:         ref("sigs.k8s.io/cluster-api-provider-openstack/api/v1beta2.BindingProfile"),
 						},
 					},
-					"disablePortSecurity": {
+					"enablePortSecurity": {
 						SchemaProps: spec.SchemaProps{
-							Description: "disablePortSecurity enables or disables the port security when set. When not set, it takes the value of the corresponding field at the network level.",
+							Description: "enablePortSecurity enables or disables the port security when set. When not set, it takes the value of the corresponding field at the network level.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/cmd/models-schema/zz_generated.openapi.go
+++ b/cmd/models-schema/zz_generated.openapi.go
@@ -23648,13 +23648,13 @@ func schema_sigsk8sio_cluster_api_provider_openstack_api_v1beta2_OpenStackCluste
 					},
 					"externalNetwork": {
 						SchemaProps: spec.SchemaProps{
-							Description: "externalNetwork is the OpenStack Network to be used to get public internet to the VMs. This option is ignored if DisableExternalNetwork is set to true.\n\nIf ExternalNetwork is defined it must refer to exactly one external network.\n\nIf ExternalNetwork is not defined or is empty the controller will use any existing external network as long as there is only one. It is an error if ExternalNetwork is not defined and there are multiple external networks unless DisableExternalNetwork is also set.\n\nIf ExternalNetwork is not defined and there are no external networks the controller will proceed as though DisableExternalNetwork was set.",
+							Description: "externalNetwork is the OpenStack Network to be used to get public internet to the VMs. This option is ignored if EnableExternalNetwork is set to false.\n\nIf ExternalNetwork is defined it must refer to exactly one external network.\n\nIf ExternalNetwork is not defined or is empty the controller will use any existing external network as long as there is only one. It is an error if ExternalNetwork is not defined and there are multiple external networks unless EnableExternalNetwork is also set to false.\n\nIf ExternalNetwork is not defined and there are no external networks the controller will proceed as though EnableExternalNetwork was set to true.",
 							Ref:         ref("sigs.k8s.io/cluster-api-provider-openstack/api/v1beta2.NetworkParam"),
 						},
 					},
-					"disableExternalNetwork": {
+					"enableExternalNetwork": {
 						SchemaProps: spec.SchemaProps{
-							Description: "disableExternalNetwork specifies whether or not to attempt to connect the cluster to an external network. This allows for the creation of clusters when connecting to an external network is not possible or desirable, e.g. if using a provider network.",
+							Description: "enableExternalNetwork specifies whether to connect the cluster to an external network. Set this to false when connecting to an external network is not possible or desirable, e.g. if using a provider network.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/cmd/models-schema/zz_generated.openapi.go
+++ b/cmd/models-schema/zz_generated.openapi.go
@@ -22148,14 +22148,14 @@ func schema_sigsk8sio_cluster_api_provider_openstack_api_v1beta2_APIServer(ref c
 					},
 					"floatingIP": {
 						SchemaProps: spec.SchemaProps{
-							Description: "floatingIP is the floating IP which will be associated with the API server. The floating IP will be created if it does not already exist. If not specified, a new floating IP is allocated. This field is not used if DisableFloatingIP is set to true.",
+							Description: "floatingIP is the floating IP which will be associated with the API server. The floating IP will be created if it does not already exist. If not specified, a new floating IP is allocated. This field is not used if EnableFloatingIP is set to false.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
-					"disableFloatingIP": {
+					"enableFloatingIP": {
 						SchemaProps: spec.SchemaProps{
-							Description: "disableFloatingIP determines whether or not to attempt to attach a floating IP to the API server.",
+							Description: "enableFloatingIP determines whether to attach a floating IP to the API server.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -3349,9 +3349,9 @@ spec:
                               description: description is a human-readable description
                                 for the port.
                               type: string
-                            disablePortSecurity:
+                            enablePortSecurity:
                               description: |-
-                                disablePortSecurity enables or disables the port security when set.
+                                enablePortSecurity enables or disables the port security when set.
                                 When not set, it takes the value of the corresponding field at the network level.
                               type: boolean
                             fixedIPs:
@@ -4079,7 +4079,7 @@ spec:
                   external networks unless EnableExternalNetwork is also set to false.
 
                   If ExternalNetwork is not defined and there are no external networks
-                  the controller will proceed as though EnableExternalNetwork was set to true.
+                  the controller will proceed as though EnableExternalNetwork was set to false.
                 maxProperties: 1
                 minProperties: 1
                 properties:
@@ -5096,9 +5096,9 @@ spec:
                               description: description is a human-readable description
                                 for the port.
                               type: string
-                            disablePortSecurity:
+                            enablePortSecurity:
                               description: |-
-                                disablePortSecurity enables or disables the port security when set.
+                                enablePortSecurity enables or disables the port security when set.
                                 When not set, it takes the value of the corresponding field at the network level.
                               type: boolean
                             fixedIPs:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -2761,10 +2761,9 @@ spec:
                   apiServer configures the API server endpoint and its associated
                   load balancer and floating IP.
                 properties:
-                  disableFloatingIP:
-                    description: |-
-                      disableFloatingIP determines whether or not to attempt to attach a
-                      floating IP to the API server.
+                  enableFloatingIP:
+                    description: enableFloatingIP determines whether to attach a floating
+                      IP to the API server.
                     type: boolean
                   fixedIP:
                     description: |-
@@ -2782,7 +2781,7 @@ spec:
                       floatingIP is the floating IP which will be associated with the API server.
                       The floating IP will be created if it does not already exist.
                       If not specified, a new floating IP is allocated.
-                      This field is not used if DisableFloatingIP is set to true.
+                      This field is not used if EnableFloatingIP is set to false.
                     type: string
                   managedLoadBalancer:
                     description: |-
@@ -4937,11 +4936,11 @@ spec:
                 is false
               rule: 'has(self.enableExternalNetwork) && !self.enableExternalNetwork
                 ? !has(self.bastion) || !has(self.bastion.floatingIP) : true'
-            - message: apiServer.disableFloatingIP cannot be false when enableExternalNetwork
+            - message: apiServer.enableFloatingIP cannot be true when enableExternalNetwork
                 is false
               rule: 'has(self.enableExternalNetwork) && !self.enableExternalNetwork
-                ? has(self.apiServer) && has(self.apiServer.disableFloatingIP) &&
-                self.apiServer.disableFloatingIP : true'
+                ? has(self.apiServer) && has(self.apiServer.enableFloatingIP) && !self.apiServer.enableFloatingIP
+                : true'
           status:
             description: status is the observed state of the OpenStackCluster.
             properties:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -4061,26 +4061,26 @@ spec:
                   scheduler to make a decision on which availability zone to use based
                   on other scheduling constraints
                 type: boolean
-              disableExternalNetwork:
+              enableExternalNetwork:
                 description: |-
-                  disableExternalNetwork specifies whether or not to attempt to connect the cluster
-                  to an external network. This allows for the creation of clusters when connecting
-                  to an external network is not possible or desirable, e.g. if using a provider network.
+                  enableExternalNetwork specifies whether to connect the cluster to an external network.
+                  Set this to false when connecting to an external network is not possible or desirable,
+                  e.g. if using a provider network.
                 type: boolean
               externalNetwork:
                 description: |-
                   externalNetwork is the OpenStack Network to be used to get public internet to the VMs.
-                  This option is ignored if DisableExternalNetwork is set to true.
+                  This option is ignored if EnableExternalNetwork is set to false.
 
                   If ExternalNetwork is defined it must refer to exactly one external network.
 
                   If ExternalNetwork is not defined or is empty the controller will use any
                   existing external network as long as there is only one. It is an
                   error if ExternalNetwork is not defined and there are multiple
-                  external networks unless DisableExternalNetwork is also set.
+                  external networks unless EnableExternalNetwork is also set to false.
 
                   If ExternalNetwork is not defined and there are no external networks
-                  the controller will proceed as though DisableExternalNetwork was set.
+                  the controller will proceed as though EnableExternalNetwork was set to true.
                 maxProperties: 1
                 minProperties: 1
                 properties:
@@ -4933,13 +4933,13 @@ spec:
             - identityRef
             type: object
             x-kubernetes-validations:
-            - message: bastion floating IP cannot be set when disableExternalNetwork
-                is true
-              rule: 'has(self.disableExternalNetwork) && self.disableExternalNetwork
+            - message: bastion floating IP cannot be set when enableExternalNetwork
+                is false
+              rule: 'has(self.enableExternalNetwork) && !self.enableExternalNetwork
                 ? !has(self.bastion) || !has(self.bastion.floatingIP) : true'
-            - message: apiServer.disableFloatingIP cannot be false when disableExternalNetwork
-                is true
-              rule: 'has(self.disableExternalNetwork) && self.disableExternalNetwork
+            - message: apiServer.disableFloatingIP cannot be false when enableExternalNetwork
+                is false
+              rule: 'has(self.enableExternalNetwork) && !self.enableExternalNetwork
                 ? has(self.apiServer) && has(self.apiServer.disableFloatingIP) &&
                 self.apiServer.disableFloatingIP : true'
           status:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -4205,10 +4205,11 @@ spec:
                   managedNetwork specifies attributes of the network. The values are used only
                   if the Cluster actuator creates the network.
                 properties:
-                  disablePortSecurity:
+                  enablePortSecurity:
                     description: |-
-                      disablePortSecurity disables the port security of the network created for the
-                      Kubernetes cluster, which also disables SecurityGroups
+                      enablePortSecurity enables port security for the network created for the
+                      Kubernetes cluster, which also enables SecurityGroups.
+                      If left empty, the network will have port security setting enabled.
                     type: boolean
                   mtu:
                     description: |-
@@ -4220,7 +4221,7 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: managedNetwork must not be empty if set
-                  rule: self == null || has(self.mtu) || has(self.disablePortSecurity)
+                  rule: self == null || has(self.mtu) || has(self.enablePortSecurity)
               managedRouter:
                 description: |-
                   managedRouter specifies attributes of the router. The values are used only

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
@@ -3681,10 +3681,11 @@ spec:
                           managedNetwork specifies attributes of the network. The values are used only
                           if the Cluster actuator creates the network.
                         properties:
-                          disablePortSecurity:
+                          enablePortSecurity:
                             description: |-
-                              disablePortSecurity disables the port security of the network created for the
-                              Kubernetes cluster, which also disables SecurityGroups
+                              enablePortSecurity enables port security for the network created for the
+                              Kubernetes cluster, which also enables SecurityGroups.
+                              If left empty, the network will have port security setting enabled.
                             type: boolean
                           mtu:
                             description: |-
@@ -3696,7 +3697,7 @@ spec:
                         type: object
                         x-kubernetes-validations:
                         - message: managedNetwork must not be empty if set
-                          rule: self == null || has(self.mtu) || has(self.disablePortSecurity)
+                          rule: self == null || has(self.mtu) || has(self.enablePortSecurity)
                       managedRouter:
                         description: |-
                           managedRouter specifies attributes of the router. The values are used only

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
@@ -2204,10 +2204,9 @@ spec:
                           apiServer configures the API server endpoint and its associated
                           load balancer and floating IP.
                         properties:
-                          disableFloatingIP:
-                            description: |-
-                              disableFloatingIP determines whether or not to attempt to attach a
-                              floating IP to the API server.
+                          enableFloatingIP:
+                            description: enableFloatingIP determines whether to attach
+                              a floating IP to the API server.
                             type: boolean
                           fixedIP:
                             description: |-
@@ -2225,7 +2224,7 @@ spec:
                               floatingIP is the floating IP which will be associated with the API server.
                               The floating IP will be created if it does not already exist.
                               If not specified, a new floating IP is allocated.
-                              This field is not used if DisableFloatingIP is set to true.
+                              This field is not used if EnableFloatingIP is set to false.
                             type: string
                           managedLoadBalancer:
                             description: |-
@@ -4425,11 +4424,11 @@ spec:
                         is false
                       rule: 'has(self.enableExternalNetwork) && !self.enableExternalNetwork
                         ? !has(self.bastion) || !has(self.bastion.floatingIP) : true'
-                    - message: apiServer.disableFloatingIP cannot be false when enableExternalNetwork
+                    - message: apiServer.enableFloatingIP cannot be true when enableExternalNetwork
                         is false
                       rule: 'has(self.enableExternalNetwork) && !self.enableExternalNetwork
-                        ? has(self.apiServer) && has(self.apiServer.disableFloatingIP)
-                        && self.apiServer.disableFloatingIP : true'
+                        ? has(self.apiServer) && has(self.apiServer.enableFloatingIP)
+                        && !self.apiServer.enableFloatingIP : true'
                 required:
                 - spec
                 type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
@@ -3535,26 +3535,26 @@ spec:
                           scheduler to make a decision on which availability zone to use based
                           on other scheduling constraints
                         type: boolean
-                      disableExternalNetwork:
+                      enableExternalNetwork:
                         description: |-
-                          disableExternalNetwork specifies whether or not to attempt to connect the cluster
-                          to an external network. This allows for the creation of clusters when connecting
-                          to an external network is not possible or desirable, e.g. if using a provider network.
+                          enableExternalNetwork specifies whether to connect the cluster to an external network.
+                          Set this to false when connecting to an external network is not possible or desirable,
+                          e.g. if using a provider network.
                         type: boolean
                       externalNetwork:
                         description: |-
                           externalNetwork is the OpenStack Network to be used to get public internet to the VMs.
-                          This option is ignored if DisableExternalNetwork is set to true.
+                          This option is ignored if EnableExternalNetwork is set to false.
 
                           If ExternalNetwork is defined it must refer to exactly one external network.
 
                           If ExternalNetwork is not defined or is empty the controller will use any
                           existing external network as long as there is only one. It is an
                           error if ExternalNetwork is not defined and there are multiple
-                          external networks unless DisableExternalNetwork is also set.
+                          external networks unless EnableExternalNetwork is also set to false.
 
                           If ExternalNetwork is not defined and there are no external networks
-                          the controller will proceed as though DisableExternalNetwork was set.
+                          the controller will proceed as though EnableExternalNetwork was set to true.
                         maxProperties: 1
                         minProperties: 1
                         properties:
@@ -4421,13 +4421,13 @@ spec:
                     - identityRef
                     type: object
                     x-kubernetes-validations:
-                    - message: bastion floating IP cannot be set when disableExternalNetwork
-                        is true
-                      rule: 'has(self.disableExternalNetwork) && self.disableExternalNetwork
+                    - message: bastion floating IP cannot be set when enableExternalNetwork
+                        is false
+                      rule: 'has(self.enableExternalNetwork) && !self.enableExternalNetwork
                         ? !has(self.bastion) || !has(self.bastion.floatingIP) : true'
-                    - message: apiServer.disableFloatingIP cannot be false when disableExternalNetwork
-                        is true
-                      rule: 'has(self.disableExternalNetwork) && self.disableExternalNetwork
+                    - message: apiServer.disableFloatingIP cannot be false when enableExternalNetwork
+                        is false
+                      rule: 'has(self.enableExternalNetwork) && !self.enableExternalNetwork
                         ? has(self.apiServer) && has(self.apiServer.disableFloatingIP)
                         && self.apiServer.disableFloatingIP : true'
                 required:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
@@ -2804,9 +2804,9 @@ spec:
                                       description: description is a human-readable
                                         description for the port.
                                       type: string
-                                    disablePortSecurity:
+                                    enablePortSecurity:
                                       description: |-
-                                        disablePortSecurity enables or disables the port security when set.
+                                        enablePortSecurity enables or disables the port security when set.
                                         When not set, it takes the value of the corresponding field at the network level.
                                       type: boolean
                                     fixedIPs:
@@ -3553,7 +3553,7 @@ spec:
                           external networks unless EnableExternalNetwork is also set to false.
 
                           If ExternalNetwork is not defined and there are no external networks
-                          the controller will proceed as though EnableExternalNetwork was set to true.
+                          the controller will proceed as though EnableExternalNetwork was set to false.
                         maxProperties: 1
                         minProperties: 1
                         properties:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
@@ -1586,9 +1586,9 @@ spec:
                       description: description is a human-readable description for
                         the port.
                       type: string
-                    disablePortSecurity:
+                    enablePortSecurity:
                       description: |-
-                        disablePortSecurity enables or disables the port security when set.
+                        enablePortSecurity enables or disables the port security when set.
                         When not set, it takes the value of the corresponding field at the network level.
                       type: boolean
                     fixedIPs:
@@ -2400,9 +2400,9 @@ spec:
                           description: description is a human-readable description
                             for the port.
                           type: string
-                        disablePortSecurity:
+                        enablePortSecurity:
                           description: |-
-                            disablePortSecurity enables or disables the port security when set.
+                            enablePortSecurity enables or disables the port security when set.
                             When not set, it takes the value of the corresponding field at the network level.
                           type: boolean
                         fixedIPs:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
@@ -1330,9 +1330,9 @@ spec:
                               description: description is a human-readable description
                                 for the port.
                               type: string
-                            disablePortSecurity:
+                            enablePortSecurity:
                               description: |-
-                                disablePortSecurity enables or disables the port security when set.
+                                enablePortSecurity enables or disables the port security when set.
                                 When not set, it takes the value of the corresponding field at the network level.
                               type: boolean
                             fixedIPs:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackservers.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackservers.yaml
@@ -305,9 +305,9 @@ spec:
                       description: description is a human-readable description for
                         the port.
                       type: string
-                    disablePortSecurity:
+                    enablePortSecurity:
                       description: |-
-                        disablePortSecurity enables or disables the port security when set.
+                        enablePortSecurity enables or disables the port security when set.
                         When not set, it takes the value of the corresponding field at the network level.
                       type: boolean
                     fixedIPs:
@@ -1120,9 +1120,9 @@ spec:
                           description: description is a human-readable description
                             for the port.
                           type: string
-                        disablePortSecurity:
+                        enablePortSecurity:
                           description: |-
-                            disablePortSecurity enables or disables the port security when set.
+                            enablePortSecurity enables or disables the port security when set.
                             When not set, it takes the value of the corresponding field at the network level.
                           type: boolean
                         fixedIPs:

--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -1028,7 +1028,7 @@ func reconcileControlPlaneEndpoint(scope *scope.WithLogger, networkingService *n
 
 	// API server load balancer is disabled, but external network and floating IP are not. Create
 	// a floating IP to be attached directly to a control plane host.
-	case !ptr.Deref(openStackCluster.Spec.APIServer.GetDisableFloatingIP(), false) && ptr.Deref(openStackCluster.Spec.EnableExternalNetwork, true):
+	case ptr.Deref(openStackCluster.Spec.APIServer.GetEnableFloatingIP(), true) && ptr.Deref(openStackCluster.Spec.EnableExternalNetwork, true):
 		fp, err := networkingService.GetOrCreateFloatingIP(openStackCluster, openStackCluster, clusterResourceName, openStackCluster.Spec.APIServer.GetFloatingIP())
 		if err != nil {
 			handleUpdateOSCError(openStackCluster, fmt.Errorf("floating IP cannot be got or created: %w", err))

--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -456,7 +456,7 @@ func (r *OpenStackClusterReconciler) reconcileBastion(ctx context.Context, scope
 		return nil, err
 	}
 
-	if !ptr.Deref(openStackCluster.Spec.DisableExternalNetwork, false) {
+	if ptr.Deref(openStackCluster.Spec.EnableExternalNetwork, true) {
 		return bastionAddFloatingIP(openStackCluster, clusterResourceName, port, networkingService)
 	}
 
@@ -1026,9 +1026,9 @@ func reconcileControlPlaneEndpoint(scope *scope.WithLogger, networkingService *n
 	case openStackCluster.Spec.ControlPlaneEndpoint != nil && openStackCluster.Spec.ControlPlaneEndpoint.IsValid():
 		host = openStackCluster.Spec.ControlPlaneEndpoint.Host
 
-	// API server load balancer is disabled, but external netowork and floating IP are not. Create
+	// API server load balancer is disabled, but external network and floating IP are not. Create
 	// a floating IP to be attached directly to a control plane host.
-	case !ptr.Deref(openStackCluster.Spec.APIServer.GetDisableFloatingIP(), false) && !ptr.Deref(openStackCluster.Spec.DisableExternalNetwork, false):
+	case !ptr.Deref(openStackCluster.Spec.APIServer.GetDisableFloatingIP(), false) && ptr.Deref(openStackCluster.Spec.EnableExternalNetwork, true):
 		fp, err := networkingService.GetOrCreateFloatingIP(openStackCluster, openStackCluster, clusterResourceName, openStackCluster.Spec.APIServer.GetFloatingIP())
 		if err != nil {
 			handleUpdateOSCError(openStackCluster, fmt.Errorf("floating IP cannot be got or created: %w", err))

--- a/controllers/openstackcluster_controller_test.go
+++ b/controllers/openstackcluster_controller_test.go
@@ -440,8 +440,8 @@ var _ = Describe("OpenStackCluster controller", func() {
 				Spec:    &bastionSpec,
 			},
 			APIServer: &infrav1.APIServer{
-				DisableFloatingIP: ptr.To(true),
-				FixedIP:           ptr.To("10.0.0.1"),
+				EnableFloatingIP: ptr.To(false),
+				FixedIP:          ptr.To("10.0.0.1"),
 			},
 			ExternalNetwork: &infrav1.NetworkParam{
 				ID: ptr.To(externalNetworkID),
@@ -521,8 +521,8 @@ var _ = Describe("OpenStackCluster controller", func() {
 				Spec:    &bastionSpec,
 			},
 			APIServer: &infrav1.APIServer{
-				DisableFloatingIP: ptr.To(true),
-				FixedIP:           ptr.To("10.0.0.1"),
+				EnableFloatingIP: ptr.To(false),
+				FixedIP:          ptr.To("10.0.0.1"),
 			},
 			ExternalNetwork: &infrav1.NetworkParam{
 				ID: ptr.To(externalNetworkID),
@@ -605,8 +605,8 @@ var _ = Describe("OpenStackCluster controller", func() {
 				CloudName: "openstack",
 			},
 			APIServer: &infrav1.APIServer{
-				DisableFloatingIP: ptr.To(true),
-				FixedIP:           ptr.To("10.0.0.1"),
+				EnableFloatingIP: ptr.To(false),
+				FixedIP:          ptr.To("10.0.0.1"),
 			},
 			EnableExternalNetwork: ptr.To(false),
 			Subnets: []infrav1.SubnetParam{
@@ -890,8 +890,8 @@ var _ = Describe("OpenStackCluster controller", func() {
 			},
 			EnableExternalNetwork: ptr.To(false),
 			APIServer: &infrav1.APIServer{
-				DisableFloatingIP: ptr.To(true),
-				FixedIP:           ptr.To(fixedIP),
+				EnableFloatingIP: ptr.To(false),
+				FixedIP:          ptr.To(fixedIP),
 			},
 		}
 		err := k8sClient.Create(ctx, testCluster)
@@ -946,8 +946,8 @@ var _ = Describe("OpenStackCluster controller", func() {
 			},
 			EnableExternalNetwork: ptr.To(false),
 			APIServer: &infrav1.APIServer{
-				DisableFloatingIP: ptr.To(true),
-				FixedIP:           ptr.To("192.168.0.10"),
+				EnableFloatingIP: ptr.To(false),
+				FixedIP:          ptr.To("192.168.0.10"),
 			},
 			ManagedSubnets: []infrav1.SubnetSpec{
 				{CIDR: "192.168.0.0/24", DNSNameservers: []string{"8.8.8.8"}},
@@ -996,8 +996,8 @@ var _ = Describe("OpenStackCluster controller", func() {
 				ID: ptr.To(externalNetworkID),
 			},
 			APIServer: &infrav1.APIServer{
-				DisableFloatingIP: ptr.To(true),
-				FixedIP:           ptr.To("192.168.0.10"),
+				EnableFloatingIP: ptr.To(false),
+				FixedIP:          ptr.To("192.168.0.10"),
 			},
 		}
 		err := k8sClient.Create(ctx, testCluster)
@@ -1044,8 +1044,8 @@ var _ = Describe("OpenStackCluster controller", func() {
 			},
 			EnableExternalNetwork: ptr.To(false),
 			APIServer: &infrav1.APIServer{
-				DisableFloatingIP: ptr.To(true),
-				FixedIP:           ptr.To("192.168.0.10"),
+				EnableFloatingIP: ptr.To(false),
+				FixedIP:          ptr.To("192.168.0.10"),
 			},
 		}
 		err := k8sClient.Create(ctx, testCluster)
@@ -1089,8 +1089,8 @@ var _ = Describe("OpenStackCluster controller", func() {
 			},
 			EnableExternalNetwork: ptr.To(false),
 			APIServer: &infrav1.APIServer{
-				DisableFloatingIP: ptr.To(true),
-				FixedIP:           ptr.To("192.168.0.10"),
+				EnableFloatingIP: ptr.To(false),
+				FixedIP:          ptr.To("192.168.0.10"),
 			},
 		}
 		err := k8sClient.Create(ctx, testCluster)
@@ -1145,8 +1145,8 @@ var _ = Describe("OpenStackCluster controller", func() {
 			},
 			EnableExternalNetwork: ptr.To(false),
 			APIServer: &infrav1.APIServer{
-				DisableFloatingIP: ptr.To(true),
-				FixedIP:           ptr.To("192.168.0.10"),
+				EnableFloatingIP: ptr.To(false),
+				FixedIP:          ptr.To("192.168.0.10"),
 			},
 		}
 		err := k8sClient.Create(ctx, testCluster)
@@ -1211,8 +1211,8 @@ var _ = Describe("OpenStackCluster controller", func() {
 			},
 			EnableExternalNetwork: ptr.To(false),
 			APIServer: &infrav1.APIServer{
-				DisableFloatingIP: ptr.To(true),
-				FixedIP:           ptr.To("192.168.0.10"),
+				EnableFloatingIP: ptr.To(false),
+				FixedIP:          ptr.To("192.168.0.10"),
 			},
 			ManagedSecurityGroups: &infrav1.ManagedSecurityGroups{
 				ClusterNodesSecurityGroupRules: []infrav1.SecurityGroupRuleSpec{
@@ -1289,8 +1289,8 @@ var _ = Describe("OpenStackCluster controller", func() {
 			},
 			EnableExternalNetwork: ptr.To(false),
 			APIServer: &infrav1.APIServer{
-				DisableFloatingIP: ptr.To(true),
-				FixedIP:           ptr.To("192.168.0.10"),
+				EnableFloatingIP: ptr.To(false),
+				FixedIP:          ptr.To("192.168.0.10"),
 			},
 			ManagedSecurityGroups: &infrav1.ManagedSecurityGroups{
 				ClusterNodesSecurityGroupRules: []infrav1.SecurityGroupRuleSpec{

--- a/controllers/openstackcluster_controller_test.go
+++ b/controllers/openstackcluster_controller_test.go
@@ -608,7 +608,7 @@ var _ = Describe("OpenStackCluster controller", func() {
 				DisableFloatingIP: ptr.To(true),
 				FixedIP:           ptr.To("10.0.0.1"),
 			},
-			DisableExternalNetwork: ptr.To(true),
+			EnableExternalNetwork: ptr.To(false),
 			Subnets: []infrav1.SubnetParam{
 				{ID: ptr.To(clusterSubnetID)},
 			},
@@ -888,7 +888,7 @@ var _ = Describe("OpenStackCluster controller", func() {
 			Network: &infrav1.NetworkParam{
 				ID: ptr.To(clusterNetworkID),
 			},
-			DisableExternalNetwork: ptr.To(true),
+			EnableExternalNetwork: ptr.To(false),
 			APIServer: &infrav1.APIServer{
 				DisableFloatingIP: ptr.To(true),
 				FixedIP:           ptr.To(fixedIP),
@@ -944,7 +944,7 @@ var _ = Describe("OpenStackCluster controller", func() {
 				Name:      "test-creds",
 				CloudName: "openstack",
 			},
-			DisableExternalNetwork: ptr.To(true),
+			EnableExternalNetwork: ptr.To(false),
 			APIServer: &infrav1.APIServer{
 				DisableFloatingIP: ptr.To(true),
 				FixedIP:           ptr.To("192.168.0.10"),
@@ -1042,7 +1042,7 @@ var _ = Describe("OpenStackCluster controller", func() {
 			Network: &infrav1.NetworkParam{
 				ID: ptr.To(clusterNetworkID),
 			},
-			DisableExternalNetwork: ptr.To(true),
+			EnableExternalNetwork: ptr.To(false),
 			APIServer: &infrav1.APIServer{
 				DisableFloatingIP: ptr.To(true),
 				FixedIP:           ptr.To("192.168.0.10"),
@@ -1087,7 +1087,7 @@ var _ = Describe("OpenStackCluster controller", func() {
 			Network: &infrav1.NetworkParam{
 				ID: ptr.To(clusterNetworkID),
 			},
-			DisableExternalNetwork: ptr.To(true),
+			EnableExternalNetwork: ptr.To(false),
 			APIServer: &infrav1.APIServer{
 				DisableFloatingIP: ptr.To(true),
 				FixedIP:           ptr.To("192.168.0.10"),
@@ -1143,7 +1143,7 @@ var _ = Describe("OpenStackCluster controller", func() {
 			Router: &infrav1.RouterParam{
 				ID: ptr.To(clusterRouterID),
 			},
-			DisableExternalNetwork: ptr.To(true),
+			EnableExternalNetwork: ptr.To(false),
 			APIServer: &infrav1.APIServer{
 				DisableFloatingIP: ptr.To(true),
 				FixedIP:           ptr.To("192.168.0.10"),
@@ -1209,7 +1209,7 @@ var _ = Describe("OpenStackCluster controller", func() {
 			Network: &infrav1.NetworkParam{
 				ID: ptr.To(clusterNetworkID),
 			},
-			DisableExternalNetwork: ptr.To(true),
+			EnableExternalNetwork: ptr.To(false),
 			APIServer: &infrav1.APIServer{
 				DisableFloatingIP: ptr.To(true),
 				FixedIP:           ptr.To("192.168.0.10"),
@@ -1287,7 +1287,7 @@ var _ = Describe("OpenStackCluster controller", func() {
 			Network: &infrav1.NetworkParam{
 				ID: ptr.To(clusterNetworkID),
 			},
-			DisableExternalNetwork: ptr.To(true),
+			EnableExternalNetwork: ptr.To(false),
 			APIServer: &infrav1.APIServer{
 				DisableFloatingIP: ptr.To(true),
 				FixedIP:           ptr.To("192.168.0.10"),

--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -716,8 +716,8 @@ func openStackMachineSpecToOpenStackServerSpec(openStackMachineSpec *infrav1.Ope
 		}
 		// Only inject the default SG when portSecurity is not disabled,
 		// there are no SGs passed by user and defaultSecGroup is set
-		portSecurityDisabled := serverPort.DisablePortSecurity != nil && *serverPort.DisablePortSecurity
-		if !portSecurityDisabled && len(serverPort.SecurityGroups) == 0 && defaultSecGroup != nil {
+		portSecurityEnabled := serverPort.EnablePortSecurity == nil || *serverPort.EnablePortSecurity
+		if portSecurityEnabled && len(serverPort.SecurityGroups) == 0 && defaultSecGroup != nil {
 			serverPort.SecurityGroups = []infrav1.SecurityGroupParam{
 				{
 					ID: defaultSecGroup,

--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -828,7 +828,7 @@ func (r *OpenStackMachineReconciler) reconcileAPIServerLoadBalancer(scope *scope
 			})
 			return fmt.Errorf("reconcile load balancer member: %w", err)
 		}
-	} else if !ptr.Deref(openStackCluster.Spec.APIServer.GetDisableFloatingIP(), false) && !ptr.Deref(openStackCluster.Spec.DisableExternalNetwork, false) {
+	} else if !ptr.Deref(openStackCluster.Spec.APIServer.GetDisableFloatingIP(), false) && ptr.Deref(openStackCluster.Spec.EnableExternalNetwork, true) {
 		var floatingIPAddress *string
 		switch {
 		case openStackCluster.Spec.ControlPlaneEndpoint != nil && openStackCluster.Spec.ControlPlaneEndpoint.IsValid():

--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -828,7 +828,7 @@ func (r *OpenStackMachineReconciler) reconcileAPIServerLoadBalancer(scope *scope
 			})
 			return fmt.Errorf("reconcile load balancer member: %w", err)
 		}
-	} else if !ptr.Deref(openStackCluster.Spec.APIServer.GetDisableFloatingIP(), false) && ptr.Deref(openStackCluster.Spec.EnableExternalNetwork, true) {
+	} else if ptr.Deref(openStackCluster.Spec.APIServer.GetEnableFloatingIP(), true) && ptr.Deref(openStackCluster.Spec.EnableExternalNetwork, true) {
 		var floatingIPAddress *string
 		switch {
 		case openStackCluster.Spec.ControlPlaneEndpoint != nil && openStackCluster.Spec.ControlPlaneEndpoint.IsValid():

--- a/controllers/openstackmachine_controller_test.go
+++ b/controllers/openstackmachine_controller_test.go
@@ -400,7 +400,7 @@ func TestOpenStackMachineSpecToOpenStackServerSpec(t *testing.T) {
 				Ports: []infrav1.PortOpts{{
 					Network: &infrav1.NetworkParam{ID: ptr.To(networkUUID)},
 					ResolvedPortSpecFields: infrav1.ResolvedPortSpecFields{
-						DisablePortSecurity: ptr.To(true),
+						EnablePortSecurity: ptr.To(false),
 					},
 				}},
 			},
@@ -413,7 +413,7 @@ func TestOpenStackMachineSpecToOpenStackServerSpec(t *testing.T) {
 					Network:        &infrav1.NetworkParam{ID: ptr.To(networkUUID)},
 					SecurityGroups: nil,
 					ResolvedPortSpecFields: infrav1.ResolvedPortSpecFields{
-						DisablePortSecurity: ptr.To(true),
+						EnablePortSecurity: ptr.To(false),
 					},
 				}},
 				Tags:        tags,

--- a/docs/book/src/api/v1beta2/api.md
+++ b/docs/book/src/api/v1beta2/api.md
@@ -2202,15 +2202,16 @@ To use this field, the Openstack installation requires the net-mtu neutron API e
 </tr>
 <tr>
 <td>
-<code>disablePortSecurity</code><br/>
+<code>enablePortSecurity</code><br/>
 <em>
 bool
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>disablePortSecurity disables the port security of the network created for the
-Kubernetes cluster, which also disables SecurityGroups</p>
+<p>enablePortSecurity enables port security for the network created for the
+Kubernetes cluster, which also enables SecurityGroups.
+If left empty, the network will have port security setting enabled.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/book/src/api/v1beta2/api.md
+++ b/docs/book/src/api/v1beta2/api.md
@@ -851,20 +851,19 @@ string
 <p>floatingIP is the floating IP which will be associated with the API server.
 The floating IP will be created if it does not already exist.
 If not specified, a new floating IP is allocated.
-This field is not used if DisableFloatingIP is set to true.</p>
+This field is not used if EnableFloatingIP is set to false.</p>
 </td>
 </tr>
 <tr>
 <td>
-<code>disableFloatingIP</code><br/>
+<code>enableFloatingIP</code><br/>
 <em>
 bool
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>disableFloatingIP determines whether or not to attempt to attach a
-floating IP to the API server.</p>
+<p>enableFloatingIP determines whether to attach a floating IP to the API server.</p>
 </td>
 </tr>
 <tr>

--- a/docs/book/src/api/v1beta2/api.md
+++ b/docs/book/src/api/v1beta2/api.md
@@ -182,7 +182,7 @@ existing external network as long as there is only one. It is an
 error if ExternalNetwork is not defined and there are multiple
 external networks unless EnableExternalNetwork is also set to false.</p>
 <p>If ExternalNetwork is not defined and there are no external networks
-the controller will proceed as though EnableExternalNetwork was set to true.</p>
+the controller will proceed as though EnableExternalNetwork was set to false.</p>
 </td>
 </tr>
 <tr>
@@ -2719,7 +2719,7 @@ existing external network as long as there is only one. It is an
 error if ExternalNetwork is not defined and there are multiple
 external networks unless EnableExternalNetwork is also set to false.</p>
 <p>If ExternalNetwork is not defined and there are no external networks
-the controller will proceed as though EnableExternalNetwork was set to true.</p>
+the controller will proceed as though EnableExternalNetwork was set to false.</p>
 </td>
 </tr>
 <tr>
@@ -3184,7 +3184,7 @@ existing external network as long as there is only one. It is an
 error if ExternalNetwork is not defined and there are multiple
 external networks unless EnableExternalNetwork is also set to false.</p>
 <p>If ExternalNetwork is not defined and there are no external networks
-the controller will proceed as though EnableExternalNetwork was set to true.</p>
+the controller will proceed as though EnableExternalNetwork was set to false.</p>
 </td>
 </tr>
 <tr>
@@ -4632,14 +4632,14 @@ rule:create_port:binding:profile</p>
 </tr>
 <tr>
 <td>
-<code>disablePortSecurity</code><br/>
+<code>enablePortSecurity</code><br/>
 <em>
 bool
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>disablePortSecurity enables or disables the port security when set.
+<p>enablePortSecurity enables or disables the port security when set.
 When not set, it takes the value of the corresponding field at the network level.</p>
 </td>
 </tr>

--- a/docs/book/src/api/v1beta2/api.md
+++ b/docs/book/src/api/v1beta2/api.md
@@ -175,28 +175,28 @@ NetworkParam
 <td>
 <em>(Optional)</em>
 <p>externalNetwork is the OpenStack Network to be used to get public internet to the VMs.
-This option is ignored if DisableExternalNetwork is set to true.</p>
+This option is ignored if EnableExternalNetwork is set to false.</p>
 <p>If ExternalNetwork is defined it must refer to exactly one external network.</p>
 <p>If ExternalNetwork is not defined or is empty the controller will use any
 existing external network as long as there is only one. It is an
 error if ExternalNetwork is not defined and there are multiple
-external networks unless DisableExternalNetwork is also set.</p>
+external networks unless EnableExternalNetwork is also set to false.</p>
 <p>If ExternalNetwork is not defined and there are no external networks
-the controller will proceed as though DisableExternalNetwork was set.</p>
+the controller will proceed as though EnableExternalNetwork was set to true.</p>
 </td>
 </tr>
 <tr>
 <td>
-<code>disableExternalNetwork</code><br/>
+<code>enableExternalNetwork</code><br/>
 <em>
 bool
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>disableExternalNetwork specifies whether or not to attempt to connect the cluster
-to an external network. This allows for the creation of clusters when connecting
-to an external network is not possible or desirable, e.g. if using a provider network.</p>
+<p>enableExternalNetwork specifies whether to connect the cluster to an external network.
+Set this to false when connecting to an external network is not possible or desirable,
+e.g. if using a provider network.</p>
 </td>
 </tr>
 <tr>
@@ -2713,28 +2713,28 @@ NetworkParam
 <td>
 <em>(Optional)</em>
 <p>externalNetwork is the OpenStack Network to be used to get public internet to the VMs.
-This option is ignored if DisableExternalNetwork is set to true.</p>
+This option is ignored if EnableExternalNetwork is set to false.</p>
 <p>If ExternalNetwork is defined it must refer to exactly one external network.</p>
 <p>If ExternalNetwork is not defined or is empty the controller will use any
 existing external network as long as there is only one. It is an
 error if ExternalNetwork is not defined and there are multiple
-external networks unless DisableExternalNetwork is also set.</p>
+external networks unless EnableExternalNetwork is also set to false.</p>
 <p>If ExternalNetwork is not defined and there are no external networks
-the controller will proceed as though DisableExternalNetwork was set.</p>
+the controller will proceed as though EnableExternalNetwork was set to true.</p>
 </td>
 </tr>
 <tr>
 <td>
-<code>disableExternalNetwork</code><br/>
+<code>enableExternalNetwork</code><br/>
 <em>
 bool
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>disableExternalNetwork specifies whether or not to attempt to connect the cluster
-to an external network. This allows for the creation of clusters when connecting
-to an external network is not possible or desirable, e.g. if using a provider network.</p>
+<p>enableExternalNetwork specifies whether to connect the cluster to an external network.
+Set this to false when connecting to an external network is not possible or desirable,
+e.g. if using a provider network.</p>
 </td>
 </tr>
 <tr>
@@ -3178,28 +3178,28 @@ NetworkParam
 <td>
 <em>(Optional)</em>
 <p>externalNetwork is the OpenStack Network to be used to get public internet to the VMs.
-This option is ignored if DisableExternalNetwork is set to true.</p>
+This option is ignored if EnableExternalNetwork is set to false.</p>
 <p>If ExternalNetwork is defined it must refer to exactly one external network.</p>
 <p>If ExternalNetwork is not defined or is empty the controller will use any
 existing external network as long as there is only one. It is an
 error if ExternalNetwork is not defined and there are multiple
-external networks unless DisableExternalNetwork is also set.</p>
+external networks unless EnableExternalNetwork is also set to false.</p>
 <p>If ExternalNetwork is not defined and there are no external networks
-the controller will proceed as though DisableExternalNetwork was set.</p>
+the controller will proceed as though EnableExternalNetwork was set to true.</p>
 </td>
 </tr>
 <tr>
 <td>
-<code>disableExternalNetwork</code><br/>
+<code>enableExternalNetwork</code><br/>
 <em>
 bool
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>disableExternalNetwork specifies whether or not to attempt to connect the cluster
-to an external network. This allows for the creation of clusters when connecting
-to an external network is not possible or desirable, e.g. if using a provider network.</p>
+<p>enableExternalNetwork specifies whether to connect the cluster to an external network.
+Set this to false when connecting to an external network is not possible or desirable,
+e.g. if using a provider network.</p>
 </td>
 </tr>
 <tr>

--- a/docs/book/src/clusteropenstack/configuration.md
+++ b/docs/book/src/clusteropenstack/configuration.md
@@ -309,12 +309,12 @@ associated to the first controller node and the other controller nodes have no f
 to any other controller node. So we recommend to only set one controller node when floating IP is needed,
 or please consider using load balancer instead, see [issue #1265](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/1265) for further information.
 
-Note: `spec.disableExternalNetwork` must be unset or set to `false` to allow the API server to have a floating IP.
+Note: `spec.enableExternalNetwork` must be unset or set to `true` to allow the API server to have a floating IP.
 
 ### Disabling the API server floating IP
 
 It is possible to provision a cluster without a floating IP for the API server by setting
-`OpenStackCluster.spec.disableAPIServerFloatingIP: true` (the default is `false`). This will
+`OpenStackCluster.spec.APIServer.enableFloatingIP: false` (the default is `true`). This will
 prevent a floating IP from being allocated.
 
 > **WARNING**
@@ -568,7 +568,7 @@ spec:
       - network:
           id: <your-network-id>
         ...
-        disablePortSecurity: true
+        enablePortSecurity: false
         ...
 ```
 
@@ -782,7 +782,7 @@ spec:
     floatingIP: <Floating IP address>
 ```
 
-Note: A floating IP can only be added if `OpenStackCluster.Spec.DisableExternalNetwork` is not set or set to `false`.
+Note: A floating IP can only be added if `OpenStackCluster.Spec.EnableExternalNetwork` is not set or set to `true`.
 
 If `managedSecurityGroups` is set to a non-nil value (e.g. `{}`), security group rule opening 22/tcp is added to security groups for bastion, controller, and worker nodes respectively. Otherwise, you have to add `securityGroups` to the `bastion` in `OpenStackCluster` spec and `OpenStackMachineTemplate` spec template respectively.
 

--- a/docs/book/src/topics/crd-changes/v1beta1-to-v1beta2.md
+++ b/docs/book/src/topics/crd-changes/v1beta1-to-v1beta2.md
@@ -8,6 +8,7 @@
     - [API server fields restructure](#api-server-fields-restructure)
     - [DisableExternalNetwork renamed to EnableExternalNetwork](#disableexternalnetwork-renamed-to-enableexternalnetwork)
     - [Flavor field restructure](#flavor-field-restructure)
+    - [Port security field rename](#port-security-field-rename)
     - [Network management fields restructure](#network-management-fields-restructure)
     - [External router IPs restructure](#external-router-ips-restructure)
     - [Managed security group rules rename](#managed-security-group-rules-rename)
@@ -104,6 +105,22 @@ following the ID/Filter pattern used by other fields. This applies to `OpenStack
 ```
 
 For `OpenStackCluster` the same change applies under `spec.bastion.spec.flavor`.
+
+### Port security field rename
+
+`spec.ports[*].disablePortSecurity` has been renamed to `spec.ports[*].enablePortSecurity`
+with inverted polarity — set it to `false` to disable port security instead of `true`.
+This applies to `OpenStackMachine` and `OpenStackMachineTemplate`.
+
+```diff
+ spec:
+   ports:
+-  - disablePortSecurity: true
++  - enablePortSecurity: false
+```
+
+For `OpenStackMachineTemplate` the same change applies under `spec.template.spec.ports[*].enablePortSecurity`.
+For `OpenStackCluster` and `OpenStackClusterTemplate` the same change applies under `spec.bastion.spec.ports[*].enablePortSecurity`.
 
 ### Network management fields restructure
 

--- a/docs/book/src/topics/crd-changes/v1beta1-to-v1beta2.md
+++ b/docs/book/src/topics/crd-changes/v1beta1-to-v1beta2.md
@@ -35,8 +35,10 @@ This only documents backwards incompatible changes. Fields that were added to v1
 
 `spec.apiServerFloatingIP`, `spec.apiServerFixedIP`, `spec.apiServerPort`,
 `spec.disableAPIServerFloatingIP`, and `spec.apiServerLoadBalancer` have been consolidated
-into a single structured `spec.apiServer` object. This applies to `OpenStackCluster` and
-`OpenStackClusterTemplate`.
+into a single structured `spec.apiServer` object. Note that `disableAPIServerFloatingIP` has
+been renamed to `apiServer.enableFloatingIP` with inverted polarity — set it to `false` to
+disable the floating IP instead of `true`. Defaults to `true`. This applies to `OpenStackCluster`
+and `OpenStackClusterTemplate`.
 
 ```diff
  spec:
@@ -52,7 +54,7 @@ into a single structured `spec.apiServer` object. This applies to `OpenStackClus
 +    floatingIP: 1.2.3.4
 +    fixedIP: 10.0.0.1
 +    port: 6443
-+    disableFloatingIP: true
++    enableFloatingIP: false
 +    managedLoadBalancer:
 +      enabled: true
 +      allowedCIDRs:

--- a/docs/book/src/topics/crd-changes/v1beta1-to-v1beta2.md
+++ b/docs/book/src/topics/crd-changes/v1beta1-to-v1beta2.md
@@ -92,15 +92,17 @@ For `OpenStackCluster` the same change applies under `spec.bastion.spec.flavor`.
 
 `spec.networkMTU` and `spec.disablePortSecurity` have been replaced by a structured
 `spec.managedNetwork` object. The field is optional, but must not be empty if set.
+Note that `disablePortSecurity` has been renamed to `enablePortSecurity` with inverted
+polarity — set it to `false` to disable port security instead of `true`.
 This applies to `OpenStackCluster` and `OpenStackClusterTemplate`.
 
 ```diff
  spec:
--  networkMTU: 
--  disablePortSecurity: 
+-  networkMTU: 1500
+-  disablePortSecurity: true
 +  managedNetwork:
-+    mtu: 
-+    disablePortSecurity: 
++    mtu: 1500
++    enablePortSecurity: false
 ```
 
 For `OpenStackClusterTemplate` the same change applies under `spec.template.spec.managedNetwork`.

--- a/docs/book/src/topics/crd-changes/v1beta1-to-v1beta2.md
+++ b/docs/book/src/topics/crd-changes/v1beta1-to-v1beta2.md
@@ -6,6 +6,7 @@
   - [Migration](#migration)
   - [API Changes](#api-changes)
     - [API server fields restructure](#api-server-fields-restructure)
+    - [DisableExternalNetwork renamed to EnableExternalNetwork](#disableexternalnetwork-renamed-to-enableexternalnetwork)
     - [Flavor field restructure](#flavor-field-restructure)
     - [Network management fields restructure](#network-management-fields-restructure)
     - [External router IPs restructure](#external-router-ips-restructure)
@@ -69,6 +70,20 @@ Additionally, the corresponding status field has been renamed for consistency wi
      name: my-lb
      id: lb-id-123
 ```
+
+### DisableExternalNetwork renamed to EnableExternalNetwork
+
+`spec.disableExternalNetwork` has been renamed to `spec.enableExternalNetwork` with inverted
+polarity — set it to `false` to disable external network connectivity instead of `true`.
+This applies to `OpenStackCluster` and `OpenStackClusterTemplate`.
+
+```diff
+ spec:
+-  disableExternalNetwork: true
++  enableExternalNetwork: false
+```
+
+For `OpenStackClusterTemplate` the same change applies under `spec.template.spec.enableExternalNetwork`.
 
 ### Flavor field restructure
 

--- a/pkg/cloud/services/loadbalancer/loadbalancer.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer.go
@@ -117,7 +117,7 @@ func (s *Service) ReconcileLoadBalancer(openStackCluster *infrav1.OpenStackClust
 		}
 	}
 
-	if !ptr.Deref(openStackCluster.Spec.APIServer.GetDisableFloatingIP(), false) {
+	if ptr.Deref(openStackCluster.Spec.APIServer.GetEnableFloatingIP(), true) {
 		floatingIPAddress, err := getAPIServerFloatingIP(openStackCluster)
 		if err != nil {
 			return false, err
@@ -178,7 +178,7 @@ func getAPIServerVIPAddress(openStackCluster *infrav1.OpenStackCluster) (*string
 		return openStackCluster.Spec.APIServer.GetFixedIP(), nil
 
 		// If we are using the VIP as the control plane endpoint, use any value explicitly set on the control plane endpoint
-	case ptr.Deref(openStackCluster.Spec.APIServer.GetDisableFloatingIP(), false) && openStackCluster.Spec.ControlPlaneEndpoint != nil && openStackCluster.Spec.ControlPlaneEndpoint.IsValid():
+	case ptr.Deref(openStackCluster.Spec.APIServer.GetEnableFloatingIP(), true) && openStackCluster.Spec.ControlPlaneEndpoint != nil && openStackCluster.Spec.ControlPlaneEndpoint.IsValid():
 		fixedIPAddress, err := lookupHost(openStackCluster.Spec.ControlPlaneEndpoint.Host)
 		if err != nil {
 			return nil, fmt.Errorf("lookup host: %w", err)

--- a/pkg/cloud/services/loadbalancer/loadbalancer.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer.go
@@ -178,7 +178,7 @@ func getAPIServerVIPAddress(openStackCluster *infrav1.OpenStackCluster) (*string
 		return openStackCluster.Spec.APIServer.GetFixedIP(), nil
 
 		// If we are using the VIP as the control plane endpoint, use any value explicitly set on the control plane endpoint
-	case ptr.Deref(openStackCluster.Spec.APIServer.GetEnableFloatingIP(), true) && openStackCluster.Spec.ControlPlaneEndpoint != nil && openStackCluster.Spec.ControlPlaneEndpoint.IsValid():
+	case !ptr.Deref(openStackCluster.Spec.APIServer.GetEnableFloatingIP(), true) && openStackCluster.Spec.ControlPlaneEndpoint != nil && openStackCluster.Spec.ControlPlaneEndpoint.IsValid():
 		fixedIPAddress, err := lookupHost(openStackCluster.Spec.ControlPlaneEndpoint.Host)
 		if err != nil {
 			return nil, fmt.Errorf("lookup host: %w", err)

--- a/pkg/cloud/services/loadbalancer/loadbalancer_test.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer_test.go
@@ -71,7 +71,7 @@ func Test_ReconcileLoadBalancer(t *testing.T) {
 				ManagedLoadBalancer: &infrav1.APIServerLoadBalancer{
 					Enabled: ptr.To(true),
 				},
-				DisableFloatingIP: ptr.To(true),
+				EnableFloatingIP: ptr.To(false),
 			},
 			ControlPlaneEndpoint: &clusterv1.APIEndpoint{
 				Host: apiHostname,
@@ -193,7 +193,7 @@ func Test_ReconcileLoadBalancer(t *testing.T) {
 								MaxRetriesDown: 4,
 							},
 						},
-						DisableFloatingIP: ptr.To(true),
+						EnableFloatingIP: ptr.To(false),
 					},
 					ControlPlaneEndpoint: &clusterv1.APIEndpoint{
 						Host: apiHostname,
@@ -296,7 +296,7 @@ func Test_ReconcileLoadBalancer(t *testing.T) {
 								MaxRetriesDown: 4,
 							},
 						},
-						DisableFloatingIP: ptr.To(true),
+						EnableFloatingIP: ptr.To(false),
 					},
 					ControlPlaneEndpoint: &clusterv1.APIEndpoint{
 						Host: apiHostname,
@@ -391,7 +391,7 @@ func Test_ReconcileLoadBalancer(t *testing.T) {
 								MaxRetriesDown: 4,
 							},
 						},
-						DisableFloatingIP: ptr.To(true),
+						EnableFloatingIP: ptr.To(false),
 					},
 					ControlPlaneEndpoint: &clusterv1.APIEndpoint{
 						Host: apiHostname,
@@ -552,7 +552,7 @@ func Test_getAPIServerVIPAddress(t *testing.T) {
 			openStackCluster: &infrav1.OpenStackCluster{
 				Spec: infrav1.OpenStackClusterSpec{
 					APIServer: &infrav1.APIServer{
-						DisableFloatingIP: ptr.To(true),
+						EnableFloatingIP: ptr.To(false),
 					},
 					ControlPlaneEndpoint: &clusterv1.APIEndpoint{
 						Host: apiHostname,
@@ -568,7 +568,7 @@ func Test_getAPIServerVIPAddress(t *testing.T) {
 			openStackCluster: &infrav1.OpenStackCluster{
 				Spec: infrav1.OpenStackClusterSpec{
 					APIServer: &infrav1.APIServer{
-						DisableFloatingIP: ptr.To(true),
+						EnableFloatingIP: ptr.To(false),
 					},
 					ControlPlaneEndpoint: &clusterv1.APIEndpoint{
 						Host: "invalid-api.test-cluster.test",
@@ -987,7 +987,7 @@ func Test_ReconcileLoadBalancerMember(t *testing.T) {
 							ID: &lbNetworkID,
 						},
 					},
-					DisableFloatingIP: ptr.To(true),
+					EnableFloatingIP: ptr.To(false),
 				},
 				ControlPlaneEndpoint: &clusterv1.APIEndpoint{
 					Host: apiHostname,

--- a/pkg/cloud/services/networking/network.go
+++ b/pkg/cloud/services/networking/network.go
@@ -119,7 +119,9 @@ func (s *Service) ReconcileNetwork(openStackCluster *infrav1.OpenStackCluster, c
 	}
 
 	if openStackCluster.Spec.ManagedNetwork != nil {
-		if ptr.Deref(openStackCluster.Spec.ManagedNetwork.DisablePortSecurity, false) {
+		// Port Security is set to disabled only when EnablePortSecurity is
+		// set and equals false
+		if !ptr.Deref(openStackCluster.Spec.ManagedNetwork.EnablePortSecurity, true) {
 			opts.PortSecurityEnabled = gophercloud.Disabled
 		}
 

--- a/pkg/cloud/services/networking/network.go
+++ b/pkg/cloud/services/networking/network.go
@@ -51,9 +51,9 @@ func (c createOpts) ToNetworkCreateMap() (map[string]interface{}, error) {
 // The external network can be specified in the cluster spec or will be searched for if not specified.
 // OpenStackCluster.Status.ExternalNetwork will be set to nil if one of these conditions are met:
 // - no external network was given in the cluster spec and no external network was found
-// - the user has set OpenStackCluster.Spec.DisableExternalNetwork to true.
+// - the user has set OpenStackCluster.Spec.EnableExternalNetwork to false.
 func (s *Service) ReconcileExternalNetwork(openStackCluster *infrav1.OpenStackCluster) error {
-	if ptr.Deref(openStackCluster.Spec.DisableExternalNetwork, false) {
+	if ptr.Deref(openStackCluster.Spec.EnableExternalNetwork, true) {
 		s.scope.Logger().Info("External network is disabled - proceeding with internal network only")
 		openStackCluster.Status.ExternalNetwork = nil
 		return nil

--- a/pkg/cloud/services/networking/network.go
+++ b/pkg/cloud/services/networking/network.go
@@ -53,7 +53,7 @@ func (c createOpts) ToNetworkCreateMap() (map[string]interface{}, error) {
 // - no external network was given in the cluster spec and no external network was found
 // - the user has set OpenStackCluster.Spec.EnableExternalNetwork to false.
 func (s *Service) ReconcileExternalNetwork(openStackCluster *infrav1.OpenStackCluster) error {
-	if ptr.Deref(openStackCluster.Spec.EnableExternalNetwork, true) {
+	if !ptr.Deref(openStackCluster.Spec.EnableExternalNetwork, true) {
 		s.scope.Logger().Info("External network is disabled - proceeding with internal network only")
 		openStackCluster.Status.ExternalNetwork = nil
 		return nil

--- a/pkg/cloud/services/networking/network_test.go
+++ b/pkg/cloud/services/networking/network_test.go
@@ -436,13 +436,13 @@ func Test_ReconcileExternalNetwork(t *testing.T) {
 			name: "not reconcile external network when external network disabled",
 			openStackCluster: &infrav1.OpenStackCluster{
 				Spec: infrav1.OpenStackClusterSpec{
-					DisableExternalNetwork: ptr.To(true),
+					EnableExternalNetwork: ptr.To(false),
 				},
 			},
 			expect: func(Gomega, *mock.MockNetworkClientMockRecorder) {},
 			want: &infrav1.OpenStackCluster{
 				Spec: infrav1.OpenStackClusterSpec{
-					DisableExternalNetwork: ptr.To(true),
+					EnableExternalNetwork: ptr.To(false),
 				},
 				Status: infrav1.OpenStackClusterStatus{
 					ExternalNetwork: nil,

--- a/pkg/cloud/services/networking/network_test.go
+++ b/pkg/cloud/services/networking/network_test.go
@@ -211,7 +211,7 @@ func Test_ReconcileNetwork(t *testing.T) {
 			openStackCluster: &infrav1.OpenStackCluster{
 				Spec: infrav1.OpenStackClusterSpec{
 					ManagedNetwork: &infrav1.ManagedNetwork{
-						DisablePortSecurity: ptr.To(true),
+						EnablePortSecurity: ptr.To(false),
 					},
 				},
 			},

--- a/pkg/cloud/services/networking/port.go
+++ b/pkg/cloud/services/networking/port.go
@@ -181,7 +181,7 @@ func (s *Service) EnsurePort(eventObject runtime.Object, portSpec *infrav1.Resol
 		return port, nil
 	}
 	var addressPairs []ports.AddressPair
-	if !ptr.Deref(portSpec.DisablePortSecurity, false) {
+	if ptr.Deref(portSpec.EnablePortSecurity, true) {
 		for _, ap := range portSpec.AllowedAddressPairs {
 			addressPairs = append(addressPairs, ports.AddressPair{
 				IPAddress:  ap.IPAddress,
@@ -225,18 +225,17 @@ func (s *Service) EnsurePort(eventObject runtime.Object, portSpec *infrav1.Resol
 		createOpts.FixedIPs = fixedIPs
 	}
 	if portSpec.SecurityGroups != nil {
-		if ptr.Deref(portSpec.DisablePortSecurity, false) {
+		if !ptr.Deref(portSpec.EnablePortSecurity, true) {
 			return nil, errors.New("security groups cannot be set when port security is disabled")
 		}
 		createOpts.SecurityGroups = &portSpec.SecurityGroups
 	}
 	builder = createOpts
 
-	if portSpec.DisablePortSecurity != nil {
-		portSecurity := !*portSpec.DisablePortSecurity
+	if portSpec.EnablePortSecurity != nil {
 		portSecurityOpts := portsecurity.PortCreateOptsExt{
 			CreateOptsBuilder:   builder,
-			PortSecurityEnabled: &portSecurity,
+			PortSecurityEnabled: portSpec.EnablePortSecurity,
 		}
 		builder = portSecurityOpts
 	}
@@ -511,7 +510,7 @@ func (s *Service) normalizePorts(ports []infrav1.PortOpts, clusterResourceName, 
 		}
 
 		// Resolve security groups when port security is not disabled
-		if !ptr.Deref(port.DisablePortSecurity, false) {
+		if ptr.Deref(port.EnablePortSecurity, true) {
 			if len(port.SecurityGroups) == 0 {
 				normalizedPort.SecurityGroups = defaultSecurityGroupIDs
 			} else {

--- a/pkg/cloud/services/networking/port_test.go
+++ b/pkg/cloud/services/networking/port_test.go
@@ -253,7 +253,7 @@ func Test_EnsurePort(t *testing.T) {
 				Name:      "test-port",
 				NetworkID: netID,
 				ResolvedPortSpecFields: infrav1.ResolvedPortSpecFields{
-					DisablePortSecurity: ptr.To(true),
+					EnablePortSecurity: ptr.To(false),
 				},
 				SecurityGroups: []string{portSecurityGroupID},
 			},
@@ -272,7 +272,7 @@ func Test_EnsurePort(t *testing.T) {
 				Name:      "test-port",
 				NetworkID: netID,
 				ResolvedPortSpecFields: infrav1.ResolvedPortSpecFields{
-					DisablePortSecurity: ptr.To(true),
+					EnablePortSecurity: ptr.To(false),
 					AllowedAddressPairs: []infrav1.AddressPair{
 						{
 							IPAddress:  ipAddress1,
@@ -312,7 +312,7 @@ func Test_EnsurePort(t *testing.T) {
 				Name:      "test-port",
 				NetworkID: netID,
 				ResolvedPortSpecFields: infrav1.ResolvedPortSpecFields{
-					DisablePortSecurity: ptr.To(false),
+					EnablePortSecurity: ptr.To(true),
 					AllowedAddressPairs: []infrav1.AddressPair{
 						{
 							IPAddress:  ipAddress1,
@@ -957,7 +957,7 @@ func TestService_ConstructPorts(t *testing.T) {
 				Ports: []infrav1.PortOpts{
 					{
 						ResolvedPortSpecFields: infrav1.ResolvedPortSpecFields{
-							DisablePortSecurity: ptr.To(true),
+							EnablePortSecurity: ptr.To(false),
 						},
 					},
 				},
@@ -977,7 +977,7 @@ func TestService_ConstructPorts(t *testing.T) {
 					Description: defaultDescription,
 					Tags:        []string{"test-tag"},
 					ResolvedPortSpecFields: infrav1.ResolvedPortSpecFields{
-						DisablePortSecurity: ptr.To(true),
+						EnablePortSecurity: ptr.To(false),
 					},
 				},
 			},
@@ -1063,7 +1063,7 @@ func Test_getPortName(t *testing.T) {
 				NameSuffix: ptr.To("foo2"),
 				Network:    &infrav1.NetworkParam{ID: ptr.To("bar")},
 				ResolvedPortSpecFields: infrav1.ResolvedPortSpecFields{
-					DisablePortSecurity: ptr.To(true),
+					EnablePortSecurity: ptr.To(false),
 				},
 			},
 			netIndex: 4,

--- a/pkg/generated/applyconfiguration/api/v1beta2/apiserver.go
+++ b/pkg/generated/applyconfiguration/api/v1beta2/apiserver.go
@@ -36,11 +36,10 @@ type APIServerApplyConfiguration struct {
 	// floatingIP is the floating IP which will be associated with the API server.
 	// The floating IP will be created if it does not already exist.
 	// If not specified, a new floating IP is allocated.
-	// This field is not used if DisableFloatingIP is set to true.
+	// This field is not used if EnableFloatingIP is set to false.
 	FloatingIP *string `json:"floatingIP,omitempty"`
-	// disableFloatingIP determines whether or not to attempt to attach a
-	// floating IP to the API server.
-	DisableFloatingIP *bool `json:"disableFloatingIP,omitempty"`
+	// enableFloatingIP determines whether to attach a floating IP to the API server.
+	EnableFloatingIP *bool `json:"enableFloatingIP,omitempty"`
 	// managedLoadBalancer configures the optional LoadBalancer for the API server.
 	// If not specified, no load balancer will be created.
 	ManagedLoadBalancer *APIServerLoadBalancerApplyConfiguration `json:"managedLoadBalancer,omitempty"`
@@ -76,11 +75,11 @@ func (b *APIServerApplyConfiguration) WithFloatingIP(value string) *APIServerApp
 	return b
 }
 
-// WithDisableFloatingIP sets the DisableFloatingIP field in the declarative configuration to the given value
+// WithEnableFloatingIP sets the EnableFloatingIP field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the DisableFloatingIP field is set to the value of the last call.
-func (b *APIServerApplyConfiguration) WithDisableFloatingIP(value bool) *APIServerApplyConfiguration {
-	b.DisableFloatingIP = &value
+// If called multiple times, the EnableFloatingIP field is set to the value of the last call.
+func (b *APIServerApplyConfiguration) WithEnableFloatingIP(value bool) *APIServerApplyConfiguration {
+	b.EnableFloatingIP = &value
 	return b
 }
 

--- a/pkg/generated/applyconfiguration/api/v1beta2/managednetwork.go
+++ b/pkg/generated/applyconfiguration/api/v1beta2/managednetwork.go
@@ -28,9 +28,10 @@ type ManagedNetworkApplyConfiguration struct {
 	// If left empty, the network will have the default MTU defined in Openstack network service.
 	// To use this field, the Openstack installation requires the net-mtu neutron API extension.
 	MTU *int `json:"mtu,omitempty"`
-	// disablePortSecurity disables the port security of the network created for the
-	// Kubernetes cluster, which also disables SecurityGroups
-	DisablePortSecurity *bool `json:"disablePortSecurity,omitempty"`
+	// enablePortSecurity enables port security for the network created for the
+	// Kubernetes cluster, which also enables SecurityGroups.
+	// If left empty, the network will have port security setting enabled.
+	EnablePortSecurity *bool `json:"enablePortSecurity,omitempty"`
 }
 
 // ManagedNetworkApplyConfiguration constructs a declarative configuration of the ManagedNetwork type for use with
@@ -47,10 +48,10 @@ func (b *ManagedNetworkApplyConfiguration) WithMTU(value int) *ManagedNetworkApp
 	return b
 }
 
-// WithDisablePortSecurity sets the DisablePortSecurity field in the declarative configuration to the given value
+// WithEnablePortSecurity sets the EnablePortSecurity field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the DisablePortSecurity field is set to the value of the last call.
-func (b *ManagedNetworkApplyConfiguration) WithDisablePortSecurity(value bool) *ManagedNetworkApplyConfiguration {
-	b.DisablePortSecurity = &value
+// If called multiple times, the EnablePortSecurity field is set to the value of the last call.
+func (b *ManagedNetworkApplyConfiguration) WithEnablePortSecurity(value bool) *ManagedNetworkApplyConfiguration {
+	b.EnablePortSecurity = &value
 	return b
 }

--- a/pkg/generated/applyconfiguration/api/v1beta2/openstackclusterspec.go
+++ b/pkg/generated/applyconfiguration/api/v1beta2/openstackclusterspec.go
@@ -50,22 +50,22 @@ type OpenStackClusterSpecApplyConfiguration struct {
 	// are specified.
 	Network *NetworkParamApplyConfiguration `json:"network,omitempty"`
 	// externalNetwork is the OpenStack Network to be used to get public internet to the VMs.
-	// This option is ignored if DisableExternalNetwork is set to true.
+	// This option is ignored if EnableExternalNetwork is set to false.
 	//
 	// If ExternalNetwork is defined it must refer to exactly one external network.
 	//
 	// If ExternalNetwork is not defined or is empty the controller will use any
 	// existing external network as long as there is only one. It is an
 	// error if ExternalNetwork is not defined and there are multiple
-	// external networks unless DisableExternalNetwork is also set.
+	// external networks unless EnableExternalNetwork is also set to false.
 	//
 	// If ExternalNetwork is not defined and there are no external networks
-	// the controller will proceed as though DisableExternalNetwork was set.
+	// the controller will proceed as though EnableExternalNetwork was set to true.
 	ExternalNetwork *NetworkParamApplyConfiguration `json:"externalNetwork,omitempty"`
-	// disableExternalNetwork specifies whether or not to attempt to connect the cluster
-	// to an external network. This allows for the creation of clusters when connecting
-	// to an external network is not possible or desirable, e.g. if using a provider network.
-	DisableExternalNetwork *bool `json:"disableExternalNetwork,omitempty"`
+	// enableExternalNetwork specifies whether to connect the cluster to an external network.
+	// Set this to false when connecting to an external network is not possible or desirable,
+	// e.g. if using a provider network.
+	EnableExternalNetwork *bool `json:"enableExternalNetwork,omitempty"`
 	// apiServer configures the API server endpoint and its associated
 	// load balancer and floating IP.
 	APIServer *APIServerApplyConfiguration `json:"apiServer,omitempty"`
@@ -178,11 +178,11 @@ func (b *OpenStackClusterSpecApplyConfiguration) WithExternalNetwork(value *Netw
 	return b
 }
 
-// WithDisableExternalNetwork sets the DisableExternalNetwork field in the declarative configuration to the given value
+// WithEnableExternalNetwork sets the EnableExternalNetwork field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the DisableExternalNetwork field is set to the value of the last call.
-func (b *OpenStackClusterSpecApplyConfiguration) WithDisableExternalNetwork(value bool) *OpenStackClusterSpecApplyConfiguration {
-	b.DisableExternalNetwork = &value
+// If called multiple times, the EnableExternalNetwork field is set to the value of the last call.
+func (b *OpenStackClusterSpecApplyConfiguration) WithEnableExternalNetwork(value bool) *OpenStackClusterSpecApplyConfiguration {
+	b.EnableExternalNetwork = &value
 	return b
 }
 

--- a/pkg/generated/applyconfiguration/api/v1beta2/openstackclusterspec.go
+++ b/pkg/generated/applyconfiguration/api/v1beta2/openstackclusterspec.go
@@ -60,7 +60,7 @@ type OpenStackClusterSpecApplyConfiguration struct {
 	// external networks unless EnableExternalNetwork is also set to false.
 	//
 	// If ExternalNetwork is not defined and there are no external networks
-	// the controller will proceed as though EnableExternalNetwork was set to true.
+	// the controller will proceed as though EnableExternalNetwork was set to false.
 	ExternalNetwork *NetworkParamApplyConfiguration `json:"externalNetwork,omitempty"`
 	// enableExternalNetwork specifies whether to connect the cluster to an external network.
 	// Set this to false when connecting to an external network is not possible or desirable,

--- a/pkg/generated/applyconfiguration/api/v1beta2/portopts.go
+++ b/pkg/generated/applyconfiguration/api/v1beta2/portopts.go
@@ -169,11 +169,11 @@ func (b *PortOptsApplyConfiguration) WithProfile(value *BindingProfileApplyConfi
 	return b
 }
 
-// WithDisablePortSecurity sets the DisablePortSecurity field in the declarative configuration to the given value
+// WithEnablePortSecurity sets the EnablePortSecurity field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the DisablePortSecurity field is set to the value of the last call.
-func (b *PortOptsApplyConfiguration) WithDisablePortSecurity(value bool) *PortOptsApplyConfiguration {
-	b.ResolvedPortSpecFieldsApplyConfiguration.DisablePortSecurity = &value
+// If called multiple times, the EnablePortSecurity field is set to the value of the last call.
+func (b *PortOptsApplyConfiguration) WithEnablePortSecurity(value bool) *PortOptsApplyConfiguration {
+	b.ResolvedPortSpecFieldsApplyConfiguration.EnablePortSecurity = &value
 	return b
 }
 

--- a/pkg/generated/applyconfiguration/api/v1beta2/resolvedportspec.go
+++ b/pkg/generated/applyconfiguration/api/v1beta2/resolvedportspec.go
@@ -164,11 +164,11 @@ func (b *ResolvedPortSpecApplyConfiguration) WithProfile(value *BindingProfileAp
 	return b
 }
 
-// WithDisablePortSecurity sets the DisablePortSecurity field in the declarative configuration to the given value
+// WithEnablePortSecurity sets the EnablePortSecurity field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the DisablePortSecurity field is set to the value of the last call.
-func (b *ResolvedPortSpecApplyConfiguration) WithDisablePortSecurity(value bool) *ResolvedPortSpecApplyConfiguration {
-	b.ResolvedPortSpecFieldsApplyConfiguration.DisablePortSecurity = &value
+// If called multiple times, the EnablePortSecurity field is set to the value of the last call.
+func (b *ResolvedPortSpecApplyConfiguration) WithEnablePortSecurity(value bool) *ResolvedPortSpecApplyConfiguration {
+	b.ResolvedPortSpecFieldsApplyConfiguration.EnablePortSecurity = &value
 	return b
 }
 

--- a/pkg/generated/applyconfiguration/api/v1beta2/resolvedportspecfields.go
+++ b/pkg/generated/applyconfiguration/api/v1beta2/resolvedportspecfields.go
@@ -54,9 +54,9 @@ type ResolvedPortSpecFieldsApplyConfiguration struct {
 	// To set profiles, your tenant needs permissions rule:create_port, and
 	// rule:create_port:binding:profile
 	Profile *BindingProfileApplyConfiguration `json:"profile,omitempty"`
-	// disablePortSecurity enables or disables the port security when set.
+	// enablePortSecurity enables or disables the port security when set.
 	// When not set, it takes the value of the corresponding field at the network level.
-	DisablePortSecurity *bool `json:"disablePortSecurity,omitempty"`
+	EnablePortSecurity *bool `json:"enablePortSecurity,omitempty"`
 	// propagateUplinkStatus enables or disables the propagate uplink status on the port.
 	PropagateUplinkStatus *bool `json:"propagateUplinkStatus,omitempty"`
 	// valueSpecs are extra parameters to include in the API request with OpenStack.
@@ -124,11 +124,11 @@ func (b *ResolvedPortSpecFieldsApplyConfiguration) WithProfile(value *BindingPro
 	return b
 }
 
-// WithDisablePortSecurity sets the DisablePortSecurity field in the declarative configuration to the given value
+// WithEnablePortSecurity sets the EnablePortSecurity field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the DisablePortSecurity field is set to the value of the last call.
-func (b *ResolvedPortSpecFieldsApplyConfiguration) WithDisablePortSecurity(value bool) *ResolvedPortSpecFieldsApplyConfiguration {
-	b.DisablePortSecurity = &value
+// If called multiple times, the EnablePortSecurity field is set to the value of the last call.
+func (b *ResolvedPortSpecFieldsApplyConfiguration) WithEnablePortSecurity(value bool) *ResolvedPortSpecFieldsApplyConfiguration {
+	b.EnablePortSecurity = &value
 	return b
 }
 

--- a/pkg/generated/applyconfiguration/internal/internal.go
+++ b/pkg/generated/applyconfiguration/internal/internal.go
@@ -2250,7 +2250,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: controlPlaneOmitAvailabilityZone
       type:
         scalar: boolean
-    - name: disableExternalNetwork
+    - name: enableExternalNetwork
       type:
         scalar: boolean
     - name: externalNetwork

--- a/pkg/generated/applyconfiguration/internal/internal.go
+++ b/pkg/generated/applyconfiguration/internal/internal.go
@@ -2071,7 +2071,7 @@ var schemaYAML = typed.YAMLObject(`types:
 - name: io.k8s.sigs.cluster-api-provider-openstack.api.v1beta2.ManagedNetwork
   map:
     fields:
-    - name: disablePortSecurity
+    - name: enablePortSecurity
       type:
         scalar: boolean
     - name: mtu

--- a/pkg/generated/applyconfiguration/internal/internal.go
+++ b/pkg/generated/applyconfiguration/internal/internal.go
@@ -2585,7 +2585,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: description
       type:
         scalar: string
-    - name: disablePortSecurity
+    - name: enablePortSecurity
       type:
         scalar: boolean
     - name: fixedIPs
@@ -2688,7 +2688,7 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         scalar: string
       default: ""
-    - name: disablePortSecurity
+    - name: enablePortSecurity
       type:
         scalar: boolean
     - name: fixedIPs

--- a/pkg/generated/applyconfiguration/internal/internal.go
+++ b/pkg/generated/applyconfiguration/internal/internal.go
@@ -1775,7 +1775,7 @@ var schemaYAML = typed.YAMLObject(`types:
 - name: io.k8s.sigs.cluster-api-provider-openstack.api.v1beta2.APIServer
   map:
     fields:
-    - name: disableFloatingIP
+    - name: enableFloatingIP
       type:
         scalar: boolean
     - name: fixedIP

--- a/pkg/webhooks/openstackcluster_webhook.go
+++ b/pkg/webhooks/openstackcluster_webhook.go
@@ -127,13 +127,13 @@ func (*openStackClusterWebhook) ValidateUpdate(_ context.Context, oldObj, newObj
 
 	// Allow APIServerFixedIP to be set for the first time when floating IP is disabled.
 	if oldObj.Spec.APIServer != nil && newObj.Spec.APIServer != nil {
-		if ptr.Deref(oldObj.Spec.APIServer.DisableFloatingIP, false) && ptr.Deref(oldObj.Spec.APIServer.FixedIP, "") == "" {
+		if ptr.Deref(oldObj.Spec.APIServer.GetEnableFloatingIP(), true) && ptr.Deref(oldObj.Spec.APIServer.FixedIP, "") == "" {
 			oldObj.Spec.APIServer.FixedIP = nil
 			newObj.Spec.APIServer.FixedIP = nil
 		}
 
 		// If API Server floating IP is disabled, allow the change of the API Server port only for the first time.
-		if ptr.Deref(oldObj.Spec.APIServer.GetDisableFloatingIP(), false) && oldObj.Spec.APIServer.GetPort() == nil && newObj.Spec.APIServer.GetPort() != nil {
+		if ptr.Deref(oldObj.Spec.APIServer.GetEnableFloatingIP(), true) && oldObj.Spec.APIServer.GetPort() == nil && newObj.Spec.APIServer.GetPort() != nil {
 			newObj.Spec.APIServer.Port = nil
 		}
 	}

--- a/pkg/webhooks/openstackcluster_webhook.go
+++ b/pkg/webhooks/openstackcluster_webhook.go
@@ -127,13 +127,12 @@ func (*openStackClusterWebhook) ValidateUpdate(_ context.Context, oldObj, newObj
 
 	// Allow APIServerFixedIP to be set for the first time when floating IP is disabled.
 	if oldObj.Spec.APIServer != nil && newObj.Spec.APIServer != nil {
-		if ptr.Deref(oldObj.Spec.APIServer.GetEnableFloatingIP(), true) && ptr.Deref(oldObj.Spec.APIServer.FixedIP, "") == "" {
+		if !ptr.Deref(oldObj.Spec.APIServer.GetEnableFloatingIP(), true) && ptr.Deref(oldObj.Spec.APIServer.FixedIP, "") == "" {
 			oldObj.Spec.APIServer.FixedIP = nil
 			newObj.Spec.APIServer.FixedIP = nil
 		}
-
 		// If API Server floating IP is disabled, allow the change of the API Server port only for the first time.
-		if ptr.Deref(oldObj.Spec.APIServer.GetEnableFloatingIP(), true) && oldObj.Spec.APIServer.GetPort() == nil && newObj.Spec.APIServer.GetPort() != nil {
+		if !ptr.Deref(oldObj.Spec.APIServer.GetEnableFloatingIP(), true) && oldObj.Spec.APIServer.GetPort() == nil && newObj.Spec.APIServer.GetPort() != nil {
 			newObj.Spec.APIServer.Port = nil
 		}
 	}

--- a/pkg/webhooks/openstackcluster_webhook_test.go
+++ b/pkg/webhooks/openstackcluster_webhook_test.go
@@ -439,7 +439,7 @@ func TestOpenStackCluster_ValidateUpdate(t *testing.T) {
 						CloudName: "foobar",
 					},
 					APIServer: &infrav1.APIServer{
-						DisableFloatingIP: ptr.To(true),
+						EnableFloatingIP: ptr.To(false),
 					},
 				},
 			},
@@ -450,8 +450,8 @@ func TestOpenStackCluster_ValidateUpdate(t *testing.T) {
 						CloudName: "foobar",
 					},
 					APIServer: &infrav1.APIServer{
-						DisableFloatingIP: ptr.To(true),
-						FixedIP:           ptr.To("20.1.56.1"),
+						EnableFloatingIP: ptr.To(false),
+						FixedIP:          ptr.To("20.1.56.1"),
 					},
 				},
 			},
@@ -466,7 +466,7 @@ func TestOpenStackCluster_ValidateUpdate(t *testing.T) {
 						CloudName: "foobar",
 					},
 					APIServer: &infrav1.APIServer{
-						DisableFloatingIP: ptr.To(false),
+						EnableFloatingIP: ptr.To(true),
 					},
 				},
 			},
@@ -477,8 +477,8 @@ func TestOpenStackCluster_ValidateUpdate(t *testing.T) {
 						CloudName: "foobar",
 					},
 					APIServer: &infrav1.APIServer{
-						DisableFloatingIP: ptr.To(false),
-						FixedIP:           ptr.To("20.1.56.1"),
+						EnableFloatingIP: ptr.To(true),
+						FixedIP:          ptr.To("20.1.56.1"),
 					},
 				},
 			},
@@ -493,15 +493,15 @@ func TestOpenStackCluster_ValidateUpdate(t *testing.T) {
 						CloudName: "foobar",
 					},
 					APIServer: &infrav1.APIServer{
-						DisableFloatingIP: ptr.To(true),
+						EnableFloatingIP: ptr.To(false),
 					},
 				},
 			},
 			newCluster: &infrav1.OpenStackCluster{
 				Spec: infrav1.OpenStackClusterSpec{
 					APIServer: &infrav1.APIServer{
-						DisableFloatingIP: ptr.To(true),
-						Port:              ptr.To(uint16(8443)),
+						EnableFloatingIP: ptr.To(false),
+						Port:             ptr.To(uint16(8443)),
 					},
 				},
 			},
@@ -516,7 +516,7 @@ func TestOpenStackCluster_ValidateUpdate(t *testing.T) {
 						CloudName: "foobar",
 					},
 					APIServer: &infrav1.APIServer{
-						DisableFloatingIP: ptr.To(false),
+						EnableFloatingIP: ptr.To(true),
 					},
 				},
 			},
@@ -527,8 +527,8 @@ func TestOpenStackCluster_ValidateUpdate(t *testing.T) {
 						CloudName: "foobar",
 					},
 					APIServer: &infrav1.APIServer{
-						DisableFloatingIP: ptr.To(false),
-						Port:              ptr.To(uint16(8443)),
+						EnableFloatingIP: ptr.To(true),
+						Port:             ptr.To(uint16(8443)),
 					},
 				},
 			},

--- a/pkg/webhooks/openstackclustertemplate_webhook_test.go
+++ b/pkg/webhooks/openstackclustertemplate_webhook_test.go
@@ -56,7 +56,7 @@ func TestOpenStackClusterTemplate_ValidateUpdate(t *testing.T) {
 								CloudName: "foobar",
 							},
 							APIServer: &infrav1.APIServer{
-								DisableFloatingIP: ptr.To(true),
+								EnableFloatingIP: ptr.To(false),
 							},
 						},
 					},

--- a/pkg/webhooks/openstackmachine_webhook.go
+++ b/pkg/webhooks/openstackmachine_webhook.go
@@ -57,8 +57,8 @@ func (*openStackMachineWebhook) ValidateCreate(_ context.Context, newObj *infrav
 	}
 
 	for _, port := range newObj.Spec.Ports {
-		if ptr.Deref(port.DisablePortSecurity, false) && len(port.SecurityGroups) > 0 {
-			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "ports"), "cannot have security groups when DisablePortSecurity is set to true"))
+		if !ptr.Deref(port.EnablePortSecurity, true) && len(port.SecurityGroups) > 0 {
+			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "ports"), "cannot have security groups when EnablePortSecurity is set to false"))
 		}
 	}
 

--- a/pkg/webhooks/openstackmachine_webhook_test.go
+++ b/pkg/webhooks/openstackmachine_webhook_test.go
@@ -77,7 +77,7 @@ func TestOpenStackMachine_ValidateCreate(t *testing.T) {
 						{
 							SecurityGroups: []infrav1.SecurityGroupParam{{ID: ptr.To("sg-1")}},
 							ResolvedPortSpecFields: infrav1.ResolvedPortSpecFields{
-								DisablePortSecurity: ptr.To(true),
+								EnablePortSecurity: ptr.To(false),
 							},
 						},
 					},

--- a/pkg/webhooks/openstackserver_webhook.go
+++ b/pkg/webhooks/openstackserver_webhook.go
@@ -60,8 +60,8 @@ func (*openStackServerWebhook) ValidateCreate(_ context.Context, newObj *infrav1
 	}
 
 	for _, port := range newObj.Spec.Ports {
-		if ptr.Deref(port.DisablePortSecurity, false) && len(port.SecurityGroups) > 0 {
-			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "ports"), "cannot have security groups when DisablePortSecurity is set to true"))
+		if !ptr.Deref(port.EnablePortSecurity, true) && len(port.SecurityGroups) > 0 {
+			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "ports"), "cannot have security groups when EnablePortSecurity is set to false"))
 		}
 	}
 

--- a/test/e2e/suites/apivalidations/openstackcluster_test.go
+++ b/test/e2e/suites/apivalidations/openstackcluster_test.go
@@ -198,7 +198,7 @@ var _ = Describe("OpenStackCluster API validations", func() {
 			Expect(createObj(cluster)).NotTo(Succeed(), "OpenStackCluster creation should not succeed")
 		})
 
-		It("should not allow a bastion floating IP with DisableExternalNetwork set to true", func() {
+		It("should not allow a bastion floating IP with EnableExternalNetwork set to false", func() {
 			cluster.Spec.Bastion = &infrav1.Bastion{
 				Enabled: ptr.To(true),
 				Spec: &infrav1.OpenStackMachineSpec{
@@ -215,15 +215,15 @@ var _ = Describe("OpenStackCluster API validations", func() {
 				},
 				FloatingIP: ptr.To("10.0.0.0"),
 			}
-			cluster.Spec.DisableExternalNetwork = ptr.To(true)
+			cluster.Spec.EnableExternalNetwork = ptr.To(false)
 			Expect(createObj(cluster)).ToNot(Succeed(), "OpenStackCluster creation should not succeed")
 		})
 
-		It("should not allow DisableFloatingIP to be false with DisableExternalNetwork set to true", func() {
+		It("should not allow DisableFloatingIP to be false with EnableExternalNetwork set to false", func() {
 			cluster.Spec.APIServer = &infrav1.APIServer{
 				DisableFloatingIP: ptr.To(false),
 			}
-			cluster.Spec.DisableExternalNetwork = ptr.To(true)
+			cluster.Spec.EnableExternalNetwork = ptr.To(false)
 			Expect(createObj(cluster)).ToNot(Succeed(), "OpenStackCluster creation should not succeed")
 		})
 

--- a/test/e2e/suites/apivalidations/openstackcluster_test.go
+++ b/test/e2e/suites/apivalidations/openstackcluster_test.go
@@ -219,9 +219,9 @@ var _ = Describe("OpenStackCluster API validations", func() {
 			Expect(createObj(cluster)).ToNot(Succeed(), "OpenStackCluster creation should not succeed")
 		})
 
-		It("should not allow DisableFloatingIP to be false with EnableExternalNetwork set to false", func() {
+		It("should not allow EnableFloatingIP to be true with EnableExternalNetwork set to false", func() {
 			cluster.Spec.APIServer = &infrav1.APIServer{
-				DisableFloatingIP: ptr.To(false),
+				EnableFloatingIP: ptr.To(true),
 			}
 			cluster.Spec.EnableExternalNetwork = ptr.To(false)
 			Expect(createObj(cluster)).ToNot(Succeed(), "OpenStackCluster creation should not succeed")

--- a/test/e2e/suites/apivalidations/openstackmachine_test.go
+++ b/test/e2e/suites/apivalidations/openstackmachine_test.go
@@ -267,7 +267,7 @@ var _ = Describe("OpenStackMachine API validations", func() {
 			Expect(k8sClient.Create(ctx, machine)).NotTo(Succeed(), "OpenStackMachine creation with root device name in spec.AdditionalBlockDevices should not succeed")
 		})
 
-		It("should not allow to create machine with both SecurityGroups and DisablePortSecurity", func() {
+		It("should not allow to create machine with both SecurityGroups and EnablePortSecurity set to false", func() {
 			machine := defaultMachine()
 			machine.Spec.Ports = []infrav1.PortOpts{
 				{
@@ -275,13 +275,13 @@ var _ = Describe("OpenStackMachine API validations", func() {
 						Filter: &infrav1.SecurityGroupFilter{Name: "test-security-group"},
 					}},
 					ResolvedPortSpecFields: infrav1.ResolvedPortSpecFields{
-						DisablePortSecurity: ptr.To(true),
+						EnablePortSecurity: ptr.To(false),
 					},
 				},
 			}
 
-			By("Creating a machine with both SecurityGroups and DisablePortSecurity")
-			Expect(k8sClient.Create(ctx, machine)).NotTo(Succeed(), "OpenStackMachine creation with both SecurityGroups and DisablePortSecurity should not succeed")
+			By("Creating a machine with both SecurityGroups and EnablePortSecurity set to false")
+			Expect(k8sClient.Create(ctx, machine)).NotTo(Succeed(), "OpenStackMachine creation with both SecurityGroups and EnablePortSecurity set to false should not succeed")
 		})
 
 		/* FIXME: These tests are failing

--- a/test/e2e/suites/apivalidations/openstackserver_test.go
+++ b/test/e2e/suites/apivalidations/openstackserver_test.go
@@ -164,7 +164,7 @@ var _ = Describe("OpenStackServer API validations", func() {
 			Expect(k8sClient.Create(ctx, server)).NotTo(Succeed(), "OpenStackserver creation with root device name in spec.AdditionalBlockDevices should not succeed")
 		})
 
-		It("should not allow to create server with both SecurityGroups and DisablePortSecurity", func() {
+		It("should not allow to create server with both SecurityGroups and EnablePortSecurity set to false", func() {
 			server := defaultServer()
 			server.Spec.Ports = []infrav1.PortOpts{
 				{
@@ -172,13 +172,13 @@ var _ = Describe("OpenStackServer API validations", func() {
 						Filter: &infrav1.SecurityGroupFilter{Name: "test-security-group"},
 					}},
 					ResolvedPortSpecFields: infrav1.ResolvedPortSpecFields{
-						DisablePortSecurity: ptr.To(true),
+						EnablePortSecurity: ptr.To(false),
 					},
 				},
 			}
 
-			By("Creating a server with both SecurityGroups and DisablePortSecurity")
-			Expect(k8sClient.Create(ctx, server)).NotTo(Succeed(), "OpenStackServer creation with both SecurityGroups and DisablePortSecurity should not succeed")
+			By("Creating a server with both SecurityGroups and EnablePortSecurity set to false")
+			Expect(k8sClient.Create(ctx, server)).NotTo(Succeed(), "OpenStackServer creation with both SecurityGroups and EnablePortSecurity set to false should not succeed")
 		})
 
 		/* FIXME: These tests are failing

--- a/test/helpers/fuzzerfuncs.go
+++ b/test/helpers/fuzzerfuncs.go
@@ -272,7 +272,7 @@ func fuzzAPIServer(as **infrav1.APIServer, c randfill.Continue) {
 	if a.FloatingIP == nil &&
 		a.FixedIP == nil &&
 		a.Port == nil &&
-		a.DisableFloatingIP == nil &&
+		a.EnableFloatingIP == nil &&
 		a.ManagedLoadBalancer == nil {
 		a.FloatingIP = ptr.To(nonEmptyString(c))
 	}

--- a/test/helpers/fuzzerfuncs.go
+++ b/test/helpers/fuzzerfuncs.go
@@ -241,7 +241,7 @@ func fuzzManagedNetwork(mn **infrav1.ManagedNetwork, c randfill.Continue) {
 	}
 	m := &infrav1.ManagedNetwork{}
 	c.Fill(m)
-	if m.MTU == nil && m.DisablePortSecurity == nil {
+	if m.MTU == nil && m.EnablePortSecurity == nil {
 		m.MTU = ptr.To(int(c.Int31()))
 	}
 	*mn = m


### PR DESCRIPTION
**What this PR does / why we need it**:
Switch the polarity of various fields from `disableX` to `enableX`


**Which issue(s) this PR fixes**:
Fixes #2974 

**Special notes for your reviewer**:

1. I have done a seperate commit per change, this was to simplify development and (hopefully) reviewing  since i wanted to be extra careful when flipping various "ifs" and not make a mistake there. If preferred i can squash commits before merging
2. Please doublecheck the various spots where i had to change "ifs" etc as a mistake there could alter the behavior of CAPO quite a bit :yum: => edit: had to fix some of them already due to unit tests failing so...

**TODOs**:

- [ ] squashed commits
- if necessary:
  - [X] includes documentation
  - [X] adds unit tests

/hold
