### PR TITLE
🌱 Prevent go requirement changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -109,11 +109,14 @@ updates:
   # Not sure why the above golang.org/x/* ignore doesn't catch these.
   - dependency-name: "golang.org/x/crypto"
   - dependency-name: "golang.org/x/text"
+  # Ignore all github.com/prometheus/client_golang bumps to prevent cascading Go version requirements.
+  - dependency-name: "github.com/prometheus/client_golang"
   # Ignore setup-envtest major and minor bumps to prevent cascading Go version requirements
   - dependency-name: "sigs.k8s.io/controller-runtime/tools/setup-envtest"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
-  # Ignore ginkgo to prevent cascading Go version requirements
+  # Ignore ginkgo and gomega to prevent cascading Go version requirements
   - dependency-name: "github.com/onsi/ginkgo/v2"
+  - dependency-name: "github.com/onsi/gomega"
   # Ignore gophercloud minor and major bumps to prevent cascading Go version requirements
   - dependency-name: "github.com/gophercloud/gophercloud/v2"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
@@ -180,11 +183,14 @@ updates:
   # Not sure why the above /* doesn't catch these.
   - dependency-name: "golang.org/x/crypto"
   - dependency-name: "golang.org/x/text"
+  # Ignore all github.com/prometheus/client_golang bumps to prevent cascading Go version requirements.
+  - dependency-name: "github.com/prometheus/client_golang"
   # Ignore setup-envtest major and minor bumps to prevent cascading Go version requirements
   - dependency-name: "sigs.k8s.io/controller-runtime/tools/setup-envtest"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
-  # Ignore ginkgo to prevent cascading Go version requirements
+  # Ignore ginkgo and gomega to prevent cascading Go version requirements
   - dependency-name: "github.com/onsi/ginkgo/v2"
+  - dependency-name: "github.com/onsi/gomega"
   # Ignore gophercloud minor and major bumps to prevent cascading Go version requirements
   - dependency-name: "github.com/gophercloud/gophercloud/v2"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]


### PR DESCRIPTION
Missed a couple of dependencies in the previous PR.

**What this PR does / why we need it**:

Ignore prometheus/client_golang and gomega updates, since they require newer go versions, on the release branches.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

