### PR TITLE
✨Feature/multiple subnets

### DIFF
--- a/api/v1beta1/openstackcluster_types.go
+++ b/api/v1beta1/openstackcluster_types.go
@@ -54,13 +54,21 @@ type OpenStackClusterSpec struct {
 
 	// Subnets specifies existing subnets to use if not ManagedSubnets are
 	// specified. All subnets must be in the network specified by Network.
-	// There can be zero, one, or two subnets. If no subnets are specified,
-	// all subnets in Network will be used. If 2 subnets are specified, one
-	// must be IPv4 and the other IPv6.
-	// +kubebuilder:validation:MaxItems=2
+	// If no subnets are specified, all subnets in Network will be used.
+	// Multiple subnets of the same IP version are supported when PrimarySubnet
+	// is also set to identify which subnet should be used for services like
+	// load balancer VIP allocation.
 	// +listType=atomic
 	// +optional
 	Subnets []SubnetParam `json:"subnets,omitempty"`
+
+	// PrimarySubnet identifies the primary subnet for the cluster when multiple
+	// subnets are specified in Subnets. It is used to determine the subnet for
+	// load balancer VIP allocation and node member registration.
+	// If not specified and multiple subnets exist, the first subnet in the
+	// resolved Subnets list is used.
+	// +optional
+	PrimarySubnet *SubnetParam `json:"primarySubnet,omitempty"`
 
 	// NetworkMTU sets the maximum transmission unit (MTU) value to address fragmentation for the private network ID.
 	// This value will be used only if the Cluster actuator creates the network.

--- a/api/v1beta1/zz_generated.conversion.go
+++ b/api/v1beta1/zz_generated.conversion.go
@@ -1583,6 +1583,15 @@ func autoConvert_v1beta1_OpenStackClusterSpec_To_v1beta2_OpenStackClusterSpec(in
 	} else {
 		out.Subnets = nil
 	}
+	if in.PrimarySubnet != nil {
+		in, out := &in.PrimarySubnet, &out.PrimarySubnet
+		*out = new(v1beta2.SubnetParam)
+		if err := Convert_v1beta1_SubnetParam_To_v1beta2_SubnetParam(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.PrimarySubnet = nil
+	}
 	// WARNING: in.NetworkMTU requires manual conversion: does not exist in peer-type
 	// WARNING: in.ExternalRouterIPs requires manual conversion: does not exist in peer-type
 	out.ExternalNetwork = (*v1beta2.NetworkParam)(unsafe.Pointer(in.ExternalNetwork))
@@ -1633,6 +1642,15 @@ func autoConvert_v1beta2_OpenStackClusterSpec_To_v1beta1_OpenStackClusterSpec(in
 		}
 	} else {
 		out.Subnets = nil
+	}
+	if in.PrimarySubnet != nil {
+		in, out := &in.PrimarySubnet, &out.PrimarySubnet
+		*out = new(SubnetParam)
+		if err := Convert_v1beta2_SubnetParam_To_v1beta1_SubnetParam(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.PrimarySubnet = nil
 	}
 	// WARNING: in.ManagedRouter requires manual conversion: does not exist in peer-type
 	out.Router = (*RouterParam)(unsafe.Pointer(in.Router))

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -712,6 +712,11 @@ func (in *OpenStackClusterSpec) DeepCopyInto(out *OpenStackClusterSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.PrimarySubnet != nil {
+		in, out := &in.PrimarySubnet, &out.PrimarySubnet
+		*out = new(SubnetParam)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.NetworkMTU != nil {
 		in, out := &in.NetworkMTU, &out.NetworkMTU
 		*out = new(int)

--- a/api/v1beta2/openstackcluster_types.go
+++ b/api/v1beta2/openstackcluster_types.go
@@ -43,13 +43,21 @@ type OpenStackClusterSpec struct {
 
 	// subnets specifies existing subnets to use if not ManagedSubnets are
 	// specified. All subnets must be in the network specified by Network.
-	// There can be zero, one, or two subnets. If no subnets are specified,
-	// all subnets in Network will be used. If 2 subnets are specified, one
-	// must be IPv4 and the other IPv6.
-	// +kubebuilder:validation:MaxItems=2
+	// If no subnets are specified, all subnets in Network will be used.
+	// Multiple subnets of the same IP version are supported when primarySubnet
+	// is also set to identify which subnet should be used for services like
+	// load balancer VIP allocation.
 	// +listType=atomic
 	// +optional
 	Subnets []SubnetParam `json:"subnets,omitempty"`
+
+	// primarySubnet identifies the primary subnet for the cluster when multiple
+	// subnets are specified in Subnets. It is used to determine the subnet for
+	// load balancer VIP allocation and node member registration.
+	// If not specified and multiple subnets exist, the first subnet in the
+	// resolved Subnets list is used.
+	// +optional
+	PrimarySubnet *SubnetParam `json:"primarySubnet,omitempty"`
 
 	// managedRouter specifies attributes of the router. The values are used only
 	// if the Cluster actuator creates the router.

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -834,6 +834,11 @@ func (in *OpenStackClusterSpec) DeepCopyInto(out *OpenStackClusterSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.PrimarySubnet != nil {
+		in, out := &in.PrimarySubnet, &out.PrimarySubnet
+		*out = new(SubnetParam)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ManagedRouter != nil {
 		in, out := &in.ManagedRouter, &out.ManagedRouter
 		*out = new(ManagedRouter)

--- a/cmd/models-schema/zz_generated.openapi.go
+++ b/cmd/models-schema/zz_generated.openapi.go
@@ -19497,7 +19497,7 @@ func schema_sigsk8sio_cluster_api_provider_openstack_api_v1beta1_OpenStackCluste
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Subnets specifies existing subnets to use if not ManagedSubnets are specified. All subnets must be in the network specified by Network. There can be zero, one, or two subnets. If no subnets are specified, all subnets in Network will be used. If 2 subnets are specified, one must be IPv4 and the other IPv6.",
+							Description: "Subnets specifies existing subnets to use if not ManagedSubnets are specified. All subnets must be in the network specified by Network. If no subnets are specified, all subnets in Network will be used. Multiple subnets of the same IP version are supported when PrimarySubnet is also set to identify which subnet should be used for services like load balancer VIP allocation.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -19507,6 +19507,12 @@ func schema_sigsk8sio_cluster_api_provider_openstack_api_v1beta1_OpenStackCluste
 									},
 								},
 							},
+						},
+					},
+					"primarySubnet": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PrimarySubnet identifies the primary subnet for the cluster when multiple subnets are specified in Subnets. It is used to determine the subnet for load balancer VIP allocation and node member registration. If not specified and multiple subnets exist, the first subnet in the resolved Subnets list is used.",
+							Ref:         ref("sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1.SubnetParam"),
 						},
 					},
 					"networkMTU": {
@@ -23610,7 +23616,7 @@ func schema_sigsk8sio_cluster_api_provider_openstack_api_v1beta2_OpenStackCluste
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "subnets specifies existing subnets to use if not ManagedSubnets are specified. All subnets must be in the network specified by Network. There can be zero, one, or two subnets. If no subnets are specified, all subnets in Network will be used. If 2 subnets are specified, one must be IPv4 and the other IPv6.",
+							Description: "subnets specifies existing subnets to use if not ManagedSubnets are specified. All subnets must be in the network specified by Network. If no subnets are specified, all subnets in Network will be used. Multiple subnets of the same IP version are supported when primarySubnet is also set to identify which subnet should be used for services like load balancer VIP allocation.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -23620,6 +23626,12 @@ func schema_sigsk8sio_cluster_api_provider_openstack_api_v1beta2_OpenStackCluste
 									},
 								},
 							},
