### PR TITLE
✨ infer IP version from subnet CIDR on creation

### DIFF
--- a/pkg/cloud/services/networking/network.go
+++ b/pkg/cloud/services/networking/network.go
@@ -19,6 +19,7 @@ package networking
 import (
 	"errors"
 	"fmt"
+	"net"
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/attributestags"
@@ -224,11 +225,17 @@ func (s *Service) ReconcileSubnet(openStackCluster *infrav1.OpenStackCluster, cl
 }
 
 func (s *Service) createSubnet(openStackCluster *infrav1.OpenStackCluster, clusterResourceName string, name string) (*subnets.Subnet, error) {
+	cidr := openStackCluster.Spec.ManagedSubnets[0].CIDR
+	ipVersion := gophercloud.IPv4
+	if ip, _, err := net.ParseCIDR(cidr); err == nil && ip.To4() == nil {
+		ipVersion = gophercloud.IPv6
+	}
+
 	opts := subnets.CreateOpts{
 		NetworkID:      openStackCluster.Status.Network.ID,
 		Name:           name,
-		IPVersion:      4,
-		CIDR:           openStackCluster.Spec.ManagedSubnets[0].CIDR,
+		IPVersion:      ipVersion,
+		CIDR:           cidr,
 		DNSNameservers: openStackCluster.Spec.ManagedSubnets[0].DNSNameservers,
 		Description:    names.GetDescription(clusterResourceName),
 	}

--- a/pkg/cloud/services/networking/network_test.go
+++ b/pkg/cloud/services/networking/network_test.go
@@ -1070,6 +1070,102 @@ func Test_ReconcileSubnet(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "creation with IPv6 CIDR uses IPVersion 6",
+			openStackCluster: &infrav1.OpenStackCluster{
+				Spec: infrav1.OpenStackClusterSpec{
+					ManagedSubnets: []infrav1.SubnetSpec{
+						{
+							CIDR: "fd12:3456:789a::/48",
+						},
+					},
+				},
+				Status: infrav1.OpenStackClusterStatus{
+					Network: &infrav1.NetworkStatusWithSubnets{
+						NetworkStatus: infrav1.NetworkStatus{
+							ID: fakeNetworkID,
+						},
+					},
+				},
+			},
+			expect: func(m *mock.MockNetworkClientMockRecorder) {
+				m.
+					ListSubnet(subnets.ListOpts{NetworkID: fakeNetworkID, CIDR: "fd12:3456:789a::/48"}).
+					Return([]subnets.Subnet{}, nil)
+
+				m.
+					CreateSubnet(subnets.CreateOpts{
+						NetworkID:   fakeNetworkID,
+						Name:        expectedSubnetName,
+						IPVersion:   6,
+						CIDR:        "fd12:3456:789a::/48",
+						Description: expectedSubnetDesc,
+					}).
+					Return(&subnets.Subnet{
+						ID:   fakeSubnetID,
+						Name: expectedSubnetName,
+						CIDR: "fd12:3456:789a::/48",
+					}, nil)
+			},
+			want: &infrav1.OpenStackClusterStatus{
+				Network: &infrav1.NetworkStatusWithSubnets{
+					NetworkStatus: infrav1.NetworkStatus{
+						ID: fakeNetworkID,
+					},
+					Subnets: []infrav1.Subnet{
+						{
+							Name: expectedSubnetName,
+							ID:   fakeSubnetID,
+							CIDR: "fd12:3456:789a::/48",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "ensures status set when reconciling an existing IPv6 subnet",
+			openStackCluster: &infrav1.OpenStackCluster{
+				Spec: infrav1.OpenStackClusterSpec{
+					ManagedSubnets: []infrav1.SubnetSpec{
+						{
+							CIDR: "fd12:3456:789a::/48",
+						},
+					},
+				},
+				Status: infrav1.OpenStackClusterStatus{
+					Network: &infrav1.NetworkStatusWithSubnets{
+						NetworkStatus: infrav1.NetworkStatus{
+							ID: fakeNetworkID,
+						},
+					},
+				},
+			},
+			expect: func(m *mock.MockNetworkClientMockRecorder) {
+				m.
+					ListSubnet(subnets.ListOpts{NetworkID: fakeNetworkID, CIDR: "fd12:3456:789a::/48"}).
+					Return([]subnets.Subnet{
+						{
+							ID:   fakeSubnetID,
+							Name: expectedSubnetName,
+							CIDR: "fd12:3456:789a::/48",
+						},
+					}, nil)
+			},
+			want: &infrav1.OpenStackClusterStatus{
+				Network: &infrav1.NetworkStatusWithSubnets{
+					NetworkStatus: infrav1.NetworkStatus{
+						ID: fakeNetworkID,
+					},
+					Subnets: []infrav1.Subnet{
+						{
+							Name: expectedSubnetName,
+							ID:   fakeSubnetID,
+							CIDR: "fd12:3456:789a::/48",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**What this PR does / why we need it**:
Subnet creation was unconditionally passing IPVersion 4 to OpenStack, which would cause IPv6 subnets to be created with the wrong IP version. The fix parses the CIDR and selects IPv6 when the network address has no IPv4 representation. Tests are extended to cover both the create and reconcile-existing paths for an IPv6 CIDR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1587

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [x] adds unit tests
