### PR TITLE
🌱 Bump ORC to v2.6.0 in E2E

### DIFF
--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -10,7 +10,7 @@ images:
 # Use local dev images built source tree;
 - name: gcr.io/k8s-staging-capi-openstack/capi-openstack-controller:e2e
   loadBehavior: mustLoad
-- name: quay.io/orc/openstack-resource-controller:v2.5.0
+- name: quay.io/orc/openstack-resource-controller:v2.6.0
   loadBehavior: tryLoad
 
 providers:
@@ -178,7 +178,7 @@ providers:
 - name: openstack-resource-controller
   type: RuntimeExtensionProvider # ORC isn't a provider but we fake it so it can be handled by the clusterctl machinery.
   versions:
-  - name: v2.5.0
+  - name: v2.6.0
     value: ../../../../cluster-api-provider-openstack/test/infrastructure/openstack-resource-controller/config/default
     contract: v1beta2
     files:

--- a/test/e2e/data/shared/openstack-resource-controller/metadata.yaml
+++ b/test/e2e/data/shared/openstack-resource-controller/metadata.yaml
@@ -20,3 +20,6 @@ releaseSeries:
 - major: 2
   minor: 5
   contract: v1beta2
+- major: 2
+  minor: 6
+  contract: v1beta2

--- a/test/infrastructure/openstack-resource-controller/config/default/kustomization.yaml
+++ b/test/infrastructure/openstack-resource-controller/config/default/kustomization.yaml
@@ -8,4 +8,4 @@ labels:
     cluster.x-k8s.io/provider: "runtime-extension-openstack-resource-controller"
 
 resources:
-- https://github.com/k-orc/openstack-resource-controller/releases/download/v2.5.0/install.yaml
+- https://github.com/k-orc/openstack-resource-controller/releases/download/v2.6.0/install.yaml


### PR DESCRIPTION

Fixes #3241

Bumps ORC from v2.5.0 to v2.6.0 in E2E test manifests:
- E2E install manifest URL
- E2E config image tag and provider version
- clusterctl metadata.yaml (added releaseSeries entry for 2.6, contract v1beta2)

go.mod was already on v2.6.0; only the E2E test references were lagging.