### PR TITLE
:bug: Add nil guard for LoadBalancerNetwork

### DIFF
--- a/pkg/cloud/services/loadbalancer/loadbalancer.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer.go
@@ -646,6 +646,9 @@ func (s *Service) ReconcileLoadBalancerMember(openStackCluster *infrav1.OpenStac
 	if openStackCluster.Status.APIServerLoadBalancer == nil {
 		return errors.New("network.APIServerLoadBalancer is not yet available in openStackCluster.Status")
 	}
+	if openStackCluster.Status.APIServerLoadBalancer.LoadBalancerNetwork == nil {
+		return errors.New("apiServerLoadBalancer.LoadBalancerNetwork is not yet available in openStackCluster.Status")
+	}
 	if openStackCluster.Spec.ControlPlaneEndpoint == nil || !openStackCluster.Spec.ControlPlaneEndpoint.IsValid() {
 		return errors.New("ControlPlaneEndpoint is not yet set in openStackCluster.Spec")
 	}

--- a/pkg/cloud/services/loadbalancer/loadbalancer_test.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer_test.go
@@ -1180,6 +1180,20 @@ func Test_ReconcileLoadBalancerMember(t *testing.T) {
 			},
 			wantError: nil,
 		},
+		{
+			// LoadBalancerNetwork is nil when the cluster was created with an older CAPO version that
+			// did not populate this field. The reconciler must return an error to requeue and wait
+			// for the cluster controller to populate the field.
+			name: "nil LoadBalancerNetwork, return error and wait",
+			clusterSpec: func() *infrav1.OpenStackCluster {
+				c := makeCluster(nil, clusterNetID)
+				c.Status.APIServerLoadBalancer.LoadBalancerNetwork = nil
+				return c
+			}(),
+			expectNetwork:      func(*mock.MockNetworkClientMockRecorder) {},
+			expectLoadBalancer: func(*mock.MockLbClientMockRecorder) {},
+			wantError:          errors.New("apiServerLoadBalancer.LoadBalancerNetwork is not yet available in openStackCluster.Status"),
+		},
 	}
 
 	for _, tt := range lbtests {


### PR DESCRIPTION
**What this PR does / why we need it**:
After upgrade or clusterctl move, we may not have the status populated yet.

This is a backport of #3192 (couldnt be done automatic due to v1beta2)

**Which issue(s) this PR fixes**:
Relates to #3190 

**Special notes for your reviewer**:


**TODOs**:
- [X] squashed commits
- if necessary:
  - [X] includes documentation
  - [X] adds unit tests

/hold
