### PR TITLE
🌱 Ignore two vulnerabilities in x/net

### DIFF
--- a/.govuln_exclude
+++ b/.govuln_exclude
@@ -1,0 +1,7 @@
+# Requires a go version bump to fix (golang.org/x/net >= v0.55.0).
+# These vulnerabilities require a compromised OpenStack or Kubernetes API
+# server to exploit, which is not something we defend against.
+# https://pkg.go.dev/vuln/GO-2026-5026
+GO-2026-5026
+# https://pkg.go.dev/vuln/GO-2026-4918
+GO-2026-4918


### PR DESCRIPTION
**What this PR does / why we need it**:

Ignore GO-2026-5026 and GO-2026-4918.
The fixed versions require a new minor version of go, which we consider as a breaking change. The vulnerabilities would require a compromised Kubernetes API server or OpenStack server to affect CAPO. These are not scenarios we defend against.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
