### PR TITLE
📖 docs: remove reference to removed kustomize installation method for ORC

### DIFF
--- a/docs/book/src/clusteropenstack/configuration.md
+++ b/docs/book/src/clusteropenstack/configuration.md
@@ -142,12 +142,6 @@ ORC_VERSION=v2.0.3
 kubectl apply -f "https://github.com/k-orc/openstack-resource-controller/releases/download/${ORC_VERSION}/install.yaml"
 ```
 
-We also publish a Kustomize module which can be used to install ORC:
-
-```bash
-kubectl apply --server-side -k "https://github.com/k-orc/openstack-resource-controller/dist?ref=${ORC_VERSION}"
-```
-
 In most cases, the default configuration should be sufficient.
 Check the [ORC documentation](https://k-orc.cloud) for more information.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The upstream documentation for ORC no longer mentions any kustomize related [installation method](https://k-orc.cloud/installation/) that could be used. I did snoop around for a while and found some `kustomization.yaml` files in the [config](https://github.com/k-orc/openstack-resource-controller/tree/main/config) and [examples](https://github.com/k-orc/openstack-resource-controller/tree/main/examples) subdirs, but neither seems to be intended for direct downstream consumption AFAICT. 

So i figured we could save someone else the research and remove the reference for the time being (:

**Which issue(s) this PR fixes**:
Fixes #3266

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
