### PR TITLE
🐛 Add nil guard for LoadBalancerNetwork

### DIFF
--- a/pkg/cloud/services/loadbalancer/loadbalancer.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer.go
@@ -647,6 +647,9 @@ func (s *Service) ReconcileLoadBalancerMember(openStackCluster *infrav1.OpenStac
 	if openStackCluster.Status.APIServerManagedLoadBalancer == nil {
 		return errors.New("network.APIServerLoadBalancer is not yet available in openStackCluster.Status")
 	}
+	if openStackCluster.Status.APIServerManagedLoadBalancer.LoadBalancerNetwork == nil {
+		return errors.New("apiServerManagedLoadBalancer.LoadBalancerNetwork is not yet available in openStackCluster.Status")
+	}
 	if openStackCluster.Spec.ControlPlaneEndpoint == nil || !openStackCluster.Spec.ControlPlaneEndpoint.IsValid() {
 		return errors.New("ControlPlaneEndpoint is not yet set in openStackCluster.Spec")
 	}

--- a/pkg/cloud/services/loadbalancer/loadbalancer_test.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer_test.go
@@ -1208,6 +1208,20 @@ func Test_ReconcileLoadBalancerMember(t *testing.T) {
 			},
 			wantError: nil,
 		},
+		{
+			// LoadBalancerNetwork is nil when the cluster was created with an older CAPO version that
+			// did not populate this field. The reconciler must return an error to requeue and wait
+			// for the cluster controller to populate the field.
+			name: "nil LoadBalancerNetwork, return error and wait",
+			clusterSpec: func() *infrav1.OpenStackCluster {
+				c := makeCluster(nil, clusterNetID)
+				c.Status.APIServerManagedLoadBalancer.LoadBalancerNetwork = nil
+				return c
+			}(),
+			expectNetwork:      func(*mock.MockNetworkClientMockRecorder) {},
+			expectLoadBalancer: func(*mock.MockLbClientMockRecorder) {},
+			wantError:          errors.New("apiServerManagedLoadBalancer.LoadBalancerNetwork is not yet available in openStackCluster.Status"),
+		},
 	}
 
 	for _, tt := range lbtests {


### PR DESCRIPTION
**What this PR does / why we need it**:

After upgrade or clusterctl move, we may not have the status populated yet.
Then we need to wait for it before we can proceed with reconciliation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3190

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [x] adds unit tests

/hold
