### PR TITLE
📖 proposal for configurable allow-all outbound traffic in managed SGs

### DIFF
--- a/docs/proposals/20260706-managed-security-groups-egress.md
+++ b/docs/proposals/20260706-managed-security-groups-egress.md
@@ -25,7 +25,7 @@ CAPO managed security group rules are not all the same kind of rule:
 * Infrastructure rules required for normal cluster operation, such as etcd, kubelet, API server, NodePort, and bastion SSH.
 * Permissive default outbound rules that allow all IPv4 and IPv6 egress.
 
-This proposal targets only the second category. Required infrastructure rules remain managed by CAPO, including minimum egress required for cluster operation.
+This proposal targets only the second category. Required infrastructure rules remain managed by CAPO, including scoped in-cluster egress and egress to the API server endpoint required for cluster operation.
 
 ### Goals
 
@@ -86,12 +86,29 @@ Behavior:
 * If `managedSecurityGroups` is set to an empty object, behavior is unchanged.
 * If `allowAllOutboundTraffic` is unset or `true`, CAPO creates the current default allow-all IPv4 and IPv6 egress rules.
 * If `allowAllOutboundTraffic` is `false`, CAPO removes the default allow-all egress rules.
-* When `allowAllOutboundTraffic` is `false`, CAPO creates minimum egress rules between the control plane and worker security groups.
-* When `allowAllOutboundTraffic` is `false`, CAPO creates egress rules to the API server endpoint on the configured API server port.
+
+* When `allowAllOutboundTraffic` is `false`, CAPO creates scoped egress rules from the control plane and worker security groups to the managed control plane, worker, and self security groups. These rules allow all protocols and all ports and are created for both IPv4 and IPv6.
+* When `allowAllOutboundTraffic` is `false`, CAPO creates TCP egress rules from the control plane and worker security groups to the API server endpoint on the configured API server port. The rule `etherType` matches the address family of the API endpoint.
+
 * Required ingress rules remain unchanged.
 * User-defined egress rules continue to be reconciled normally.
 * The same allow-all outbound setting is applied consistently to the node security groups and the bastion security group.
 * When `allowAllOutboundTraffic` is `false`, CAPO creates TCP port 22 egress rules from the bastion security group to the control plane and worker security groups.
+
+The scoped in-cluster egress rules have the following properties:
+
+* `direction: egress`
+* `remoteGroupID`: the managed control plane, worker, or source security group itself
+* no protocol restriction
+* no port restriction
+* equivalent rules for both `IPv4` and `IPv6`
+
+The API server endpoint rule has:
+
+* `direction: egress`
+* `protocol: tcp`
+* destination port equal to the configured API server port
+* an `etherType` matching the API endpoint address family
 
 ## API Changes
 
