### PR TITLE
:sparkles: Enable PriorityQueue per default

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,7 +24,7 @@ spec:
         - "--v=2"
         - "--diagnostics-address=127.0.0.1:8080"
         - "--insecure-diagnostics=true"
-        - "--feature-gates=PriorityQueue=${EXP_CAPO_PRIORITY_QUEUE:=false},AutoScaleFromZero=${EXP_CAPO_AUTOSCALE_FROM_ZERO:=false}"
+        - "--feature-gates=PriorityQueue=${EXP_CAPO_PRIORITY_QUEUE:=true},AutoScaleFromZero=${EXP_CAPO_AUTOSCALE_FROM_ZERO:=false}"
         image: controller:latest
         imagePullPolicy: Always
         name: manager

--- a/docs/book/src/experimental-features/priority-queue.md
+++ b/docs/book/src/experimental-features/priority-queue.md
@@ -1,6 +1,7 @@
 # Priority Queue
 
-> **Note:** PriorityQueue is available in >= 0.14
+> **Note:** PriorityQueue is available as an alpha feature in 0.14 (disabled by
+> default) and graduated to beta in 0.15 (enabled by default).
 
 The `PriorityQueue` feature flag enables the usage of the controller-runtime PriorityQueue.
 
@@ -11,10 +12,21 @@ More information on controller-runtime PriorityQueue:
 - [design docs](https://github.com/kubernetes-sigs/controller-runtime/pull/3013)
 - [tracking issue](https://github.com/kubernetes-sigs/controller-runtime/issues/2374)
 
-## Enabling Priority Queue
+## Feature gate maturity
 
-You can enable `PriorityQueue` using the following.
+| Version | Stage | Default  |
+|---------|-------|----------|
+| 0.14    | Alpha | Disabled |
+| 0.15    | Beta  | Enabled  |
 
+## Enabling/Disabling Priority Queue
+
+To enable:
 - Environment variable: `EXP_CAPO_PRIORITY_QUEUE=true`
 - clusterctl.yaml variable: `EXP_CAPO_PRIORITY_QUEUE: true`
 - --feature-gates argument: `PriorityQueue=true`
+
+To disable:
+- Environment variable: `EXP_CAPO_PRIORITY_QUEUE=false`
+- clusterctl.yaml variable: `EXP_CAPO_PRIORITY_QUEUE: false`
+- `--feature-gates` argument: `PriorityQueue=false`

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -33,6 +33,7 @@ const (
 	// instead of the default queue implementation.
 	//
 	// alpha: v0.14
+	// beta: v0.15
 	PriorityQueue featuregate.Feature = "PriorityQueue"
 
 	// AutoScaleFromZero is a feature gate that enables the OpenStackMachineTemplate controller that adds
@@ -51,6 +52,6 @@ func init() {
 // To add a new feature, define a key for it above and add it here.
 var defaultCAPOFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	// Every feature should be initiated here:
-	PriorityQueue:     {Default: false, PreRelease: featuregate.Alpha},
+	PriorityQueue:     {Default: true, PreRelease: featuregate.Beta},
 	AutoScaleFromZero: {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -216,7 +216,7 @@ variables:
   WORKERS_MACHINE_TEMPLATE_UPGRADE_TO: "upgrade-to-md-0"
   CNI: "../../data/cni/calico.yaml"
   CCM: "../../data/ccm/cloud-controller-manager.yaml"
-  EXP_CAPO_PRIORITY_QUEUE: "false"
+  EXP_CAPO_PRIORITY_QUEUE: "true"
   EXP_CAPO_AUTOSCALE_FROM_ZERO: "true"
   IP_FAMILY: "ipv4"
   OPENSTACK_BASTION_IMAGE_NAME: "cirros-0.6.1-x86_64-disk"


### PR DESCRIPTION
**What this PR does / why we need it**:
Move PriorityQueue to Beta and enable by default. This is to stay in-line with:
- controller-runtime >= v0.23 where PQ is enabled by default
- cluster-api >= v1.13 where PQ is also beta and enabled by default

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- if necessary:
  - [X] includes documentation
  - [X] adds unit tests

/hold
