### PR TITLE
:seedling: CI: Correctly pin to v1.13 latest

### DIFF
--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -17,8 +17,8 @@ providers:
 - name: cluster-api
   type: CoreProvider
   versions:
-  - name: "{go://sigs.k8s.io/cluster-api@latest-v1.13}"
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@latest-v1.13}/core-components.yaml"
+  - name: "{go://sigs.k8s.io/cluster-api@v1.13}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.13}/core-components.yaml"
     type: "url"
     contract: v1beta2
     replacements:
@@ -48,8 +48,8 @@ providers:
 - name: kubeadm
   type: BootstrapProvider
   versions:
-  - name: "{go://sigs.k8s.io/cluster-api@latest-v1.13}"
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@latest-v1.13}/bootstrap-components.yaml"
+  - name: "{go://sigs.k8s.io/cluster-api@v1.13}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.13}/bootstrap-components.yaml"
     type: "url"
     contract: v1beta2
     replacements:
@@ -79,8 +79,8 @@ providers:
 - name: kubeadm
   type: ControlPlaneProvider
   versions:
-  - name: "{go://sigs.k8s.io/cluster-api@latest-v1.13}"
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@latest-v1.13}/control-plane-components.yaml"
+  - name: "{go://sigs.k8s.io/cluster-api@v1.13}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.13}/control-plane-components.yaml"
     type: "url"
     contract: v1beta2
     replacements:


### PR DESCRIPTION
**What this PR does / why we need it**:
`{go://sigs.k8s.io/cluster-api@latest-v1.13}` was resulting to v1.13.0.rc-1 which didnt include various bug fixes. Change it to `{go://sigs.k8s.io/cluster-api@v1.13}`


**TODOs**:

- [X] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests


