### PR TITLE
🌱 Configure dependabot to avoid golang bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -105,6 +105,10 @@ updates:
   # Ignore golang.org/x minor and major bumps to prevent cascading Go version requirements
   - dependency-name: "golang.org/x/*"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  # Ignore all golang.org/x/crypto and golang.org/x/text bumps to prevent cascading Go version requirements
+  # Not sure why the above golang.org/x/* ignore doesn't catch these.
+  - dependency-name: "golang.org/x/crypto"
+  - dependency-name: "golang.org/x/text"
   # Ignore setup-envtest major and minor bumps to prevent cascading Go version requirements
   - dependency-name: "sigs.k8s.io/controller-runtime/tools/setup-envtest"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
@@ -172,6 +176,10 @@ updates:
   # Ignore golang.org/x minor and major bumps to prevent cascading Go version requirements
   - dependency-name: "golang.org/x/*"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  # Ignore all golang.org/x/crypto and golang.org/x/text bumps to prevent cascading Go version requirements
+  # Not sure why the above /* doesn't catch these.
+  - dependency-name: "golang.org/x/crypto"
+  - dependency-name: "golang.org/x/text"
   # Ignore setup-envtest major and minor bumps to prevent cascading Go version requirements
   - dependency-name: "sigs.k8s.io/controller-runtime/tools/setup-envtest"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]


### PR DESCRIPTION
**What this PR does / why we need it**:

Add explicit ignore rules for `golang.org/x/crypto` and `golang.org/x/text` to prevent cascading Go version requirement changes. This is for the release branches specifically. On main we still want them.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
