### PR TITLE
:bug: Share OpenStack HTTP transports by TLS trust config to stop connection leaks

### DIFF
--- a/main.go
+++ b/main.go
@@ -99,6 +99,7 @@ var (
 	caCertsPath                         string
 	showVersion                         bool
 	scopeCacheMaxSize                   int
+	transportCacheMaxSize               int
 	skipCRDMigrationPhases              []string
 	logOptions                          = logs.NewOptions()
 )
@@ -178,6 +179,8 @@ func InitFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&caCertsPath, "ca-certs", "", "The path to a PEM-encoded CA Certificate file to supply as default for each request.")
 
 	fs.IntVar(&scopeCacheMaxSize, "scope-cache-max-size", 10, "The maximum credentials count the operator should keep in cache. Setting this value to 0 means no cache.")
+
+	fs.IntVar(&transportCacheMaxSize, "transport-cache-max-size", 10, "The maximum number of distinct TLS trust configurations (CA bundle + verify mode) whose connection pools are kept warm. Cannot be disabled; values below 1 are ignored.")
 
 	fs.StringArrayVar(&skipCRDMigrationPhases, "skip-crd-migration-phases", []string{},
 		"List of CRD migration phases to skip. Valid values are: StorageVersionMigration, CleanupManagedFields.")
