### PR TITLE
:rocket: Release v0.14.6

### DIFF
--- a/releasenotes/v0.14.6.md
+++ b/releasenotes/v0.14.6.md
@@ -1,0 +1,54 @@
+# Highlights
+
+## Changes since v0.14.4
+
+## :chart_with_upwards_trend: Overview
+
+- 13 new commits merged
+- 1 bug fixed 🐛
+
+## :bug: Bug Fixes
+
+- Add nil guard for LoadBalancerNetwork (#3193)
+
+## :seedling: Others
+
+- Bump cloudbuild image to support go 1.26 (#3234)
+- Bump Go version to 1.25.10 (#3163)
+- Bump Go version to 1.25.11 (#3199)
+- Ignore two vulnerabilities in x/net (#3200)
+- Patch govulncheck to support ignoring findings (#3187)
+
+## Dependencies
+
+### Added
+
+_Nothing has changed._
+
+### Changed
+
+- github.com/coredns/corefile-migration: [v1.0.31 → v1.0.32](https://github.com/coredns/corefile-migration/compare/v1.0.31...v1.0.32)
+- github.com/moby/spdystream: [v0.5.0 → v0.5.1](https://github.com/moby/spdystream/compare/v0.5.0...v0.5.1)
+- github.com/onsi/ginkgo/v2: [v2.28.1 → v2.28.2](https://github.com/onsi/ginkgo/compare/v2.28.1...v2.28.2)
+- github.com/onsi/gomega: [v1.39.1 → v1.42.0](https://github.com/onsi/gomega/compare/v1.39.1...v1.42.0)
+- go.opentelemetry.io/otel/metric: v1.40.0 → v1.41.0
+- go.opentelemetry.io/otel/trace: v1.40.0 → v1.41.0
+- go.opentelemetry.io/otel: v1.40.0 → v1.41.0
+- gopkg.in/ini.v1: v1.67.1 → v1.67.3
+- k8s.io/api: v0.34.6 → v0.34.9
+- k8s.io/apiextensions-apiserver: v0.34.6 → v0.34.9
+- k8s.io/apimachinery: v0.34.6 → v0.34.9
+- k8s.io/apiserver: v0.34.6 → v0.34.9
+- k8s.io/client-go: v0.34.6 → v0.34.9
+- k8s.io/code-generator: v0.34.6 → v0.34.9
+- k8s.io/component-base: v0.34.6 → v0.34.9
+- k8s.io/kms: v0.34.6 → v0.34.9
+- sigs.k8s.io/cluster-api/test: v1.12.7 → v1.12.8
+- sigs.k8s.io/cluster-api: v1.12.7 → v1.12.8
+- sigs.k8s.io/structured-merge-diff/v6: v6.3.2 → v6.4.0
+
+### Removed
+
+_Nothing has changed._
+
+_Thanks to all our contributors!_ 😊


### PR DESCRIPTION
New patch release v0.14.6

Previous release note for v0.14.5 got merged but had issue with the image build, so we have to fix it by bumping cloudbuild image to support go 1.26