### PR TITLE
🌱bump go version to 1.26.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 # Build the manager binary
 ARG GO_VERSION
-FROM golang:${GO_VERSION:-1.26.3} AS builder
+FROM golang:${GO_VERSION:-1.26.4} AS builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg goproxy=$(go env GOPROXY) to override the goproxy

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ unexport GOPATH
 TRACE ?= 0
 
 # Go
-GO_VERSION ?= 1.26.3
+GO_VERSION ?= 1.26.4
 
 # Ensure correct toolchain is used
 GOTOOLCHAIN = go$(GO_VERSION)

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@ command = "make -C docs/book build"
 publish = "docs/book/book"
 
 [build.environment]
-GO_VERSION = "1.26.3"
+GO_VERSION = "1.26.4"
 
 # Standard Netlify redirects
 [[redirects]]


### PR DESCRIPTION

**What this PR does / why we need it**: Bump go version

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3196

/hold
