### PR TITLE
🌱 Replace requeue delay with watch

### DIFF
--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -69,7 +69,6 @@ const (
 	waitForClusterInfrastructureReadyDuration = 15 * time.Second
 	waitForInstanceBecomeActiveToReconcile    = 60 * time.Second
 	waitForBuildingInstanceToReconcile        = 10 * time.Second
-	deleteServerRequeueDelay                  = 10 * time.Second
 	waitingForInstanceCreatedMessage          = "Waiting for instance to be created"
 )
 
@@ -272,10 +271,11 @@ func (r *OpenStackMachineReconciler) reconcileDelete(ctx context.Context, scope 
 			})
 			return ctrl.Result{}, err
 		}
-		// If the server was found, we need to wait for it to be deleted before
-		// removing the OpenStackMachine finalizer.
+		// Wait for the OpenStackServer to be fully deleted before
+		// removing the OpenStackMachine finalizer. The watch on
+		// OpenStackServer delete events will trigger a reconcile.
 		scope.Logger().Info("Waiting for server to be deleted before removing finalizer")
-		return ctrl.Result{RequeueAfter: deleteServerRequeueDelay}, nil
+		return ctrl.Result{}, nil
 	}
 
 	controllerutil.RemoveFinalizer(openStackMachine, infrav1.MachineFinalizer)

--- a/controllers/openstackserver_controller.go
+++ b/controllers/openstackserver_controller.go
@@ -860,7 +860,7 @@ func OpenStackServerReconcileComplete(log logr.Logger) predicate.Funcs {
 			log.V(4).Info("OpenStackServer is still reconciling, blocking further processing")
 			return false
 		},
-		DeleteFunc:  func(event.DeleteEvent) bool { return false },
+		DeleteFunc:  func(event.DeleteEvent) bool { return true },
 		GenericFunc: func(event.GenericEvent) bool { return false },
 	}
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Commit 186c11d2e (#2182) added a new OpenStackServerReconcileComplete predicate in order to reduce reconcile churn from many updates to the server. However, the predicate only watched for Ready or error transitions, meaning delete events were no longer delivered. This was addressed in commit 050875940 (#2254), where we added a RequeueAfter to ensure the OpenStackMachine controller polls for an OpenStackServer's disappearance before deleting the OpenStackMachine.

However, this is less efficient (and more complicated) than it can be: the delay means we will only kick the OpenStackMachine deletion on multiples of 10 second, rather than immediately like we would with a watch. Address this by modifying the predicate so that it will also watch for delete events, ensuring we proceed with OpenStackMachine deletion immediately upon OpenStackServer's removal and allowing us to remove the delay.

(Note that I spotted this while trying to debug another, unrelated issue in a downstream product. I believe it's a nice to have rather than a bug)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

(n/a)

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