@@ -321,7 +324,7 @@ func setupChecks(mgr ctrl.Manager) {
 }
 
 func setupReconcilers(ctx context.Context, mgr ctrl.Manager, caCerts []byte) {
-	scopeFactory := scope.NewFactory(scopeCacheMaxSize)
+	scopeFactory := scope.NewFactory(scopeCacheMaxSize, transportCacheMaxSize)
 
 	crdMigratorConfig := map[client.Object]crdmigrator.ByObjectConfig{
 		&infrav1beta1.OpenStackCluster{}: {

--- a/pkg/scope/provider.go
+++ b/pkg/scope/provider.go
@@ -18,10 +18,7 @@ package scope
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -256,22 +253,11 @@ func NewProviderClient(cloud clientconfig.Cloud, regionName string, caCert []byt
 	ua.Prepend(fmt.Sprintf("cluster-api-provider-openstack/%s", version.Get().String()))
 	provider.UserAgent = ua
 
-	config := &tls.Config{
-		MinVersion: tls.VersionTLS12,
+	transport, err := getOrCreateTransport(caCert, cloud.Verify)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("get transport for cloud %v: %w", cloud.Cloud, err)
 	}
-	if cloud.Verify != nil {
-		config.InsecureSkipVerify = !*cloud.Verify
-	}
-	if caCert != nil {
-		config.RootCAs = x509.NewCertPool()
-		ok := config.RootCAs.AppendCertsFromPEM(caCert)
-		if !ok {
-			// If no certificates were successfully parsed, set RootCAs to nil to use the host's root CA
-			config.RootCAs = nil
-		}
-	}
-
-	provider.HTTPClient.Transport = &http.Transport{Proxy: http.ProxyFromEnvironment, TLSClientConfig: config}
+	provider.HTTPClient.Transport = transport
 	if klog.V(5).Enabled() {
 		provider.HTTPClient.Transport = &osclient.RoundTripper{
 			Rt:     provider.HTTPClient.Transport,

--- a/pkg/scope/scope.go
+++ b/pkg/scope/scope.go
@@ -29,11 +29,13 @@ import (
 )
 
 // NewFactory creates the default scope factory. It generates service clients which make OpenStack API calls against a running cloud.
-func NewFactory(maxCacheSize int) Factory {
+// maxTransportCacheSize bounds the number of distinct TLS trust configurations (CA bundle + verify mode) whose connection pools are kept warm; see setMaxCachedTransports.
+func NewFactory(maxCacheSize int, maxTransportCacheSize int) Factory {
 	var c *cache.LRUExpireCache
 	if maxCacheSize > 0 {
 		c = cache.NewLRUExpireCache(maxCacheSize)
 	}
+	setMaxCachedTransports(maxTransportCacheSize)
 	return &providerScopeFactory{
 		clientCache: c,
 	}

--- a/pkg/scope/transport.go
+++ b/pkg/scope/transport.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scope
+
+import (
+	"container/list"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// maxCachedTransports bounds how many distinct TLS trust configurations
+// (CA bundle + verify mode) are kept warm at once. Overridable via
+// setMaxCachedTransports / --transport-cache-max-size.
+var maxCachedTransports = 10
+
+// setMaxCachedTransports cannot disable the cache (n <= 0 is ignored):
+// evicting an entry here is what closes its connections, so it must stay on
+// for scope-cache eviction elsewhere to be safe.
+func setMaxCachedTransports(n int) {
+	if n < 1 {
+		return
+	}
+	transportCacheMu.Lock()
+	defer transportCacheMu.Unlock()
+	maxCachedTransports = n
+}
+
+var transportCacheMu sync.Mutex
+
+// transportCacheOrder/transportCacheIndex form a small LRU of *http.Transport
+// keyed by TLS trust configuration (CA bundle + verify mode) rather than by
+// credential. net/http never closes a Transport's idle connections on its
+// own, so caching one per credential (high-cardinality, evicted constantly
+// by the scope cache) leaked a connection pool on every eviction. TLS
+// config is low-cardinality and stable across a fleet on the same cloud(s),
+// so it's safe to cache here instead, explicitly calling
+// CloseIdleConnections on whatever gets evicted on overflow.
+var (
+	transportCacheOrder list.List
+	transportCacheIndex = map[string]*list.Element{}
+)
+
+type transportCacheEntry struct {
+	key       string
+	transport *http.Transport
+}
+
+func getOrCreateTransport(caCert []byte, verify *bool) (*http.Transport, error) {
+	key, err := transportCacheKey(caCert, verify)
+	if err != nil {
+		return nil, fmt.Errorf("compute transport cache key: %w", err)
+	}
+
+	transportCacheMu.Lock()
+	defer transportCacheMu.Unlock()
+
+	if element, ok := transportCacheIndex[key]; ok {
+		transportCacheOrder.MoveToFront(element)
+		return element.Value.(*transportCacheEntry).transport, nil
+	}
+
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+	if verify != nil {
+		tlsConfig.InsecureSkipVerify = !*verify
+	}
+	if caCert != nil {
+		tlsConfig.RootCAs = x509.NewCertPool()
+		if !tlsConfig.RootCAs.AppendCertsFromPEM(caCert) {
+			// If no certificates were successfully parsed, set RootCAs to nil to use the host's root CA
+			tlsConfig.RootCAs = nil
+		}
+	}
+
+	t := &http.Transport{
+		Proxy:               http.ProxyFromEnvironment,
+		TLSClientConfig:     tlsConfig,
+		IdleConnTimeout:     90 * time.Second,
+		MaxIdleConnsPerHost: 25,
+	}
+
+	if transportCacheOrder.Len() >= maxCachedTransports {
+		oldest := transportCacheOrder.Back()
+		oldestEntry := oldest.Value.(*transportCacheEntry)
+		transportCacheOrder.Remove(oldest)
+		delete(transportCacheIndex, oldestEntry.key)
+		oldestEntry.transport.CloseIdleConnections()
+	}
+
+	transportCacheIndex[key] = transportCacheOrder.PushFront(&transportCacheEntry{key: key, transport: t})
+	return t, nil
+}
+
+type transportCacheKeyInput struct {
+	CACert []byte
+	Verify *bool
+}
+
+func transportCacheKey(caCert []byte, verify *bool) (string, error) {
+	hash, err := computeSpewHash(transportCacheKeyInput{CACert: caCert, Verify: verify})
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%d", hash), nil
+}

--- a/pkg/scope/transport_test.go
+++ b/pkg/scope/transport_test.go
@@ -1,0 +1,267 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scope
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+)
+
+// generateTestCACertPEM returns a self-signed CA certificate in PEM form,
+// suitable for exercising the x509.CertPool.AppendCertsFromPEM success path.
+func generateTestCACertPEM(t *testing.T) []byte {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test-ca"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+		IsCA:         true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+// None of these tests use t.Parallel(): they share the package-level,
+// size-bounded transportCache, and running them concurrently would let one
+// test's insertions evict entries another test is mid-assertion on.
+
+func TestGetOrCreateTransport_SameConfigReturnsSameInstance(t *testing.T) {
+	caCert := generateTestCACertPEM(t)
+
+	t1, err := getOrCreateTransport(caCert, boolPtr(true))
+	if err != nil {
+		t.Fatalf("getOrCreateTransport: %v", err)
+	}
+	t2, err := getOrCreateTransport(caCert, boolPtr(true))
+	if err != nil {
+		t.Fatalf("getOrCreateTransport: %v", err)
+	}
+
+	if t1 != t2 {
+		t.Fatalf("expected the same *http.Transport instance for identical TLS config, got distinct instances")
+	}
+}
+
+func TestGetOrCreateTransport_DifferentCACertReturnsDifferentInstance(t *testing.T) {
+	cert1 := generateTestCACertPEM(t)
+	cert2 := generateTestCACertPEM(t)
+
+	t1, err := getOrCreateTransport(cert1, boolPtr(true))
+	if err != nil {
+		t.Fatalf("getOrCreateTransport: %v", err)
+	}
+	t2, err := getOrCreateTransport(cert2, boolPtr(true))
+	if err != nil {
+		t.Fatalf("getOrCreateTransport: %v", err)
+	}
+
+	if t1 == t2 {
+		t.Fatalf("expected distinct *http.Transport instances for different CA certs, got the same instance")
+	}
+}
+
+func TestGetOrCreateTransport_DifferentVerifyReturnsDifferentInstance(t *testing.T) {
+	caCert := generateTestCACertPEM(t)
+
+	insecure, err := getOrCreateTransport(caCert, boolPtr(false))
+	if err != nil {
+		t.Fatalf("getOrCreateTransport: %v", err)
+	}
+	secure, err := getOrCreateTransport(caCert, boolPtr(true))
+	if err != nil {
+		t.Fatalf("getOrCreateTransport: %v", err)
+	}
+	unset, err := getOrCreateTransport(caCert, nil)
+	if err != nil {
+		t.Fatalf("getOrCreateTransport: %v", err)
+	}
+
+	if insecure == secure || insecure == unset || secure == unset {
+		t.Fatalf("expected distinct *http.Transport instances for verify=false/true/nil, got overlapping instances")
+	}
+}
+
+func TestGetOrCreateTransport_TLSConfigReflectsVerifyAndCACert(t *testing.T) {
+	validCert := generateTestCACertPEM(t)
+
+	transport, err := getOrCreateTransport(validCert, boolPtr(false))
+	if err != nil {
+		t.Fatalf("getOrCreateTransport: %v", err)
+	}
+	if !transport.TLSClientConfig.InsecureSkipVerify {
+		t.Fatalf("expected InsecureSkipVerify=true when verify=false")
+	}
+	if transport.TLSClientConfig.RootCAs == nil {
+		t.Fatalf("expected RootCAs to be populated for a valid CA cert")
+	}
+
+	verifyingTransport, err := getOrCreateTransport(validCert, boolPtr(true))
+	if err != nil {
+		t.Fatalf("getOrCreateTransport: %v", err)
+	}
+	if verifyingTransport.TLSClientConfig.InsecureSkipVerify {
+		t.Fatalf("expected InsecureSkipVerify=false when verify=true")
+	}
+}
+
+func TestGetOrCreateTransport_InvalidCACertFallsBackToNilRootCAs(t *testing.T) {
+	// Not valid PEM/DER - AppendCertsFromPEM will fail to parse any certs.
+	invalidCert := []byte("-----BEGIN CERTIFICATE-----\nnot-a-real-cert\n-----END CERTIFICATE-----\n")
+
+	transport, err := getOrCreateTransport(invalidCert, boolPtr(true))
+	if err != nil {
+		t.Fatalf("getOrCreateTransport: %v", err)
+	}
+	if transport.TLSClientConfig.RootCAs != nil {
+		t.Fatalf("expected nil RootCAs when no certs could be parsed from caCert, falling back to host root CAs")
+	}
+}
+
+func TestGetOrCreateTransport_HasFleetSuitablePoolingDefaults(t *testing.T) {
+	transport, err := getOrCreateTransport(generateTestCACertPEM(t), boolPtr(true))
+	if err != nil {
+		t.Fatalf("getOrCreateTransport: %v", err)
+	}
+	if transport.IdleConnTimeout <= 0 {
+		t.Fatalf("expected a non-zero IdleConnTimeout so idle connections in the shared transport self-expire, got %v", transport.IdleConnTimeout)
+	}
+	// Go's unset default is 2, which is too low once this Transport is
+	// shared by every credential in the fleet against the same host.
+	if transport.MaxIdleConnsPerHost <= 2 {
+		t.Fatalf("expected MaxIdleConnsPerHost to be raised above the net/http default of 2 for a fleet-shared transport, got %d", transport.MaxIdleConnsPerHost)
+	}
+}
+
+// TestGetOrCreateTransport_ConcurrentAccessReturnsSingleInstance guards against
+// races in the shared transportCache: concurrent first-time callers for the
+// same TLS config must still converge on exactly one *http.Transport, since
+// that transport's connection pool is what makes eviction of the (much
+// higher-cardinality) per-credential scope cache safe.
+func TestGetOrCreateTransport_ConcurrentAccessReturnsSingleInstance(t *testing.T) {
+	caCert := generateTestCACertPEM(t)
+
+	const goroutines = 50
+	type result struct {
+		transport *http.Transport
+		err       error
+	}
+	out := make([]result, goroutines)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func(i int) {
+			defer wg.Done()
+			tr, err := getOrCreateTransport(caCert, boolPtr(true))
+			out[i] = result{transport: tr, err: err}
+		}(i)
+	}
+	wg.Wait()
+
+	first := out[0]
+	if first.err != nil {
+		t.Fatalf("getOrCreateTransport: %v", first.err)
+	}
+	for i, r := range out {
+		if r.err != nil {
+			t.Fatalf("goroutine %d: getOrCreateTransport: %v", i, r.err)
+		}
+		if r.transport != first.transport {
+			t.Fatalf("goroutine %d returned a different *http.Transport instance than goroutine 0", i)
+		}
+	}
+}
+
+// TestGetOrCreateTransport_EvictsLeastRecentlyUsedWhenFull exercises the
+// cache's bound: pushing it past maxCachedTransports must evict the least
+// recently used entry (closing its idle connections), not an arbitrary one,
+// and a recently-touched entry must survive.
+func TestGetOrCreateTransport_EvictsLeastRecentlyUsedWhenFull(t *testing.T) {
+	certs := make([][]byte, maxCachedTransports)
+	transports := make([]*http.Transport, maxCachedTransports)
+	for i := range certs {
+		certs[i] = generateTestCACertPEM(t)
+		tr, err := getOrCreateTransport(certs[i], boolPtr(true))
+		if err != nil {
+			t.Fatalf("getOrCreateTransport(%d): %v", i, err)
+		}
+		transports[i] = tr
+	}
+
+	// Touch index 0 so it becomes most-recently-used; index 1 becomes the
+	// least-recently-used and should be the one evicted below.
+	if tr, err := getOrCreateTransport(certs[0], boolPtr(true)); err != nil || tr != transports[0] {
+		t.Fatalf("expected a cache hit for certs[0] before overflow, got transport=%v err=%v", tr, err)
+	}
+
+	// One more distinct config pushes the cache past its bound.
+	overflowCert := generateTestCACertPEM(t)
+	if _, err := getOrCreateTransport(overflowCert, boolPtr(true)); err != nil {
+		t.Fatalf("getOrCreateTransport(overflow): %v", err)
+	}
+
+	if tr, err := getOrCreateTransport(certs[0], boolPtr(true)); err != nil || tr != transports[0] {
+		t.Fatalf("expected certs[0] (recently used) to survive eviction, got transport=%v err=%v (want %v)", tr, err, transports[0])
+	}
+	if tr, err := getOrCreateTransport(certs[1], boolPtr(true)); err != nil || tr == transports[1] {
+		t.Fatalf("expected certs[1] (least recently used) to have been evicted and replaced, got the original instance back (err=%v)", err)
+	}
+}
+
+// TestSetMaxCachedTransports checks that the bound can be overridden (as
+// NewFactory does from --transport-cache-max-size), and that non-positive
+// values are ignored rather than disabling the cache - unlike the scope
+// cache, this one must always stay on for eviction to remain safe.
+func TestSetMaxCachedTransports(t *testing.T) {
+	original := maxCachedTransports
+	t.Cleanup(func() { setMaxCachedTransports(original) })
+
+	setMaxCachedTransports(3)
+	if maxCachedTransports != 3 {
+		t.Fatalf("expected maxCachedTransports to be updated to 3, got %d", maxCachedTransports)
+	}
+
+	setMaxCachedTransports(0)
+	if maxCachedTransports != 3 {
+		t.Fatalf("expected setMaxCachedTransports(0) to be ignored, got %d", maxCachedTransports)
+	}
+
+	setMaxCachedTransports(-5)
+	if maxCachedTransports != 3 {
+		t.Fatalf("expected setMaxCachedTransports(-5) to be ignored, got %d", maxCachedTransports)
+	}
+}


### PR DESCRIPTION
pkg/scope cached one *http.Transport per credential (via the scope LRU cache), but evicting or refreshing a scope never closed it. net/http has no finalizer on Transport, so an evicted scope's idle keep-alive connections were never released - only accumulated - for the lifetime of the manager process. With one credential per cluster and a small scope cache, this showed up as tens of thousands of stale established connections across a fleet of clusters.

Key transports by TLS trust config (CA bundle + verify mode) instead of by credential: that dimension is low-cardinality and stable across a fleet against the same cloud(s), so it can be cached in a small, explicitly-evicting LRU (closing idle connections on overflow) without reintroducing the leak. The credential-level scope cache can now evict freely since it no longer owns an exclusive connection pool.

Also raises MaxIdleConnsPerHost to 25 since this transport is now shared by every credential in the fleet against a given host, and adds --transport-cache-max-size to make the new cache's bound configurable.

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3227 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
