### PR TITLE
🌱Bump go version to 1.26.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 # Build the manager binary
 ARG GO_VERSION
-FROM golang:${GO_VERSION:-1.26.4} AS builder
+FROM golang:${GO_VERSION:-1.26.5} AS builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg goproxy=$(go env GOPROXY) to override the goproxy

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ unexport GOPATH
 TRACE ?= 0
 
 # Go
-GO_VERSION ?= 1.26.4
+GO_VERSION ?= 1.26.5
 
 # Ensure correct toolchain is used
 GOTOOLCHAIN = go$(GO_VERSION)

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@ command = "make -C docs/book build"
 publish = "docs/book/book"
 
 [build.environment]
-GO_VERSION = "1.26.4"
+GO_VERSION = "1.26.5"
 
 # Standard Netlify redirects
 [[redirects]]


### PR DESCRIPTION
Bump go to address the following CVEs
 CVE-2026-39822 
 CVE-2026-42505 