### PR TITLE
🚀 Release v0.15.0-alpha.0

### DIFF
--- a/releasenotes/v0.15.0-alpha.0.md
+++ b/releasenotes/v0.15.0-alpha.0.md
@@ -1,0 +1,210 @@
+🚨 This is an ALPHA RELEASE. Use it only for testing purposes. If you find any bugs, file an [issue](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/new).
+<details>
+<summary>More details about the release</summary>
+
+:warning: **ALPHA RELEASE NOTES** :warning:
+## Highlights
+
+- This release introduces the v1beta2 API types, which are now available alongside the existing v1beta1 types.
+  The v1beta2 types include several breaking changes and new features, so please review the [migration guide](https://cluster-api-openstack.sigs.k8s.io/topics/crd-changes/v1beta1-to-v1beta2) before upgrading.
+- CAPI v1beta2 contract fully implemented.
+
+## Changes since v0.14.4
+## :chart_with_upwards_trend: Overview
+- 140 new commits merged
+- 12 breaking changes :warning:
+- 9 feature additions ✨
+- 5 bugs fixed 🐛
+
+## :memo: Proposals
+- Proposal for multi-az apiserver loadbalancer (#2660)
+
+## :warning: Breaking Changes
+- Add api/v1beta2 types with CAPI v1beta2 contract (#2947)
+- Add managedNetworks on OpenStackCluster (#3122)
+- Add managedRouter on OpenStackCluster (#3143)
+- Add v1beta2 validation and defaulting webhooks (#2966)
+- CAPI v1.13, controller-runtime v0.23 and k8s.io v0.35 (#3086)
+- Group API server fields under spec.apiServer (#3169)
+- Implement v1beta1 ↔ v1beta2 conversion webhooks (#2958)
+- KAL: Enable intergers linter (#3203)
+- Migrate controllers and types to CAPI v1beta2 conditions (#2986)
+- Rename managedSecurityGroups.allNodesSecurityGroupRules (#3155)
+- Standardize flavor in OpenStackMachine (#3087)
+- V1beta2 Switch to positive polarity for bool fields (#3189)
+
+## :sparkles: New Features
+- Add conditions for OpenStackMachineTemplate (#2994)
+- Bump Go version to 1.25.7 throughout project (#3012)
+- Bump required go version to v1.26.0 and golanci-lint to v2.12.2 (#3181)
+- Enable PriorityQueue per default (#3206)
+- Enable ssatags linter and fix findings (#3224)
+- Feature/multiple subnets (#3210)
+- Make allowedAddressPairs on OpenStackMachine ports mutable (#3056)
+- Propagate OpenStackServer dependency errors to OpenStackMachine (#3013)
+- Switch light workflows to ubuntu-slim runner (#3103)
+
+## :bug: Bug Fixes
+- Add missing conditions on network error paths in OpenStackCluster reconciler (#3107)
+- Add nil guard for LoadBalancerNetwork (#3192)
+- Ignore description when comparing security group rules (#3184)
+- Use lazy evaluation for shell calls in `Makefile` (#3154)
+- Use port_trusted_vif extension for trusted VF when available (#3120)
+
+## :seedling: Others
+- (deps): Bump zizmorcore/zizmor-action from 0.5.0 to 0.5.2 (#3062)
+- Add Kube API Linter with everything excluded (#3132)
+- Add metadata for v0.15 and update e2e (#3153)
+- Add missing tests for v1beta2 (#3096)
+- Add nikParasyr to reviewers (#2970)
+- Add OpenStackAuthenticationSucceeded condition (#2985)
+- Add regression test for security group failure on previously ready cluster (#3104)
+- Add zizmor scanner (#3050)
+- Address further issues with `Makefile` (#3212)
+- Automate golangci-lint version bumps via Dependabot (#3095)
+- Bump CI go version to 1.26.3 (#3180)
+- Bump cloudbuild image to support go 1.25 (#3030)
+- Bump cloudbuild image to support go 1.26 (#3207)
+- Bump github.com/ahmetb/gen-crd-api-reference-docs (#3159)
+- Bump Go version to 1.25.10 (#3162)
+- Bump Go version to 1.25.9 (#3105)
+- Bump go version to 1.26.4 (#3197)
+- Bump golang version to 1.24.12 (#2950)
+- Bump golang version to 1.24.13 (#2996)
+- Bump golangci-lint to 2.9.0 (#3007)
+- Bump golangci-lint to v2.10.1 (#3018)
+- Bump gomodguard to v2 (#3198)
+- Bump opentelemetry dependencies (#3015)
+- Bump x/net to v0.55.0 (#3201)
+- CI: Correctly pin to v1.13 latest (#3219)
+- Dependabot: Ignore ORC on release-0.14 (#3150)
+- E2E: Update calico cni to v3.31.3 (#2984)
+- E2E: Update CCM manifests to 1.35 (#2983)
+- E2E: Update versions for v0.14 (#2967)
+- E2E: Use Kubernetes v1.36.1 in tests (#3208)
+- Enable conflictingmarkers linter and fix issues (#3223)
+- Enable optionalorrequired linter and add required/optional markers (#3183)
+- Enable requiredfields linter (#3221)
+- Fix golangci-lint exclusion for dot imports and remove redundant nolint comments (#3097)
+- Fuzz conversion for v1beta1 <-> v1beta2 (#3119)
+- Harden GitHub workflow (#3039)
+- Ignore ginkgo and setup-envtest bumps (#3173)
+- Improve logging (#3186)
+- KAL: Enable low effort linters (#3161)
+- Linting fixes and bump of golanci-lint + go-version (#3102)
+- Mark autoscaler e2e test as non-blocking (#2955)
+- Migrate ci to stable/2026.1 (#3205)
+- New InstanceReadyCondition reason for port creation failure (#2843)
+- Patch govulncheck to support ignoring findings (#3185)
+- Remove unused vars/consts (#2953)
+- Replace requeue delay with watch (#3211)
+- Revert release worflow persist-credentials: false (#3040)
+- Set GOTOOLCHAIN in Makefile (#3067)
+- Suppress revive var-naming warning for strings pkg (#3024)
+- Update cluster-api/test to v1.13.2 (#3220)
+- Update dependabot and security scan for release-0.14 (#2949)
+- Update dependabot to ignore gophercloud and golang.org/x bumps (#3078)
+- Update external approvers (#2973)
+- Update golangci-lint to v2.8.0 (#2954)
+- Update missing go version uplift in netlify.toml file (#3038)
+- Update Trivy version to 0.69.3 (#3064)
+- Uplift go version to 1.25.8 (#3044)
+- :rocket: Release v0.12.7 (#2968)
+- :rocket: Release v0.13.3 (#2969)
+- :rocket: Release v0.13.5 (#3084)
+- :rocket: Release v0.13.6 (#3136)
+- :rocket: Release v0.13.7 (#3141)
+- :rocket: Release v0.13.8 (#3233)
+- :rocket: Release v0.14.2 (#3083)
+- :rocket: Release v0.14.3 (#3135)
+- :rocket: Release v0.14.4 (#3142)
+- :rocket: Release v0.14.5 (#3232)
+- :rocket: Release v0.14.6 (#3238)
+
+:book: Additionally, there have been 3 contributions to our documentation and book. (#3098, #3110, #3111) 
+
+## Dependencies
+
+### Added
+- github.com/google/go-github/v82: [v82.0.0](https://github.com/google/go-github/tree/v82.0.0)
+
+### Changed
+- github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp: [v1.30.0 → v1.31.0](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/compare/detectors/gcp/v1.30.0...detectors/gcp/v1.31.0)
+- github.com/coredns/corefile-migration: [v1.0.31 → v1.0.32](https://github.com/coredns/corefile-migration/compare/v1.0.31...v1.0.32)
+- github.com/docker/go-connections: [v0.6.0 → v0.7.0](https://github.com/docker/go-connections/compare/v0.6.0...v0.7.0)
+- github.com/fatih/color: [v1.18.0 → v1.19.0](https://github.com/fatih/color/compare/v1.18.0...v1.19.0)
+- github.com/google/go-querystring: [v1.1.0 → v1.2.0](https://github.com/google/go-querystring/compare/v1.1.0...v1.2.0)
+- github.com/google/pprof: [294ebfa → 545e8a4](https://github.com/google/pprof/compare/294ebfa...545e8a4)
+- github.com/gophercloud/gophercloud/v2: [v2.10.0 → v2.12.0](https://github.com/gophercloud/gophercloud/compare/v2.10.0...v2.12.0)
+- github.com/grpc-ecosystem/grpc-gateway/v2: [v2.27.7 → v2.28.0](https://github.com/grpc-ecosystem/grpc-gateway/compare/v2.27.7...v2.28.0)
+- github.com/k-orc/openstack-resource-controller/v2: [v2.4.0 → v2.6.0](https://github.com/k-orc/openstack-resource-controller/compare/v2.4.0...v2.6.0)
+- github.com/moby/moby/api: [v1.54.1 → v1.54.2](https://github.com/moby/moby/compare/api/v1.54.1...api/v1.54.2)
+- github.com/moby/moby/client: [v0.4.0 → v0.4.1](https://github.com/moby/moby/compare/client/v0.4.0...client/v0.4.1)
+- github.com/moby/spdystream: [v0.5.0 → v0.5.1](https://github.com/moby/spdystream/compare/v0.5.0...v0.5.1)
+- github.com/onsi/ginkgo/v2: [v2.28.1 → v2.31.0](https://github.com/onsi/ginkgo/compare/v2.28.1...v2.31.0)
+- github.com/onsi/gomega: [v1.39.1 → v1.42.0](https://github.com/onsi/gomega/compare/v1.39.1...v1.42.0)
+- github.com/spf13/cobra: [v1.10.1 → v1.10.2](https://github.com/spf13/cobra/compare/v1.10.1...v1.10.2)
+- github.com/valyala/fastjson: [v1.6.4 → v1.6.10](https://github.com/valyala/fastjson/compare/v1.6.4...v1.6.10)
+- go.etcd.io/bbolt: v1.4.2 → v1.4.3
+- go.etcd.io/etcd/api/v3: v3.6.6 → v3.6.10
+- go.etcd.io/etcd/client/pkg/v3: v3.6.6 → v3.6.10
+- go.etcd.io/etcd/client/v3: v3.6.6 → v3.6.10
+- go.etcd.io/etcd/pkg/v3: v3.6.4 → v3.6.5
+- go.etcd.io/etcd/server/v3: v3.6.4 → v3.6.5
+- go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc: v1.40.0 → v1.43.0
+- go.opentelemetry.io/otel/exporters/otlp/otlptrace: v1.40.0 → v1.43.0
+- go.opentelemetry.io/otel/metric: v1.40.0 → v1.43.0
+- go.opentelemetry.io/otel/sdk/metric: v1.40.0 → v1.43.0
+- go.opentelemetry.io/otel/sdk: v1.40.0 → v1.43.0
+- go.opentelemetry.io/otel/trace: v1.40.0 → v1.43.0
+- go.opentelemetry.io/otel: v1.40.0 → v1.43.0
+- go.opentelemetry.io/proto/otlp: v1.9.0 → v1.10.0
+- go.yaml.in/yaml/v2: v2.4.2 → v2.4.3
+- golang.org/x/crypto: v0.48.0 → v0.53.0
+- golang.org/x/mod: v0.32.0 → v0.36.0
+- golang.org/x/net: v0.49.0 → v0.55.0
+- golang.org/x/oauth2: v0.34.0 → v0.36.0
+- golang.org/x/sync: v0.19.0 → v0.21.0
+- golang.org/x/sys: v0.41.0 → v0.46.0
+- golang.org/x/telemetry: bd525da → 42602be
+- golang.org/x/term: v0.40.0 → v0.44.0
+- golang.org/x/text: v0.34.0 → v0.38.0
+- golang.org/x/tools/go/expect: v0.1.0-deprecated → v0.1.1-deprecated
+- golang.org/x/tools: v0.41.0 → v0.45.0
+- gonum.org/v1/gonum: v0.16.0 → v0.17.0
+- google.golang.org/genproto/googleapis/api: 8636f87 → 9d38bb4
+- google.golang.org/genproto/googleapis/rpc: 8636f87 → 9d38bb4
+- google.golang.org/grpc: v1.79.3 → v1.80.0
+- gopkg.in/evanphx/json-patch.v4: v4.12.0 → v4.13.0
+- gopkg.in/ini.v1: v1.67.1 → v1.67.3
+- k8s.io/api: v0.34.6 → v0.35.6
+- k8s.io/apiextensions-apiserver: v0.34.6 → v0.35.6
+- k8s.io/apimachinery: v0.34.6 → v0.35.6
+- k8s.io/apiserver: v0.34.6 → v0.35.6
+- k8s.io/client-go: v0.34.6 → v0.35.6
+- k8s.io/cluster-bootstrap: v0.34.2 → v0.35.4
+- k8s.io/code-generator: v0.34.6 → v0.35.6
+- k8s.io/component-base: v0.34.6 → v0.35.6
+- k8s.io/gengo/v2: 85fd79d → ec3ebc5
+- k8s.io/kms: v0.34.6 → v0.35.6
+- k8s.io/kube-openapi: f3f2b99 → 589584f
+- k8s.io/utils: 4c0f3b2 → bc988d5
+- sigs.k8s.io/cluster-api/test: v1.12.7 → v1.13.2
+- sigs.k8s.io/cluster-api: v1.12.7 → v1.13.2
+- sigs.k8s.io/controller-runtime: v0.22.5 → v0.23.3
+- sigs.k8s.io/json: cfa47c3 → 2d32026
+- sigs.k8s.io/structured-merge-diff/v6: v6.3.2 → v6.4.0
+
+### Removed
+- github.com/ProtonMail/go-crypto: [7d5c6f0](https://github.com/ProtonMail/go-crypto/tree/7d5c6f0)
+- github.com/bwesterb/go-ristretto: [v1.2.3](https://github.com/bwesterb/go-ristretto/tree/v1.2.3)
+- github.com/cloudflare/circl: [v1.6.3](https://github.com/cloudflare/circl/tree/v1.6.3)
+- github.com/google/go-github/v53: [v53.2.0](https://github.com/google/go-github/tree/v53.2.0)
+- github.com/kisielk/errcheck: [v1.5.0](https://github.com/kisielk/errcheck/tree/v1.5.0)
+- github.com/kisielk/gotool: [v1.0.0](https://github.com/kisielk/gotool/tree/v1.0.0)
+- golang.org/x/xerrors: 5ec99f8
+- google.golang.org/appengine: v1.6.7
+
+</details>
+<br/>
+_Thanks to all our contributors!_ 😊


### PR DESCRIPTION
Create an alpha release for v0.15.
Note that this does NOT include #3226. I think we have consensus to proceed without this linter and all the breaking changes that comes with it. Since this is an alpha release we can also still change our mind.

/hold