+						},
+					},
+					"primarySubnet": {
+						SchemaProps: spec.SchemaProps{
+							Description: "primarySubnet identifies the primary subnet for the cluster when multiple subnets are specified in Subnets. It is used to determine the subnet for load balancer VIP allocation and node member registration. If not specified and multiple subnets exist, the first subnet in the resolved Subnets list is used.",
+							Ref:         ref("sigs.k8s.io/cluster-api-provider-openstack/api/v1beta2.SubnetParam"),
 						},
 					},
 					"managedRouter": {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -1951,6 +1951,96 @@ spec:
                   If left empty, the network will have the default MTU defined in Openstack network service.
                   To use this field, the Openstack installation requires the net-mtu neutron API extension.
                 type: integer
+              primarySubnet:
+                description: |-
+                  PrimarySubnet identifies the primary subnet for the cluster when multiple
+                  subnets are specified in Subnets. It is used to determine the subnet for
+                  load balancer VIP allocation and node member registration.
+                  If not specified and multiple subnets exist, the first subnet in the
+                  resolved Subnets list is used.
+                maxProperties: 1
+                minProperties: 1
+                properties:
+                  filter:
+                    description: Filter specifies a filter to select the subnet. It
+                      must match exactly one subnet.
+                    minProperties: 1
+                    properties:
+                      cidr:
+                        type: string
+                      description:
+                        type: string
+                      gatewayIP:
+                        type: string
+                      ipVersion:
+                        type: integer
+                      ipv6AddressMode:
+                        type: string
+                      ipv6RAMode:
+                        type: string
+                      name:
+                        type: string
+                      notTags:
+                        description: |-
+                          NotTags is a list of tags to filter by. If specified, resources which
+                          contain all of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          minLength: 1
+                          pattern: ^[^,]+$
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      notTagsAny:
+                        description: |-
+                          NotTagsAny is a list of tags to filter by. If specified, resources
+                          which contain any of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          minLength: 1
+                          pattern: ^[^,]+$
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      projectID:
+                        type: string
+                      tags:
+                        description: |-
+                          Tags is a list of tags to filter by. If specified, the resource must
+                          have all of the tags specified to be included in the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          minLength: 1
+                          pattern: ^[^,]+$
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      tagsAny:
+                        description: |-
+                          TagsAny is a list of tags to filter by. If specified, the resource
+                          must have at least one of the tags specified to be included in the
+                          result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          minLength: 1
+                          pattern: ^[^,]+$
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                    type: object
+                  id:
+                    description: ID is the uuid of the subnet. It will not be validated.
+                    format: uuid
+                    type: string
+                type: object
               router:
                 description: |-
                   Router specifies an existing router to be used if ManagedSubnets are
@@ -2033,9 +2123,10 @@ spec:
                 description: |-
                   Subnets specifies existing subnets to use if not ManagedSubnets are
                   specified. All subnets must be in the network specified by Network.
-                  There can be zero, one, or two subnets. If no subnets are specified,
-                  all subnets in Network will be used. If 2 subnets are specified, one
-                  must be IPv4 and the other IPv6.
+                  If no subnets are specified, all subnets in Network will be used.
+                  Multiple subnets of the same IP version are supported when PrimarySubnet
+                  is also set to identify which subnet should be used for services like
+                  load balancer VIP allocation.
                 items:
                   description: SubnetParam specifies an OpenStack subnet to use. It
                     may be specified by either ID or filter, but not both.
@@ -2122,7 +2213,6 @@ spec:
                       format: uuid
                       type: string
                   type: object
-                maxItems: 2
                 type: array
                 x-kubernetes-list-type: atomic
               tags:
@@ -4752,6 +4842,107 @@ spec:
                     format: uuid
                     type: string
                 type: object
+              primarySubnet:
+                description: |-
+                  primarySubnet identifies the primary subnet for the cluster when multiple
+                  subnets are specified in Subnets. It is used to determine the subnet for
+                  load balancer VIP allocation and node member registration.
+                  If not specified and multiple subnets exist, the first subnet in the
+                  resolved Subnets list is used.
+                maxProperties: 1
+                minProperties: 1
+                properties:
+                  filter:
+                    description: filter specifies a filter to select the subnet. It
+                      must match exactly one subnet.
+                    minProperties: 1
+                    properties:
+                      cidr:
+                        description: cidr filters subnets by CIDR.
+                        type: string
+                      description:
+                        description: description filters subnets by description.
+                        type: string
+                      gatewayIP:
+                        description: gatewayIP filters subnets by gateway IP.
+                        type: string
+                      ipVersion:
+                        description: ipVersion filters subnets by IP version.
+                        format: int32
+                        type: integer
+                      ipv6AddressMode:
+                        description: ipv6AddressMode filters subnets by IPv6 address
+                          mode.
+                        type: string
+                      ipv6RAMode:
+                        description: ipv6RAMode filters subnets by IPv6 Router Advertisement
+                          mode.
+                        type: string
+                      name:
+                        description: name filters subnets by name.
+                        type: string
+                      notTags:
+                        description: |-
+                          notTags is a list of tags to filter by. If specified, resources which
+                          contain all of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          minLength: 1
+                          pattern: ^[^,]+$
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      notTagsAny:
+                        description: |-
+                          notTagsAny is a list of tags to filter by. If specified, resources
+                          which contain any of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          minLength: 1
+                          pattern: ^[^,]+$
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      projectID:
+                        description: projectID filters subnets by project ID.
+                        type: string
+                      tags:
+                        description: |-
+                          tags is a list of tags to filter by. If specified, the resource must
+                          have all of the tags specified to be included in the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          minLength: 1
+                          pattern: ^[^,]+$
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      tagsAny:
+                        description: |-
+                          tagsAny is a list of tags to filter by. If specified, the resource
+                          must have at least one of the tags specified to be included in the
+                          result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          minLength: 1
+                          pattern: ^[^,]+$
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                    type: object
+                  id:
+                    description: id is the uuid of the subnet. It will not be validated.
+                    format: uuid
+                    type: string
+                type: object
               router:
                 description: |-
                   router specifies an existing router to be used if ManagedSubnets are
@@ -4837,9 +5028,10 @@ spec:
                 description: |-
                   subnets specifies existing subnets to use if not ManagedSubnets are
                   specified. All subnets must be in the network specified by Network.
-                  There can be zero, one, or two subnets. If no subnets are specified,
-                  all subnets in Network will be used. If 2 subnets are specified, one
-                  must be IPv4 and the other IPv6.
+                  If no subnets are specified, all subnets in Network will be used.
+                  Multiple subnets of the same IP version are supported when primarySubnet
+                  is also set to identify which subnet should be used for services like
+                  load balancer VIP allocation.
                 items:
                   description: SubnetParam specifies an OpenStack subnet to use. It
                     may be specified by either ID or filter, but not both.
@@ -4937,7 +5129,6 @@ spec:
                       format: uuid
                       type: string
                   type: object
-                maxItems: 2
                 type: array
                 x-kubernetes-list-type: atomic
               tags:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
@@ -1961,6 +1961,97 @@ spec:
                           If left empty, the network will have the default MTU defined in Openstack network service.
                           To use this field, the Openstack installation requires the net-mtu neutron API extension.
                         type: integer
+                      primarySubnet:
+                        description: |-
+                          PrimarySubnet identifies the primary subnet for the cluster when multiple
+                          subnets are specified in Subnets. It is used to determine the subnet for
+                          load balancer VIP allocation and node member registration.
+                          If not specified and multiple subnets exist, the first subnet in the
+                          resolved Subnets list is used.
+                        maxProperties: 1
+                        minProperties: 1
+                        properties:
+                          filter:
+                            description: Filter specifies a filter to select the subnet.
+                              It must match exactly one subnet.
+                            minProperties: 1
+                            properties:
+                              cidr:
+                                type: string
+                              description:
+                                type: string
+                              gatewayIP:
+                                type: string
+                              ipVersion:
+                                type: integer
+                              ipv6AddressMode:
+                                type: string
+                              ipv6RAMode:
+                                type: string
+                              name:
+                                type: string
+                              notTags:
+                                description: |-
+                                  NotTags is a list of tags to filter by. If specified, resources which
+                                  contain all of the given tags will be excluded from the result.
+                                items:
+                                  description: |-
+                                    NeutronTag represents a tag on a Neutron resource.
+                                    It may not be empty and may not contain commas.
+                                  minLength: 1
+                                  pattern: ^[^,]+$
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              notTagsAny:
+                                description: |-
+                                  NotTagsAny is a list of tags to filter by. If specified, resources
+                                  which contain any of the given tags will be excluded from the result.
+                                items:
+                                  description: |-
+                                    NeutronTag represents a tag on a Neutron resource.
+                                    It may not be empty and may not contain commas.
+                                  minLength: 1
+                                  pattern: ^[^,]+$
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              projectID:
+                                type: string
+                              tags:
+                                description: |-
+                                  Tags is a list of tags to filter by. If specified, the resource must
+                                  have all of the tags specified to be included in the result.
+                                items:
+                                  description: |-
+                                    NeutronTag represents a tag on a Neutron resource.
+                                    It may not be empty and may not contain commas.
+                                  minLength: 1
+                                  pattern: ^[^,]+$
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              tagsAny:
+                                description: |-
+                                  TagsAny is a list of tags to filter by. If specified, the resource
+                                  must have at least one of the tags specified to be included in the
+                                  result.
+                                items:
+                                  description: |-
+                                    NeutronTag represents a tag on a Neutron resource.
+                                    It may not be empty and may not contain commas.
+                                  minLength: 1
+                                  pattern: ^[^,]+$
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                            type: object
+                          id:
+                            description: ID is the uuid of the subnet. It will not
+                              be validated.
+                            format: uuid
+                            type: string
+                        type: object
                       router:
                         description: |-
                           Router specifies an existing router to be used if ManagedSubnets are
@@ -2044,9 +2135,10 @@ spec:
                         description: |-
                           Subnets specifies existing subnets to use if not ManagedSubnets are
                           specified. All subnets must be in the network specified by Network.
-                          There can be zero, one, or two subnets. If no subnets are specified,
-                          all subnets in Network will be used. If 2 subnets are specified, one
-                          must be IPv4 and the other IPv6.
+                          If no subnets are specified, all subnets in Network will be used.
+                          Multiple subnets of the same IP version are supported when PrimarySubnet
+                          is also set to identify which subnet should be used for services like
+                          load balancer VIP allocation.
                         items:
                           description: SubnetParam specifies an OpenStack subnet to
                             use. It may be specified by either ID or filter, but not
@@ -2135,7 +2227,6 @@ spec:
                               format: uuid
                               type: string
                           type: object
-                        maxItems: 2
                         type: array
                         x-kubernetes-list-type: atomic
                       tags:
@@ -4234,6 +4325,110 @@ spec:
                             format: uuid
                             type: string
                         type: object
+                      primarySubnet:
+                        description: |-
+                          primarySubnet identifies the primary subnet for the cluster when multiple
+                          subnets are specified in Subnets. It is used to determine the subnet for
+                          load balancer VIP allocation and node member registration.
+                          If not specified and multiple subnets exist, the first subnet in the
+                          resolved Subnets list is used.
+                        maxProperties: 1
+                        minProperties: 1
+                        properties:
+                          filter:
+                            description: filter specifies a filter to select the subnet.
+                              It must match exactly one subnet.
+                            minProperties: 1
+                            properties:
+                              cidr:
+                                description: cidr filters subnets by CIDR.
+                                type: string
+                              description:
+                                description: description filters subnets by description.
+                                type: string
+                              gatewayIP:
+                                description: gatewayIP filters subnets by gateway
+                                  IP.
+                                type: string
+                              ipVersion:
+                                description: ipVersion filters subnets by IP version.
+                                format: int32
+                                type: integer
+                              ipv6AddressMode:
+                                description: ipv6AddressMode filters subnets by IPv6
+                                  address mode.
+                                type: string
+                              ipv6RAMode:
+                                description: ipv6RAMode filters subnets by IPv6 Router
+                                  Advertisement mode.
+                                type: string
+                              name:
+                                description: name filters subnets by name.
+                                type: string
+                              notTags:
+                                description: |-
+                                  notTags is a list of tags to filter by. If specified, resources which
+                                  contain all of the given tags will be excluded from the result.
+                                items:
+                                  description: |-
+                                    NeutronTag represents a tag on a Neutron resource.
+                                    It may not be empty and may not contain commas.
+                                  minLength: 1
+                                  pattern: ^[^,]+$
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              notTagsAny:
+                                description: |-
+                                  notTagsAny is a list of tags to filter by. If specified, resources
+                                  which contain any of the given tags will be excluded from the result.
+                                items:
+                                  description: |-
+                                    NeutronTag represents a tag on a Neutron resource.
+                                    It may not be empty and may not contain commas.
+                                  minLength: 1
+                                  pattern: ^[^,]+$
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              projectID:
+                                description: projectID filters subnets by project
+                                  ID.
+                                type: string
+                              tags:
+                                description: |-
+                                  tags is a list of tags to filter by. If specified, the resource must
+                                  have all of the tags specified to be included in the result.
+                                items:
+                                  description: |-
+                                    NeutronTag represents a tag on a Neutron resource.
+                                    It may not be empty and may not contain commas.
+                                  minLength: 1
+                                  pattern: ^[^,]+$
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              tagsAny:
+                                description: |-
+                                  tagsAny is a list of tags to filter by. If specified, the resource
+                                  must have at least one of the tags specified to be included in the
+                                  result.
+                                items:
+                                  description: |-
+                                    NeutronTag represents a tag on a Neutron resource.
+                                    It may not be empty and may not contain commas.
+                                  minLength: 1
+                                  pattern: ^[^,]+$
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                            type: object
+                          id:
+                            description: id is the uuid of the subnet. It will not
+                              be validated.
+                            format: uuid
+                            type: string
+                        type: object
                       router:
                         description: |-
                           router specifies an existing router to be used if ManagedSubnets are
@@ -4321,9 +4516,10 @@ spec:
                         description: |-
                           subnets specifies existing subnets to use if not ManagedSubnets are
                           specified. All subnets must be in the network specified by Network.
-                          There can be zero, one, or two subnets. If no subnets are specified,
-                          all subnets in Network will be used. If 2 subnets are specified, one
-                          must be IPv4 and the other IPv6.
+                          If no subnets are specified, all subnets in Network will be used.
+                          Multiple subnets of the same IP version are supported when primarySubnet
+                          is also set to identify which subnet should be used for services like
+                          load balancer VIP allocation.
                         items:
                           description: SubnetParam specifies an OpenStack subnet to
                             use. It may be specified by either ID or filter, but not
@@ -4425,7 +4621,6 @@ spec:
                               format: uuid
                               type: string
                           type: object
-                        maxItems: 2
                         type: array
                         x-kubernetes-list-type: atomic
                       tags:

--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -1146,9 +1146,6 @@ func getClusterSubnets(networkingService *networking.Service, openStackCluster *
 			}
 			return nil, err
 		}
