### PR TITLE
docs: strip JSON tag options from API references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -453,6 +453,7 @@ generate-api-docs-%: $(GEN_CRD_API_REFERENCE_DOCS) FORCE
 		-config=./docs/book/gen-crd-api-reference-docs/config.json \
 		-template-dir=./docs/book/gen-crd-api-reference-docs/template \
 		-out-file=./docs/book/src/api/$*/api.md
+	python3 ./hack/strip-api-doc-tag-options.py ./docs/book/src/api/$*/api.md
 
 ## --------------------------------------
 ##@ Docker

--- a/docs/book/src/api/v1beta1/api.md
+++ b/docs/book/src/api/v1beta1/api.md
@@ -4263,7 +4263,7 @@ This value is used for autoscaling from zero operations as defined in:
 </tr>
 <tr>
 <td>
-<code>nodeInfo,omitempty,omitzero</code><br/>
+<code>nodeInfo</code><br/>
 <em>
 <a href="#infrastructure.cluster.x-k8s.io/v1beta1.NodeInfo">
 NodeInfo

--- a/docs/book/src/api/v1beta2/api.md
+++ b/docs/book/src/api/v1beta2/api.md
@@ -331,7 +331,7 @@ to first set <code>enabled: false</code> which will remove the bastion and then 
 </tr>
 <tr>
 <td>
-<code>identityRef,omitzero</code><br/>
+<code>identityRef</code><br/>
 <em>
 <a href="#infrastructure.cluster.x-k8s.io/v1beta2.OpenStackIdentityReference">
 OpenStackIdentityReference
@@ -424,7 +424,7 @@ OpenStackClusterTemplateSpec
 <table>
 <tr>
 <td>
-<code>template,omitzero</code><br/>
+<code>template</code><br/>
 <em>
 <a href="#infrastructure.cluster.x-k8s.io/v1beta2.OpenStackClusterTemplateResource">
 OpenStackClusterTemplateResource
@@ -513,7 +513,7 @@ string
 </tr>
 <tr>
 <td>
-<code>flavor,omitzero</code><br/>
+<code>flavor</code><br/>
 <em>
 <a href="#infrastructure.cluster.x-k8s.io/v1beta2.FlavorParam">
 FlavorParam
@@ -526,7 +526,7 @@ FlavorParam
 </tr>
 <tr>
 <td>
-<code>image,omitzero</code><br/>
+<code>image</code><br/>
 <em>
 <a href="#infrastructure.cluster.x-k8s.io/v1beta2.ImageParam">
 ImageParam
@@ -800,7 +800,7 @@ OpenStackMachineTemplateSpec
 <table>
 <tr>
 <td>
-<code>template,omitzero</code><br/>
+<code>template</code><br/>
 <em>
 <a href="#infrastructure.cluster.x-k8s.io/v1beta2.OpenStackMachineTemplateResource">
 OpenStackMachineTemplateResource
@@ -1177,7 +1177,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>storage,omitzero</code><br/>
+<code>storage</code><br/>
 <em>
 <a href="#infrastructure.cluster.x-k8s.io/v1beta2.BlockDeviceStorage">
 BlockDeviceStorage
@@ -1704,7 +1704,7 @@ string
 </tr>
 <tr>
 <td>
-<code>subnet,omitzero</code><br/>
+<code>subnet</code><br/>
 <em>
 <a href="#infrastructure.cluster.x-k8s.io/v1beta2.SubnetParam">
 SubnetParam
@@ -2919,7 +2919,7 @@ to first set <code>enabled: false</code> which will remove the bastion and then 
 </tr>
 <tr>
 <td>
-<code>identityRef,omitzero</code><br/>
+<code>identityRef</code><br/>
 <em>
 <a href="#infrastructure.cluster.x-k8s.io/v1beta2.OpenStackIdentityReference">
 OpenStackIdentityReference
@@ -3131,7 +3131,7 @@ BastionStatus
 <tbody>
 <tr>
 <td>
