### PR TITLE
🌱 Bump Go version to 1.25.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 # Build the manager binary
 ARG GO_VERSION
-FROM golang:${GO_VERSION:-1.25.10} AS builder
+FROM golang:${GO_VERSION:-1.25.11} AS builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg goproxy=$(go env GOPROXY) to override the goproxy

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ unexport GOPATH
 TRACE ?= 0
 
 # Go
-GO_VERSION ?= 1.25.10
+GO_VERSION ?= 1.25.11
 
 # Ensure correct toolchain is used
 GOTOOLCHAIN = go$(GO_VERSION)

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@ command = "make -C docs/book build"
 publish = "docs/book/book"
 
 [build.environment]
-GO_VERSION = "1.25.10"
+GO_VERSION = "1.25.11"
 
 # Standard Netlify redirects
 [[redirects]]


### PR DESCRIPTION
Bumps the Go toolchain version to 1.25.11, the latest patch in the 1.25 series.

Files updated:
- Dockerfile (`GO_VERSION` default)
- Makefile (`GO_VERSION`)
- netlify.toml (`GO_VERSION`)

Intended to be cherry-picked to release-0.13.