-		if len(clusterSubnets) > 2 {
-			return nil, fmt.Errorf("more than two subnets found in the Network. Specify the subnets in the OpenStackCluster.Spec instead")
-		}
 	} else {
 		for subnet := range openStackClusterSubnets {
 			filteredSubnet, err := networkingService.GetNetworkSubnetByParam(networkID, &openStackClusterSubnets[subnet])

--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -697,7 +697,14 @@ func openStackMachineSpecToOpenStackServerSpec(openStackMachineSpec *infrav1.Ope
 	}
 
 	var clusterSubnets []infrav1.FixedIP
-	if len(openStackCluster.Spec.Subnets) > 0 {
+	if openStackCluster.Spec.PrimarySubnet != nil {
+		// When a primary subnet is set, restrict node ports to that subnet only.
+		// This allows an administrator to direct new nodes to a specific subnet,
+		// e.g. when migrating away from an exhausted subnet.
+		clusterSubnets = []infrav1.FixedIP{
+			{Subnet: openStackCluster.Spec.PrimarySubnet},
+		}
+	} else if len(openStackCluster.Spec.Subnets) > 0 {
 		clusterSubnets = make([]infrav1.FixedIP, len(openStackCluster.Spec.Subnets))
 		for idx, sn := range openStackCluster.Spec.Subnets {
 			clusterSubnets[idx] = infrav1.FixedIP{

--- a/controllers/openstackmachine_controller_test.go
+++ b/controllers/openstackmachine_controller_test.go
@@ -45,6 +45,8 @@ import (
 const (
 	networkUUID                   = "d412171b-9fd7-41c1-95a6-c24e5953974d"
 	subnetUUID                    = "d2d8d98d-b234-477e-a547-868b7cb5d6a5"
+	secondSubnetUUID              = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+	primarySubnetUUID             = "f9e8d7c6-b5a4-3210-fedc-ba9876543210"
 	extraSecurityGroupUUID        = "514bb2d8-3390-4a3b-86a7-7864ba57b329"
 	controlPlaneSecurityGroupUUID = "c9817a91-4821-42db-8367-2301002ab659"
 	workerSecurityGroupUUID       = "9c6c0d28-03c9-436c-815d-58440ac2c1c8"
@@ -178,6 +180,74 @@ func TestOpenStackMachineSpecToOpenStackServerSpec(t *testing.T) {
 						ID: ptr.To(subnetUUID),
 					},
 				},
+			},
+		},
+	}
+	openStackClusterWithMultipleSubnets := &infrav1.OpenStackCluster{
+		Spec: infrav1.OpenStackClusterSpec{
+			ManagedSecurityGroups: &infrav1.ManagedSecurityGroups{},
+			Subnets: []infrav1.SubnetParam{
+				{ID: ptr.To(subnetUUID)},
+				{ID: ptr.To(secondSubnetUUID)},
+			},
+		},
+		Status: infrav1.OpenStackClusterStatus{
+			WorkerSecurityGroup: &infrav1.SecurityGroupStatus{
+				ID: workerSecurityGroupUUID,
+			},
+			Network: &infrav1.NetworkStatusWithSubnets{
+				NetworkStatus: infrav1.NetworkStatus{
+					ID: networkUUID,
+				},
+			},
+		},
+	}
+	openStackClusterWithPrimarySubnet := &infrav1.OpenStackCluster{
+		Spec: infrav1.OpenStackClusterSpec{
+			ManagedSecurityGroups: &infrav1.ManagedSecurityGroups{},
+			Subnets: []infrav1.SubnetParam{
+				{ID: ptr.To(subnetUUID)},
+				{ID: ptr.To(secondSubnetUUID)},
+			},
+			PrimarySubnet: &infrav1.SubnetParam{
+				ID: ptr.To(primarySubnetUUID),
+			},
+		},
+		Status: infrav1.OpenStackClusterStatus{
+			WorkerSecurityGroup: &infrav1.SecurityGroupStatus{
+				ID: workerSecurityGroupUUID,
+			},
+			Network: &infrav1.NetworkStatusWithSubnets{
+				NetworkStatus: infrav1.NetworkStatus{
+					ID: networkUUID,
+				},
+			},
+		},
+	}
+	portOptsWithMultipleSubnets := []infrav1.PortOpts{
+		{
+			Network: &infrav1.NetworkParam{
+				ID: ptr.To(networkUUID),
+			},
+			SecurityGroups: []infrav1.SecurityGroupParam{
+				{ID: ptr.To(workerSecurityGroupUUID)},
+			},
+			FixedIPs: []infrav1.FixedIP{
+				{Subnet: &infrav1.SubnetParam{ID: ptr.To(subnetUUID)}},
+				{Subnet: &infrav1.SubnetParam{ID: ptr.To(secondSubnetUUID)}},
+			},
+		},
+	}
+	portOptsWithPrimarySubnet := []infrav1.PortOpts{
+		{
+			Network: &infrav1.NetworkParam{
+				ID: ptr.To(networkUUID),
+			},
+			SecurityGroups: []infrav1.SecurityGroupParam{
+				{ID: ptr.To(workerSecurityGroupUUID)},
+			},
+			FixedIPs: []infrav1.FixedIP{
+				{Subnet: &infrav1.SubnetParam{ID: ptr.To(primarySubnetUUID)}},
 			},
 		},
 	}
@@ -342,6 +412,50 @@ func TestOpenStackMachineSpecToOpenStackServerSpec(t *testing.T) {
 					Network:        &infrav1.NetworkParam{ID: ptr.To(networkUUID)},
 					SecurityGroups: []infrav1.SecurityGroupParam{{ID: ptr.To(workerSecurityGroupUUID)}},
 				}},
+				Tags:        tags,
+				UserDataRef: userData,
+			},
+		},
+		{
+			name:    "multiple subnets without primarySubnet: port gets all subnets as FixedIPs",
+			cluster: openStackClusterWithMultipleSubnets,
+			spec: &infrav1.OpenStackMachineSpec{
+				Flavor: infrav1.FlavorParam{
+					Filter: &infrav1.FlavorFilter{
+						Name: ptr.To(flavorName),
+					},
+				},
+				Image:      image,
+				SSHKeyName: sshKeyName,
+			},
+			want: &infrav1alpha1.OpenStackServerSpec{
+				Flavor:      ptr.To(flavorName),
+				IdentityRef: identityRef,
+				Image:       image,
+				SSHKeyName:  sshKeyName,
+				Ports:       portOptsWithMultipleSubnets,
+				Tags:        tags,
+				UserDataRef: userData,
+			},
+		},
+		{
+			name:    "primarySubnet set: port FixedIPs restricted to primarySubnet only",
+			cluster: openStackClusterWithPrimarySubnet,
+			spec: &infrav1.OpenStackMachineSpec{
+				Flavor: infrav1.FlavorParam{
+					Filter: &infrav1.FlavorFilter{
+						Name: ptr.To(flavorName),
+					},
+				},
+				Image:      image,
+				SSHKeyName: sshKeyName,
+			},
+			want: &infrav1alpha1.OpenStackServerSpec{
+				Flavor:      ptr.To(flavorName),
+				IdentityRef: identityRef,
+				Image:       image,
+				SSHKeyName:  sshKeyName,
+				Ports:       portOptsWithPrimarySubnet,
 				Tags:        tags,
 				UserDataRef: userData,
 			},

--- a/docs/book/src/api/v1beta1/api.md
+++ b/docs/book/src/api/v1beta1/api.md
@@ -126,9 +126,28 @@ are specified.</p>
 <em>(Optional)</em>
 <p>Subnets specifies existing subnets to use if not ManagedSubnets are
 specified. All subnets must be in the network specified by Network.
-There can be zero, one, or two subnets. If no subnets are specified,
-all subnets in Network will be used. If 2 subnets are specified, one
-must be IPv4 and the other IPv6.</p>
+If no subnets are specified, all subnets in Network will be used.
+Multiple subnets of the same IP version are supported when PrimarySubnet
+is also set to identify which subnet should be used for services like
+load balancer VIP allocation.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>primarySubnet</code><br/>
+<em>
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.SubnetParam">
+SubnetParam
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PrimarySubnet identifies the primary subnet for the cluster when multiple
+subnets are specified in Subnets. It is used to determine the subnet for
+load balancer VIP allocation and node member registration.
+If not specified and multiple subnets exist, the first subnet in the
+resolved Subnets list is used.</p>
 </td>
 </tr>
 <tr>
@@ -2474,9 +2493,28 @@ are specified.</p>
 <em>(Optional)</em>
 <p>Subnets specifies existing subnets to use if not ManagedSubnets are
 specified. All subnets must be in the network specified by Network.
-There can be zero, one, or two subnets. If no subnets are specified,
-all subnets in Network will be used. If 2 subnets are specified, one
-must be IPv4 and the other IPv6.</p>
+If no subnets are specified, all subnets in Network will be used.
+Multiple subnets of the same IP version are supported when PrimarySubnet
+is also set to identify which subnet should be used for services like
+load balancer VIP allocation.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>primarySubnet</code><br/>
+<em>
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.SubnetParam">
+SubnetParam
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PrimarySubnet identifies the primary subnet for the cluster when multiple
+subnets are specified in Subnets. It is used to determine the subnet for
+load balancer VIP allocation and node member registration.
+If not specified and multiple subnets exist, the first subnet in the
+resolved Subnets list is used.</p>
 </td>
 </tr>
 <tr>
@@ -3085,9 +3123,28 @@ are specified.</p>
 <em>(Optional)</em>
 <p>Subnets specifies existing subnets to use if not ManagedSubnets are
 specified. All subnets must be in the network specified by Network.
-There can be zero, one, or two subnets. If no subnets are specified,
-all subnets in Network will be used. If 2 subnets are specified, one
-must be IPv4 and the other IPv6.</p>
+If no subnets are specified, all subnets in Network will be used.
+Multiple subnets of the same IP version are supported when PrimarySubnet
+is also set to identify which subnet should be used for services like
+load balancer VIP allocation.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>primarySubnet</code><br/>
+<em>
+<a href="#infrastructure.cluster.x-k8s.io/v1beta1.SubnetParam">
+SubnetParam
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PrimarySubnet identifies the primary subnet for the cluster when multiple
+subnets are specified in Subnets. It is used to determine the subnet for
+load balancer VIP allocation and node member registration.
+If not specified and multiple subnets exist, the first subnet in the
+resolved Subnets list is used.</p>
 </td>
 </tr>
 <tr>

--- a/docs/book/src/api/v1beta2/api.md
+++ b/docs/book/src/api/v1beta2/api.md
@@ -100,9 +100,28 @@ subnet is supported. If you leave this empty, no network will be created.</p>
 <em>(Optional)</em>
 <p>subnets specifies existing subnets to use if not ManagedSubnets are
 specified. All subnets must be in the network specified by Network.
-There can be zero, one, or two subnets. If no subnets are specified,
-all subnets in Network will be used. If 2 subnets are specified, one
-must be IPv4 and the other IPv6.</p>
+If no subnets are specified, all subnets in Network will be used.
+Multiple subnets of the same IP version are supported when primarySubnet
+is also set to identify which subnet should be used for services like
+load balancer VIP allocation.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>primarySubnet</code><br/>
+<em>
+<a href="#infrastructure.cluster.x-k8s.io/v1beta2.SubnetParam">
+SubnetParam
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>primarySubnet identifies the primary subnet for the cluster when multiple
+subnets are specified in Subnets. It is used to determine the subnet for
+load balancer VIP allocation and node member registration.
+If not specified and multiple subnets exist, the first subnet in the
+resolved Subnets list is used.</p>
 </td>
 </tr>
 <tr>
@@ -2667,9 +2686,28 @@ subnet is supported. If you leave this empty, no network will be created.</p>
 <em>(Optional)</em>
 <p>subnets specifies existing subnets to use if not ManagedSubnets are
 specified. All subnets must be in the network specified by Network.
-There can be zero, one, or two subnets. If no subnets are specified,
-all subnets in Network will be used. If 2 subnets are specified, one
-must be IPv4 and the other IPv6.</p>
+If no subnets are specified, all subnets in Network will be used.
+Multiple subnets of the same IP version are supported when primarySubnet
+is also set to identify which subnet should be used for services like
+load balancer VIP allocation.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>primarySubnet</code><br/>
+<em>
+<a href="#infrastructure.cluster.x-k8s.io/v1beta2.SubnetParam">
+SubnetParam
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>primarySubnet identifies the primary subnet for the cluster when multiple
+subnets are specified in Subnets. It is used to determine the subnet for
+load balancer VIP allocation and node member registration.
+If not specified and multiple subnets exist, the first subnet in the
+resolved Subnets list is used.</p>
 </td>
 </tr>
 <tr>
@@ -3132,9 +3170,28 @@ subnet is supported. If you leave this empty, no network will be created.</p>
 <em>(Optional)</em>
 <p>subnets specifies existing subnets to use if not ManagedSubnets are
 specified. All subnets must be in the network specified by Network.
-There can be zero, one, or two subnets. If no subnets are specified,
-all subnets in Network will be used. If 2 subnets are specified, one
-must be IPv4 and the other IPv6.</p>
+If no subnets are specified, all subnets in Network will be used.
+Multiple subnets of the same IP version are supported when primarySubnet
+is also set to identify which subnet should be used for services like
+load balancer VIP allocation.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>primarySubnet</code><br/>
+<em>
+<a href="#infrastructure.cluster.x-k8s.io/v1beta2.SubnetParam">
+SubnetParam
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>primarySubnet identifies the primary subnet for the cluster when multiple
+subnets are specified in Subnets. It is used to determine the subnet for
+load balancer VIP allocation and node member registration.
+If not specified and multiple subnets exist, the first subnet in the
+resolved Subnets list is used.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/cloud/services/loadbalancer/loadbalancer.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer.go
@@ -55,6 +55,29 @@ const (
 	poolMemberProvisioningStatusActive          = "ACTIVE"
 )
 
+// getPrimarySubnetID returns the ID of the primary cluster subnet for use in
+// load balancer VIP allocation and member registration.
+// If PrimarySubnet is specified in the cluster spec, it is resolved via
+// GetNetworkSubnetByParam scoped to the cluster network, which validates
+// membership and supports both id and filter forms of SubnetParam.
+// Otherwise the first subnet in the cluster status is used.
+func (s *Service) getPrimarySubnetID(openStackCluster *infrav1.OpenStackCluster) (string, error) {
+	subnets := openStackCluster.Status.Network.Subnets
+	if len(subnets) == 0 {
+		return "", fmt.Errorf("no subnets available in cluster status")
+	}
+
+	if openStackCluster.Spec.PrimarySubnet == nil {
+		return subnets[0].ID, nil
+	}
+
+	subnet, err := s.networkingService.GetNetworkSubnetByParam(openStackCluster.Status.Network.ID, openStackCluster.Spec.PrimarySubnet)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve primarySubnet: %w", err)
+	}
+	return subnet.ID, nil
+}
+
 // Default values for Monitor, sync with `kubebuilder:default` annotations on APIServerLoadBalancerMonitor object.
 const (
 	defaultMonitorDelay          = 10
@@ -316,9 +339,13 @@ func (s *Service) getOrCreateAPILoadBalancer(openStackCluster *infrav1.OpenStack
 	}
 
 	if vipNetworkID == "" && vipSubnetID == "" {
-		// keep the default and create the VIP on the first cluster subnet
-		vipSubnetID = openStackCluster.Status.Network.Subnets[0].ID
-		s.scope.Logger().V(2).Info("No load balancer network specified, creating load balancer in the default subnet", "subnetID", vipSubnetID, "name", loadBalancerName)
+		// No explicit LB network specified — use the primary cluster subnet.
+		var err error
+		vipSubnetID, err = s.getPrimarySubnetID(openStackCluster)
+		if err != nil {
+			return nil, err
+		}
+		s.scope.Logger().V(2).Info("No load balancer network specified, creating load balancer in the primary subnet", "subnetID", vipSubnetID, "name", loadBalancerName)
 	} else {
 		s.scope.Logger().V(2).Info("Creating load balancer in subnet", "subnetID", vipSubnetID, "name", loadBalancerName)
 	}
@@ -720,7 +747,11 @@ func (s *Service) ReconcileLoadBalancerMember(openStackCluster *infrav1.OpenStac
 		}
 
 		if openStackCluster.Status.Network.ID != openStackCluster.Status.APIServerManagedLoadBalancer.LoadBalancerNetwork.ID {
-			lbMemberOpts.SubnetID = openStackCluster.Status.Network.Subnets[0].ID
+			primarySubnetID, err := s.getPrimarySubnetID(openStackCluster)
+			if err != nil {
+				return err
+			}
+			lbMemberOpts.SubnetID = primarySubnetID
 		}
 
 		if _, err := s.waitForLoadBalancerActive(lbID); err != nil {

--- a/pkg/cloud/services/loadbalancer/loadbalancer_test.go
+++ b/pkg/cloud/services/loadbalancer/loadbalancer_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/monitors"
 	"github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/pools"
 	"github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/providers"
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/subnets"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -804,6 +805,7 @@ func Test_getOrCreateAPILoadBalancer(t *testing.T) {
 	lbtests := []struct {
 		name               string
 		openStackCluster   *infrav1.OpenStackCluster
+		expectNetwork      func(m *mock.MockNetworkClientMockRecorder)
 		expectLoadBalancer func(m *mock.MockLbClientMockRecorder)
 		want               *loadbalancers.LoadBalancer
 		wantError          error
@@ -811,6 +813,7 @@ func Test_getOrCreateAPILoadBalancer(t *testing.T) {
 		{
 			name:             "nothing exists",
 			openStackCluster: &infrav1.OpenStackCluster{},
+			expectNetwork:    func(*mock.MockNetworkClientMockRecorder) {},
 			expectLoadBalancer: func(m *mock.MockLbClientMockRecorder) {
 				m.ListLoadBalancers(gomock.Any()).Return([]loadbalancers.LoadBalancer{}, nil)
 			},
@@ -820,6 +823,7 @@ func Test_getOrCreateAPILoadBalancer(t *testing.T) {
 		{
 			name:             "loadbalancer already exists",
 			openStackCluster: &infrav1.OpenStackCluster{},
+			expectNetwork:    func(*mock.MockNetworkClientMockRecorder) {},
 			expectLoadBalancer: func(m *mock.MockLbClientMockRecorder) {
 				m.ListLoadBalancers(gomock.Any()).Return([]loadbalancers.LoadBalancer{{ID: "AAAAA"}}, nil)
 			},
@@ -842,6 +846,7 @@ func Test_getOrCreateAPILoadBalancer(t *testing.T) {
 					},
 				},
 			},
+			expectNetwork: func(*mock.MockNetworkClientMockRecorder) {},
 			expectLoadBalancer: func(m *mock.MockLbClientMockRecorder) {
 				m.ListLoadBalancers(gomock.Any()).Return([]loadbalancers.LoadBalancer{}, nil)
 				m.ListLoadBalancerProviders().Return(octaviaProviders, nil)
@@ -881,6 +886,7 @@ func Test_getOrCreateAPILoadBalancer(t *testing.T) {
 					},
 				},
 			},
+			expectNetwork: func(*mock.MockNetworkClientMockRecorder) {},
 			expectLoadBalancer: func(m *mock.MockLbClientMockRecorder) {
 				m.ListLoadBalancers(gomock.Any()).Return([]loadbalancers.LoadBalancer{}, nil)
 				m.ListLoadBalancerProviders().Return(octaviaProviders, nil)
@@ -918,6 +924,7 @@ func Test_getOrCreateAPILoadBalancer(t *testing.T) {
 					},
 				},
 			},
+			expectNetwork: func(*mock.MockNetworkClientMockRecorder) {},
 			expectLoadBalancer: func(m *mock.MockLbClientMockRecorder) {
 				m.ListLoadBalancers(gomock.Any()).Return([]loadbalancers.LoadBalancer{}, nil)
 				m.ListLoadBalancerProviders().Return(octaviaProviders, nil)
@@ -932,6 +939,49 @@ func Test_getOrCreateAPILoadBalancer(t *testing.T) {
 				VipSubnetID: "aaaaaaaa-bbbb-cccc-dddd-222222222222",
 			},
 		},
+		{
+			name: "loadbalancer VIP uses primarySubnet when set",
+			openStackCluster: &infrav1.OpenStackCluster{
+				Spec: infrav1.OpenStackClusterSpec{
+					PrimarySubnet: &infrav1.SubnetParam{
+						ID: ptr.To("aaaaaaaa-bbbb-cccc-dddd-444444444444"),
+					},
+				},
+				Status: infrav1.OpenStackClusterStatus{
+					Network: &infrav1.NetworkStatusWithSubnets{
+						NetworkStatus: infrav1.NetworkStatus{
+							ID: "aaaaaaaa-bbbb-cccc-dddd-111111111111",
+						},
+						Subnets: []infrav1.Subnet{
+							{ID: "aaaaaaaa-bbbb-cccc-dddd-222222222222"},
+							{ID: "aaaaaaaa-bbbb-cccc-dddd-333333333333"},
+							{ID: "aaaaaaaa-bbbb-cccc-dddd-444444444444"},
+						},
+					},
+					APIServerManagedLoadBalancer: &infrav1.LoadBalancer{
+						LoadBalancerNetwork: nil,
+					},
+				},
+			},
+			expectNetwork: func(m *mock.MockNetworkClientMockRecorder) {
+				m.GetSubnet("aaaaaaaa-bbbb-cccc-dddd-444444444444").Return(&subnets.Subnet{
+					ID:        "aaaaaaaa-bbbb-cccc-dddd-444444444444",
+					NetworkID: "aaaaaaaa-bbbb-cccc-dddd-111111111111",
+				}, nil)
+			},
+			expectLoadBalancer: func(m *mock.MockLbClientMockRecorder) {
+				m.ListLoadBalancers(gomock.Any()).Return([]loadbalancers.LoadBalancer{}, nil)
+				m.ListLoadBalancerProviders().Return(octaviaProviders, nil)
+				m.CreateLoadBalancer(gomock.Any()).Return(&loadbalancers.LoadBalancer{
+					ID:          "AAAAA",
+					VipSubnetID: "aaaaaaaa-bbbb-cccc-dddd-444444444444",
+				}, nil)
+			},
+			want: &loadbalancers.LoadBalancer{
+				ID:          "AAAAA",
+				VipSubnetID: "aaaaaaaa-bbbb-cccc-dddd-444444444444",
+			},
+		},
 	}
 	for _, tt := range lbtests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -942,6 +992,7 @@ func Test_getOrCreateAPILoadBalancer(t *testing.T) {
 			lbs, err := NewService(scope.NewWithLogger(mockScopeFactory, log))
 			g.Expect(err).NotTo(HaveOccurred())
 
+			tt.expectNetwork(mockScopeFactory.NetworkClient.EXPECT())
 			tt.expectLoadBalancer(mockScopeFactory.LbClient.EXPECT())
 			lb, err := lbs.getOrCreateAPILoadBalancer(tt.openStackCluster, "AAAAA")
 			if tt.wantError != nil {

--- a/pkg/generated/applyconfiguration/api/v1beta1/openstackclusterspec.go
+++ b/pkg/generated/applyconfiguration/api/v1beta1/openstackclusterspec.go
@@ -39,10 +39,17 @@ type OpenStackClusterSpecApplyConfiguration struct {
 	Network *NetworkParamApplyConfiguration `json:"network,omitempty"`
 	// Subnets specifies existing subnets to use if not ManagedSubnets are
 	// specified. All subnets must be in the network specified by Network.
-	// There can be zero, one, or two subnets. If no subnets are specified,
-	// all subnets in Network will be used. If 2 subnets are specified, one
-	// must be IPv4 and the other IPv6.
+	// If no subnets are specified, all subnets in Network will be used.
+	// Multiple subnets of the same IP version are supported when PrimarySubnet
+	// is also set to identify which subnet should be used for services like
+	// load balancer VIP allocation.
 	Subnets []SubnetParamApplyConfiguration `json:"subnets,omitempty"`
+	// PrimarySubnet identifies the primary subnet for the cluster when multiple
+	// subnets are specified in Subnets. It is used to determine the subnet for
+	// load balancer VIP allocation and node member registration.
+	// If not specified and multiple subnets exist, the first subnet in the
+	// resolved Subnets list is used.
+	PrimarySubnet *SubnetParamApplyConfiguration `json:"primarySubnet,omitempty"`
 	// NetworkMTU sets the maximum transmission unit (MTU) value to address fragmentation for the private network ID.
 	// This value will be used only if the Cluster actuator creates the network.
 	// If left empty, the network will have the default MTU defined in Openstack network service.
@@ -186,6 +193,14 @@ func (b *OpenStackClusterSpecApplyConfiguration) WithSubnets(values ...*SubnetPa
 		}
 		b.Subnets = append(b.Subnets, *values[i])
 	}
+	return b
+}
+
+// WithPrimarySubnet sets the PrimarySubnet field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the PrimarySubnet field is set to the value of the last call.
+func (b *OpenStackClusterSpecApplyConfiguration) WithPrimarySubnet(value *SubnetParamApplyConfiguration) *OpenStackClusterSpecApplyConfiguration {
+	b.PrimarySubnet = value
 	return b
 }
 

--- a/pkg/generated/applyconfiguration/api/v1beta2/openstackclusterspec.go
+++ b/pkg/generated/applyconfiguration/api/v1beta2/openstackclusterspec.go
@@ -33,10 +33,17 @@ type OpenStackClusterSpecApplyConfiguration struct {
 	ManagedSubnets []SubnetSpecApplyConfiguration `json:"managedSubnets,omitempty"`
 	// subnets specifies existing subnets to use if not ManagedSubnets are
 	// specified. All subnets must be in the network specified by Network.
-	// There can be zero, one, or two subnets. If no subnets are specified,
-	// all subnets in Network will be used. If 2 subnets are specified, one
-	// must be IPv4 and the other IPv6.
+	// If no subnets are specified, all subnets in Network will be used.
+	// Multiple subnets of the same IP version are supported when primarySubnet
+	// is also set to identify which subnet should be used for services like
+	// load balancer VIP allocation.
 	Subnets []SubnetParamApplyConfiguration `json:"subnets,omitempty"`
+	// primarySubnet identifies the primary subnet for the cluster when multiple
+	// subnets are specified in Subnets. It is used to determine the subnet for
+	// load balancer VIP allocation and node member registration.
+	// If not specified and multiple subnets exist, the first subnet in the
+	// resolved Subnets list is used.
+	PrimarySubnet *SubnetParamApplyConfiguration `json:"primarySubnet,omitempty"`
 	// managedRouter specifies attributes of the router. The values are used only
 	// if the Cluster actuator creates the router.
 	ManagedRouter *ManagedRouterApplyConfiguration `json:"managedRouter,omitempty"`
@@ -135,6 +142,14 @@ func (b *OpenStackClusterSpecApplyConfiguration) WithSubnets(values ...*SubnetPa
 		}
 		b.Subnets = append(b.Subnets, *values[i])
 	}
+	return b
+}
+
+// WithPrimarySubnet sets the PrimarySubnet field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the PrimarySubnet field is set to the value of the last call.
+func (b *OpenStackClusterSpecApplyConfiguration) WithPrimarySubnet(value *SubnetParamApplyConfiguration) *OpenStackClusterSpecApplyConfiguration {
+	b.PrimarySubnet = value
 	return b
 }
 

--- a/pkg/generated/applyconfiguration/internal/internal.go
+++ b/pkg/generated/applyconfiguration/internal/internal.go
@@ -933,6 +933,9 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: networkMTU
       type:
         scalar: numeric
+    - name: primarySubnet
+      type:
+        namedType: io.k8s.sigs.cluster-api-provider-openstack.api.v1beta1.SubnetParam
     - name: router
       type:
         namedType: io.k8s.sigs.cluster-api-provider-openstack.api.v1beta1.RouterParam
@@ -2278,6 +2281,9 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: network
       type:
         namedType: io.k8s.sigs.cluster-api-provider-openstack.api.v1beta2.NetworkParam
+    - name: primarySubnet
+      type:
+        namedType: io.k8s.sigs.cluster-api-provider-openstack.api.v1beta2.SubnetParam
     - name: router
       type:
         namedType: io.k8s.sigs.cluster-api-provider-openstack.api.v1beta2.RouterParam

--- a/pkg/utils/controllers/controllers.go
+++ b/pkg/utils/controllers/controllers.go
@@ -27,26 +27,15 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1beta2"
 )
 
-// ValidateSubnets validates if the amount of IPv4 and IPv6 subnets is allowed by OpenStackCluster.
+// ValidateSubnets validates that all subnet CIDRs are parseable.
+// Multiple subnets of the same IP version are allowed; use PrimarySubnet to
+// specify which subnet should be used for load balancer VIP allocation and
+// member registration when multiple subnets are present.
 func ValidateSubnets(subnets []infrav1.Subnet) error {
-	isIPv6 := []bool{false, false}
-	for i, subnet := range subnets {
-		ip, _, err := net.ParseCIDR(subnet.CIDR)
-		if err != nil {
-			return err
+	for _, subnet := range subnets {
+		if _, _, err := net.ParseCIDR(subnet.CIDR); err != nil {
+			return fmt.Errorf("invalid CIDR %q in subnet %q: %w", subnet.CIDR, subnet.ID, err)
 		}
-
-		if ip.To4() == nil {
-			isIPv6[i] = true
-		}
-	}
-
-	if len(subnets) > 1 && isIPv6[0] == isIPv6[1] {
-		ethertype := 4
-		if isIPv6[0] {
-			ethertype = 6
-		}
-		return fmt.Errorf("multiple IPv%d Subnet not allowed on OpenStackCluster", ethertype)
 	}
 	return nil
 }

--- a/pkg/utils/controllers/controllers_test.go
+++ b/pkg/utils/controllers/controllers_test.go
@@ -62,7 +62,7 @@ func Test_validateSubnets(t *testing.T) {
 					CIDR: "10.0.0.0/24",
 				},
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "multiple IPv6 subnets",
@@ -71,10 +71,25 @@ func Test_validateSubnets(t *testing.T) {
 					CIDR: "2001:db8:2222:5555::/64",
 				},
 				{
+					CIDR: "2001:db8:2222:6666::/64",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "three subnets mixed IP versions",
+			subnets: []infrav1.Subnet{
+				{
+					CIDR: "192.168.0.0/24",
+				},
+				{
+					CIDR: "10.0.0.0/24",
+				},
+				{
 					CIDR: "2001:db8:2222:5555::/64",
 				},
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "invalid IP address",

--- a/pkg/webhooks/openstackcluster_webhook.go
+++ b/pkg/webhooks/openstackcluster_webhook.go
@@ -248,6 +248,11 @@ func (*openStackClusterWebhook) ValidateUpdate(_ context.Context, oldObj, newObj
 		}
 	}
 
+	// Allow changes to primarySubnet to support directing new nodes to a
+	// different subnet, e.g. when migrating away from an exhausted subnet.
+	oldObj.Spec.PrimarySubnet = nil
+	newObj.Spec.PrimarySubnet = nil
+
 	// Allow transitioning spec.network from filter to id and spec.subnets from
 	// filter to id. This lets users pin to resolved IDs after initial creation.
 	if newObj.Spec.Network != nil && oldObj.Spec.Network != nil && oldObj.Status.Network != nil {

--- a/pkg/webhooks/openstackcluster_webhook_test.go
+++ b/pkg/webhooks/openstackcluster_webhook_test.go
@@ -1409,6 +1409,78 @@ func TestOpenStackCluster_ValidateUpdate(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "Setting PrimarySubnet is allowed",
+			oldCluster: &infrav1.OpenStackCluster{
+				Spec: infrav1.OpenStackClusterSpec{
+					IdentityRef: infrav1.OpenStackIdentityReference{
+						Name:      "foobar",
+						CloudName: "foobar",
+					},
+				},
+			},
+			newCluster: &infrav1.OpenStackCluster{
+				Spec: infrav1.OpenStackClusterSpec{
+					IdentityRef: infrav1.OpenStackIdentityReference{
+						Name:      "foobar",
+						CloudName: "foobar",
+					},
+					PrimarySubnet: &infrav1.SubnetParam{
+						ID: ptr.To("aaaaaaaa-bbbb-cccc-dddd-111111111111"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Changing PrimarySubnet is allowed",
+			oldCluster: &infrav1.OpenStackCluster{
+				Spec: infrav1.OpenStackClusterSpec{
+					IdentityRef: infrav1.OpenStackIdentityReference{
+						Name:      "foobar",
+						CloudName: "foobar",
+					},
+					PrimarySubnet: &infrav1.SubnetParam{
+						ID: ptr.To("aaaaaaaa-bbbb-cccc-dddd-111111111111"),
+					},
+				},
+			},
+			newCluster: &infrav1.OpenStackCluster{
+				Spec: infrav1.OpenStackClusterSpec{
+					IdentityRef: infrav1.OpenStackIdentityReference{
+						Name:      "foobar",
+						CloudName: "foobar",
+					},
+					PrimarySubnet: &infrav1.SubnetParam{
+						ID: ptr.To("aaaaaaaa-bbbb-cccc-dddd-222222222222"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Clearing PrimarySubnet is allowed",
+			oldCluster: &infrav1.OpenStackCluster{
+				Spec: infrav1.OpenStackClusterSpec{
+					IdentityRef: infrav1.OpenStackIdentityReference{
+						Name:      "foobar",
+						CloudName: "foobar",
+					},
+					PrimarySubnet: &infrav1.SubnetParam{
+						ID: ptr.To("aaaaaaaa-bbbb-cccc-dddd-111111111111"),
+					},
+				},
+			},
+			newCluster: &infrav1.OpenStackCluster{
+				Spec: infrav1.OpenStackClusterSpec{
+					IdentityRef: infrav1.OpenStackIdentityReference{
+						Name:      "foobar",
+						CloudName: "foobar",
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This creates the possibility of use multiple subnets inside one network. OpenStack provides this functionality and we need this to not break reconciliation process if OpenStack administrators add new subnet inside a network already used by OpenStack cluster-api provider.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3160 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- if necessary:
  - [ ] includes documentation
  - [X] adds unit tests

/hold