-<code>spec,omitzero</code><br/>
+<code>spec</code><br/>
 <em>
 <a href="#infrastructure.cluster.x-k8s.io/v1beta2.OpenStackClusterSpec">
 OpenStackClusterSpec
@@ -3163,7 +3163,7 @@ OpenStackClusterSpec
 <tbody>
 <tr>
 <td>
-<code>template,omitzero</code><br/>
+<code>template</code><br/>
 <em>
 <a href="#infrastructure.cluster.x-k8s.io/v1beta2.OpenStackClusterTemplateResource">
 OpenStackClusterTemplateResource
@@ -3281,7 +3281,7 @@ string
 </tr>
 <tr>
 <td>
-<code>flavor,omitzero</code><br/>
+<code>flavor</code><br/>
 <em>
 <a href="#infrastructure.cluster.x-k8s.io/v1beta2.FlavorParam">
 FlavorParam
@@ -3294,7 +3294,7 @@ FlavorParam
 </tr>
 <tr>
 <td>
-<code>image,omitzero</code><br/>
+<code>image</code><br/>
 <em>
 <a href="#infrastructure.cluster.x-k8s.io/v1beta2.ImageParam">
 ImageParam
@@ -3628,7 +3628,7 @@ MachineResources
 <tbody>
 <tr>
 <td>
-<code>spec,omitzero</code><br/>
+<code>spec</code><br/>
 <em>
 <a href="#infrastructure.cluster.x-k8s.io/v1beta2.OpenStackMachineSpec">
 OpenStackMachineSpec
@@ -3660,7 +3660,7 @@ OpenStackMachineSpec
 <tbody>
 <tr>
 <td>
-<code>template,omitzero</code><br/>
+<code>template</code><br/>
 <em>
 <a href="#infrastructure.cluster.x-k8s.io/v1beta2.OpenStackMachineTemplateResource">
 OpenStackMachineTemplateResource
@@ -3722,7 +3722,7 @@ This value is used for autoscaling from zero operations as defined in:
 </tr>
 <tr>
 <td>
-<code>nodeInfo,omitempty,omitzero</code><br/>
+<code>nodeInfo</code><br/>
 <em>
 <a href="#infrastructure.cluster.x-k8s.io/v1beta2.NodeInfo">
 NodeInfo
@@ -4567,7 +4567,7 @@ It is a unique identifier for the property.</p>
 </tr>
 <tr>
 <td>
-<code>value,omitzero</code><br/>
+<code>value</code><br/>
 <em>
 <a href="#infrastructure.cluster.x-k8s.io/v1beta2.SchedulerHintAdditionalValue">
 SchedulerHintAdditionalValue

--- a/hack/strip-api-doc-tag-options.py
+++ b/hack/strip-api-doc-tag-options.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Remove JSON tag options from generated API reference field names."""
+
+import re
+import sys
+from pathlib import Path
+
+
+FIELD_TAG = re.compile(
+    r"(<code>[A-Za-z_][A-Za-z0-9_]*)(?:,[A-Za-z_][A-Za-z0-9_]*)+(</code><br/>)"
+)
+
+
+def strip_tag_options(document: str) -> str:
+    """Return generated API documentation with field tag options removed."""
+    return FIELD_TAG.sub(r"\1\2", document)
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(f"usage: {Path(sys.argv[0]).name} FILE [FILE ...]", file=sys.stderr)
+        return 2
+
+    for filename in sys.argv[1:]:
+        path = Path(filename)
+        original = path.read_text(encoding="utf-8")
+        updated = strip_tag_options(original)
+        if updated != original:
+            path.write_text(updated, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Fixes #3222\n\nThe generated API reference currently renders JSON serialization options such as omitzero as part of field names. This adds a small deterministic post-generation sanitizer to the existing generate-api-docs-* target and regenerates the affected v1beta1/v1beta2 references. The sanitizer only matches field-name code cells, so prose and code examples remain unchanged, and repeated runs are idempotent.\n\nValidation: the sanitizer’s focused Python checks pass, all generated API docs are free of ,omitzero, and git diff --check passes. The full Make/Go generation pipeline was not available in this Windows environment because Make and Go are not installed.