@@ -153,8 +170,8 @@ func allowAllOutboundTraffic(managedSecurityGroups *infrav1.ManagedSecurityGroup
 ```
 
 4. When building managed security group rules, include the current default allow-all egress rules only if `allowAllOutboundTraffic(...)` returns `true`.
-5. When the helper returns `false`, add scoped egress from both node security groups to the control plane and worker security groups.
-6. When the helper returns `false`, add egress from both node security groups to the API server endpoint on the configured API server port.
+5. When the helper returns `false`, add unrestricted in-cluster egress rules from both node security groups to the managed control plane, worker, and self security groups. Create equivalent rules for IPv4 and IPv6, with no protocol or port restrictions.
+6. When the helper returns `false`, add TCP egress from both node security groups to the API server endpoint on the configured API server port. Set the rule `etherType` according to the API endpoint address family.
 7. Continue applying all user-provided `SecurityGroupRuleSpec` entries unchanged.
 8. Apply the same behavior to the bastion security group so disabling allow-all outbound traffic does not leave a separate unrestricted egress path there.
 9. When `allowAllOutboundTraffic` is `false`, add TCP port 22 egress from the bastion security group to the control plane and worker security groups.
@@ -183,7 +200,10 @@ Existing validation for `SecurityGroupRuleSpec` continues to apply to explicit e
 
 No validation is required between `allowAllInClusterTraffic` and `allowAllOutboundTraffic`.
 
-`allowAllInClusterTraffic` controls ingress between cluster nodes. When `allowAllOutboundTraffic` is `false`, CAPO still creates scoped egress rules towards the cluster node security groups. Therefore, setting both `allowAllInClusterTraffic: true` and `allowAllOutboundTraffic: false` allows all in-cluster traffic while keeping external egress restricted.
+`allowAllInClusterTraffic` controls ingress between cluster nodes. When `allowAllOutboundTraffic` is `false`, CAPO creates egress rules between the managed node security groups for both IPv4 and IPv6, without protocol or port restrictions.
+
+Therefore, setting both `allowAllInClusterTraffic: true` and `allowAllOutboundTraffic: false` still allows all in-cluster traffic while
+keeping external egress restricted. No CEL validation between these fields is required.
 
 ## Testing
 
@@ -192,8 +212,10 @@ Add unit tests for managed security group rule generation:
 * `allowAllOutboundTraffic` unset keeps default IPv4 and IPv6 allow-all egress rules.
 * `allowAllOutboundTraffic: true` keeps default IPv4 and IPv6 allow-all egress rules.
 * `allowAllOutboundTraffic: false` removes the default allow-all IPv4 and IPv6 egress rules.
-* `allowAllOutboundTraffic: false` adds egress between the control plane and worker security groups.
-* `allowAllOutboundTraffic: false` adds egress to the API server endpoint on the configured API server port.
+* `allowAllOutboundTraffic: false` adds unrestricted egress between the managed control plane, worker, and self security groups for both IPv4 and IPv6.
+* The scoped in-cluster egress rules have no protocol or port restrictions.
+* `allowAllOutboundTraffic: false` adds TCP egress to the API server endpoint on the configured API server port.
+* The API server endpoint egress rule uses the address family of the endpoint.
 * `allowAllOutboundTraffic: false` adds egress to TCP port 22 to the control plane and worker security groups on Bastion security group.
 * User-defined egress rules are still included when `allowAllOutboundTraffic: false`.
 

--- a/docs/proposals/20260706-managed-security-groups-egress.md
+++ b/docs/proposals/20260706-managed-security-groups-egress.md
@@ -122,15 +122,17 @@ spec:
       remoteIPPrefix: 10.0.10.0/24
 ```
 
-The `allowAllOutboundTraffic` field will be added to both the `v1beta1` and `v1beta2` API versions with the same name and type.
+The `allowAllOutboundTraffic` field will be added only to the `v1beta2` API.
+
+The `v1beta1` API remains unchanged and does not expose this feature.
 
 No new status fields are required.
 
 ## Conversion
 
-The `allowAllOutboundTraffic` field has the same name and type in `v1beta1` and `v1beta2`.
+`allowAllOutboundTraffic` is introduced only in `v1beta2`.
 
-Conversion between both versions must preserve all possible values: `unset`, `true`, and `false`.
+No corresponding field is added to the `v1beta1` API.
 
 ## Controller Design
 
@@ -163,7 +165,8 @@ The implementation should avoid a generic `enablePredefinedRules` style flag. Su
 
 This proposal is backward compatible.
 
-Existing manifests do not need to change. Existing users keep the current unrestricted egress behavior because `allowAllOutboundTraffic` defaults to enabled when omitted.
+Existing `v1beta1` manifests are unaffected because the `v1beta1` API remains unchanged.
+Existing `v1beta2` manifests do not need to change and keep the current unrestricted egress behavior because `allowAllOutboundTraffic` defaults to enabled when omitted.
 
 The new behavior is only used when users explicitly set:
 

--- a/docs/proposals/20260706-managed-security-groups-egress.md
+++ b/docs/proposals/20260706-managed-security-groups-egress.md
@@ -25,7 +25,7 @@ CAPO managed security group rules are not all the same kind of rule:
 * Infrastructure rules required for normal cluster operation, such as etcd, kubelet, API server, NodePort, and bastion SSH.
 * Permissive default outbound rules that allow all IPv4 and IPv6 egress.
 
-This proposal targets only the second category. Required infrastructure rules remain managed by CAPO.
+This proposal targets only the second category. Required infrastructure rules remain managed by CAPO, including minimum egress required for cluster operation.
 
 ### Goals
 
@@ -85,24 +85,27 @@ Behavior:
 * If `managedSecurityGroups` is omitted, behavior is unchanged.
 * If `managedSecurityGroups` is set to an empty object, behavior is unchanged.
 * If `allowAllOutboundTraffic` is unset or `true`, CAPO creates the current default allow-all IPv4 and IPv6 egress rules.
-* If `allowAllOutboundTraffic` is `false`, CAPO skips only the default allow-all egress rules.
-* Required infrastructure rules remain unchanged.
+* If `allowAllOutboundTraffic` is `false`, CAPO removes the default allow-all egress rules.
+* When `allowAllOutboundTraffic` is `false`, CAPO creates minimum egress rules between the control plane and worker security groups.
+* When `allowAllOutboundTraffic` is `false`, CAPO creates egress rules to the API server endpoint on the configured API server port.
+* Required ingress rules remain unchanged.
 * User-defined egress rules continue to be reconciled normally.
-* The same allow-all outbound behavior is applied consistently to the node security groups and the bastion security group.
+* The same allow-all outbound setting is applied consistently to the node security groups and the bastion security group.
+* When `allowAllOutboundTraffic` is `false`, CAPO creates TCP port 22 egress rules from the bastion security group to the control plane and worker security groups.
 
 ## API Changes
 
 The change is additive:
 
 ```yaml
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OpenStackCluster
 metadata:
   name: restricted-egress
 spec:
   managedSecurityGroups:
     allowAllOutboundTraffic: false
-    allNodesSecurityGroupRules:
+    clusterNodesSecurityGroupRules:
     - name: allow-dns
       direction: egress
       etherType: IPv4
@@ -119,7 +122,15 @@ spec:
       remoteIPPrefix: 10.0.10.0/24
 ```
 
+The `allowAllOutboundTraffic` field will be added to both the `v1beta1` and `v1beta2` API versions with the same name and type.
+
 No new status fields are required.
+
+## Conversion
+
+The `allowAllOutboundTraffic` field has the same name and type in `v1beta1` and `v1beta2`.
+
+Conversion between both versions must preserve all possible values: `unset`, `true`, and `false`.
 
 ## Controller Design
 
@@ -140,8 +151,11 @@ func allowAllOutboundTraffic(managedSecurityGroups *infrav1.ManagedSecurityGroup
 ```
 
 4. When building managed security group rules, include the current default allow-all egress rules only if `allowAllOutboundTraffic(...)` returns `true`.
-5. Continue applying all user-provided `SecurityGroupRuleSpec` entries unchanged.
-6. Apply the same behavior to the bastion security group so disabling allow-all outbound traffic does not leave a separate unrestricted egress path there.
+5. When the helper returns `false`, add scoped egress from both node security groups to the control plane and worker security groups.
+6. When the helper returns `false`, add egress from both node security groups to the API server endpoint on the configured API server port.
+7. Continue applying all user-provided `SecurityGroupRuleSpec` entries unchanged.
+8. Apply the same behavior to the bastion security group so disabling allow-all outbound traffic does not leave a separate unrestricted egress path there.
+9. When `allowAllOutboundTraffic` is `false`, add TCP port 22 egress from the bastion security group to the control plane and worker security groups.
 
 The implementation should avoid a generic `enablePredefinedRules` style flag. Such a flag would also disable required infrastructure rules and force users to recreate them by hand, which is not the goal of this change.
 
@@ -164,16 +178,21 @@ No special validation is required for `allowAllOutboundTraffic`.
 
 Existing validation for `SecurityGroupRuleSpec` continues to apply to explicit egress rules. In particular, users are responsible for providing valid `direction`, `etherType`, protocol, port range, and remote fields.
 
+No validation is required between `allowAllInClusterTraffic` and `allowAllOutboundTraffic`.
+
+`allowAllInClusterTraffic` controls ingress between cluster nodes. When `allowAllOutboundTraffic` is `false`, CAPO still creates scoped egress rules towards the cluster node security groups. Therefore, setting both `allowAllInClusterTraffic: true` and `allowAllOutboundTraffic: false` allows all in-cluster traffic while keeping external egress restricted.
+
 ## Testing
 
 Add unit tests for managed security group rule generation:
 
 * `allowAllOutboundTraffic` unset keeps default IPv4 and IPv6 allow-all egress rules.
 * `allowAllOutboundTraffic: true` keeps default IPv4 and IPv6 allow-all egress rules.
-* `allowAllOutboundTraffic: false` removes only default IPv4 and IPv6 allow-all egress rules.
+* `allowAllOutboundTraffic: false` removes the default allow-all IPv4 and IPv6 egress rules.
+* `allowAllOutboundTraffic: false` adds egress between the control plane and worker security groups.
+* `allowAllOutboundTraffic: false` adds egress to the API server endpoint on the configured API server port.
+* `allowAllOutboundTraffic: false` adds egress to TCP port 22 to the control plane and worker security groups on Bastion security group.
 * User-defined egress rules are still included when `allowAllOutboundTraffic: false`.
-* Existing required infrastructure rules are not changed.
-* Bastion security group behavior follows the same setting.
 
 ## Documentation
 
@@ -184,6 +203,7 @@ Update the managed security groups documentation with:
 * A minimal restricted-egress example.
 * A note that users must provide any egress required by their environment, such as DNS, image registry, package mirror, metadata service, or API endpoints.
 * A note that CAPO still manages required infrastructure rules when default outbound traffic is disabled.
+* Document that `spec.bastion.spec.securityGroups` can be used to provide any additional bastion egress.
 
 ## Risks and Mitigations
 

--- a/docs/proposals/20260706-managed-security-groups-egress.md
+++ b/docs/proposals/20260706-managed-security-groups-egress.md
@@ -1,0 +1,216 @@
+# Configurable default outbound traffic for managed security groups
+
+## Metadata
+
+* Authors: @alejandro-ripoll
+* Reviewers: CAPO maintainers
+* Status: Proposed
+* Creation Date: 2026-07-06
+* Issue: kubernetes-sigs/cluster-api-provider-openstack#3209
+
+## Summary
+
+CAPO managed security groups currently include default egress rules that allow all outbound IPv4 and IPv6 traffic. This proposal adds a small opt-out field to `ManagedSecurityGroups` so users can keep CAPO-managed security groups while removing only the unrestricted outbound rules.
+
+The proposed API is additive and preserves the current behavior by default.
+
+## Motivation
+
+Some environments do not allow unrestricted outbound traffic from cluster nodes. Today, users who need restricted egress cannot keep the managed security group lifecycle while removing the default allow-all egress rules.
+
+This is especially relevant for environments with strict network segmentation, compliance requirements, or zero-trust policies. These users still benefit from CAPO creating and reconciling the security groups and the required Kubernetes rules, but they need control over outbound destinations.
+
+CAPO managed security group rules are not all the same kind of rule:
+
+* Infrastructure rules required for normal cluster operation, such as etcd, kubelet, API server, NodePort, and bastion SSH.
+* Permissive default outbound rules that allow all IPv4 and IPv6 egress.
+
+This proposal targets only the second category. Required infrastructure rules remain managed by CAPO.
+
+### Goals
+
+* Preserve the current default behavior.
+* Allow users to disable only the default allow-all outbound rules.
+* Keep required infrastructure rules managed by CAPO.
+* Reuse the existing `SecurityGroupRuleSpec` API for explicit egress rules.
+* Keep the change limited to `ManagedSecurityGroups`.
+* Avoid requiring users to disable `managedSecurityGroups`.
+
+### Non-Goals
+
+* Define a higher-level egress policy API.
+* Manage external firewall rules, routers, NAT, proxies, or DNS.
+* Validate whether the configured egress rules are sufficient for a working Kubernetes cluster.
+* Change existing required infrastructure rules.
+* Change behavior when `managedSecurityGroups` is not used.
+* Add a generic flag to disable all predefined rules.
+
+## User Stories
+
+### Story 1: Restricted egress
+
+As a platform engineer, I want CAPO to manage security groups for a cluster, but I want to restrict node egress to a known set of CIDRs instead of allowing `0.0.0.0/0` and `::/0`.
+
+### Story 2: Existing managed security group behavior
+
+As an existing CAPO user, I want current clusters and manifests to keep the same behavior unless I explicitly opt out of the default egress rules.
+
+### Story 3: Gradual adoption
+
+As an operator, I want to first disable the default egress rules in non-production clusters and add only the egress rules my environment requires.
+
+## Proposal
+
+Add one optional field to `ManagedSecurityGroups`:
+
+```go
+type ManagedSecurityGroups struct {
+  // AllowAllOutboundTraffic controls whether CAPO adds the default
+  // allow-all outbound rules to managed security groups.
+  //
+  // When nil or true, CAPO keeps the current behavior and creates default
+  // IPv4 and IPv6 allow-all egress rules.
+  //
+  // When false, CAPO does not create those default allow-all egress rules.
+  // Other CAPO-managed infrastructure rules are still created.
+  //
+  // +kubebuilder:default=true
+  // +optional
+  AllowAllOutboundTraffic *bool `json:"allowAllOutboundTraffic,omitempty"`
+}
+```
+
+Behavior:
+
+* If `managedSecurityGroups` is omitted, behavior is unchanged.
+* If `managedSecurityGroups` is set to an empty object, behavior is unchanged.
+* If `allowAllOutboundTraffic` is unset or `true`, CAPO creates the current default allow-all IPv4 and IPv6 egress rules.
+* If `allowAllOutboundTraffic` is `false`, CAPO skips only the default allow-all egress rules.
+* Required infrastructure rules remain unchanged.
+* User-defined egress rules continue to be reconciled normally.
+* The same allow-all outbound behavior is applied consistently to the node security groups and the bastion security group.
+
+## API Changes
+
+The change is additive:
+
+```yaml
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OpenStackCluster
+metadata:
+  name: restricted-egress
+spec:
+  managedSecurityGroups:
+    allowAllOutboundTraffic: false
+    allNodesSecurityGroupRules:
+    - name: allow-dns
+      direction: egress
+      etherType: IPv4
+      protocol: udp
+      portRangeMin: 53
+      portRangeMax: 53
+      remoteIPPrefix: 10.0.0.53/32
+    - name: allow-https-to-proxy
+      direction: egress
+      etherType: IPv4
+      protocol: tcp
+      portRangeMin: 443
+      portRangeMax: 443
+      remoteIPPrefix: 10.0.10.0/24
+```
+
+No new status fields are required.
+
+## Controller Design
+
+CAPO already builds managed security group rules before merging user-provided rules. This logic should keep required infrastructure rules separate from permissive allow-all outbound rules.
+
+The controller should:
+
+1. Keep required infrastructure rules enabled whenever managed security groups are enabled.
+2. Keep the existing allow-all outbound rules for backward compatibility when the new field is unset or true.
+3. Add a helper that decides whether the permissive outbound rules should be included:
+
+```go
+func allowAllOutboundTraffic(managedSecurityGroups *infrav1.ManagedSecurityGroups) bool {
+    return managedSecurityGroups == nil ||
+        managedSecurityGroups.AllowAllOutboundTraffic == nil ||
+        *managedSecurityGroups.AllowAllOutboundTraffic
+}
+```
+
+4. When building managed security group rules, include the current default allow-all egress rules only if `allowAllOutboundTraffic(...)` returns `true`.
+5. Continue applying all user-provided `SecurityGroupRuleSpec` entries unchanged.
+6. Apply the same behavior to the bastion security group so disabling allow-all outbound traffic does not leave a separate unrestricted egress path there.
+
+The implementation should avoid a generic `enablePredefinedRules` style flag. Such a flag would also disable required infrastructure rules and force users to recreate them by hand, which is not the goal of this change.
+
+## Backward Compatibility
+
+This proposal is backward compatible.
+
+Existing manifests do not need to change. Existing users keep the current unrestricted egress behavior because `allowAllOutboundTraffic` defaults to enabled when omitted.
+
+The new behavior is only used when users explicitly set:
+
+```yaml
+managedSecurityGroups:
+  allowAllOutboundTraffic: false
+```
+
+## Validation
+
+No special validation is required for `allowAllOutboundTraffic`.
+
+Existing validation for `SecurityGroupRuleSpec` continues to apply to explicit egress rules. In particular, users are responsible for providing valid `direction`, `etherType`, protocol, port range, and remote fields.
+
+## Testing
+
+Add unit tests for managed security group rule generation:
+
+* `allowAllOutboundTraffic` unset keeps default IPv4 and IPv6 allow-all egress rules.
+* `allowAllOutboundTraffic: true` keeps default IPv4 and IPv6 allow-all egress rules.
+* `allowAllOutboundTraffic: false` removes only default IPv4 and IPv6 allow-all egress rules.
+* User-defined egress rules are still included when `allowAllOutboundTraffic: false`.
+* Existing required infrastructure rules are not changed.
+* Bastion security group behavior follows the same setting.
+
+## Documentation
+
+Update the managed security groups documentation with:
+
+* The default behavior.
+* The new `allowAllOutboundTraffic` field.
+* A minimal restricted-egress example.
+* A note that users must provide any egress required by their environment, such as DNS, image registry, package mirror, metadata service, or API endpoints.
+* A note that CAPO still manages required infrastructure rules when default outbound traffic is disabled.
+
+## Risks and Mitigations
+
+Risk: Users may disable default outbound traffic without adding the outbound rules required for node bootstrap or normal cluster operation.
+
+Mitigation: Document the behavior clearly and keep it opt-in. CAPO still manages the infrastructure rules it already owns.
+
+Risk: Naming could be interpreted as a full egress policy feature.
+
+Mitigation: Keep the field scoped to the existing default allow-all outbound rules. Explicit custom rules remain modeled through `SecurityGroupRuleSpec`.
+
+## Alternatives
+
+### Add explicit egress CIDR fields
+
+CAPO could add fields such as `egressCIDRs` or `defaultEgressCIDRs`.
+
+This is not proposed because `SecurityGroupRuleSpec` already supports explicit egress rules, including `remoteIPPrefix`, protocol, and ports. Adding a second egress-specific API would duplicate existing functionality.
+
+### Disable all default rules
+
+CAPO could add a field to disable every default managed security group rule.
+
+This is broader than needed. The requested use case is specifically about the default unrestricted egress rules. Disabling all predefined rules would also remove required infrastructure rules such as etcd, kubelet, API server, NodePort, and bastion SSH. That would force users to re-author rules that CAPO already knows how to manage.
+
+### Require unmanaged security groups
+
+Users can avoid CAPO defaults by not using `managedSecurityGroups` and managing security groups themselves.
+
+This works, but it removes the managed lifecycle that users still want. It also increases the amount of OpenStack-specific setup required outside CAPO.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a proposal for allowing users to restrict outbound traffic while keeping CAPO-managed security group lifecycle.

The proposed approach adds a new `managedSecurityGroups.allowAllOutboundTraffic` field, defaulting to `true` to preserve the current behavior.

When set to `false`, CAPO would stop creating only the default full-open egress rules. Other CAPO-managed infrastructure rules, such as API server, kubelet, etcd, NodePort and bastion SSH rules, would still be created.

The proposal also covers applying the same behavior to bastion managed security groups.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Related to #3209

**Special notes for your reviewer**:

This is a proposal-only PR. The implementation is intentionally scoped to a minimal additive API change and avoids a generic opt-out for all predefined rules.

/hold
