### PR TITLE
fix(networking): persist recreated port IDs

### DIFF
--- a/pkg/cloud/services/networking/port.go
+++ b/pkg/cloud/services/networking/port.go
@@ -411,7 +411,7 @@ func (s *Service) EnsurePorts(eventObject runtime.Object, desiredPorts []infrav1
 		// If we already have the status, replace it,
 		// otherwise append it.
 		if i < len(resources.Ports) {
-			resources.Ports[i] = portStatus
+			resources.Ports[i] = infrav1.PortStatus{ID: port.ID}
 		} else {
 			resources.Ports = append(resources.Ports, infrav1.PortStatus{
 				ID: port.ID,

--- a/pkg/cloud/services/networking/port_test.go
+++ b/pkg/cloud/services/networking/port_test.go
@@ -516,6 +516,42 @@ func Test_EnsurePort(t *testing.T) {
 	}
 }
 
+func TestEnsurePortsUpdatesRecreatedPortStatus(t *testing.T) {
+	const (
+		stalePortID = "stale-port-id"
+		newPortID   = "new-port-id"
+		networkID   = "network-id"
+	)
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockClient := mock.NewMockNetworkClient(mockCtrl)
+	mockClient.EXPECT().ListPort(ports.ListOpts{ID: stalePortID}).Return(nil, nil)
+	mockClient.EXPECT().CreatePort(gomock.Any()).Return(&ports.Port{ID: newPortID}, nil)
+	mockClient.EXPECT().ListPort(ports.ListOpts{ID: newPortID}).Return([]ports.Port{{ID: newPortID}}, nil)
+
+	resources := infrav1alpha1.ServerResources{
+		Ports: []infrav1.PortStatus{{ID: stalePortID}},
+	}
+	service := Service{client: mockClient}
+	err := service.EnsurePorts(&infrav1.OpenStackMachine{}, []infrav1.ResolvedPortSpec{{
+		Name:      "server-0",
+		NetworkID: networkID,
+	}}, &resources)
+
+	g := NewWithT(t)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(resources.Ports).To(Equal([]infrav1.PortStatus{{ID: newPortID}}))
+
+	err = service.EnsurePorts(&infrav1.OpenStackMachine{}, []infrav1.ResolvedPortSpec{{
+		Name:      "server-0",
+		NetworkID: networkID,
+	}}, &resources)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(resources.Ports).To(Equal([]infrav1.PortStatus{{ID: newPortID}}))
+}
+
 func TestService_ConstructPorts(t *testing.T) {
 	const (
 		defaultNetworkID = "3c66f3ca-2d26-4d9d-ae3b-568f54129773"


### PR DESCRIPTION
## Summary

- persist the ID of a replacement Neutron port when a previously recorded port is missing
- prevent repeated reconciles from creating a new detached port for the same server

## Root cause

`EnsurePorts` reused the stale status entry after `EnsurePort` created a replacement. The next reconcile looked up the stale ID again and created another port.

## Validation

- `go test ./pkg/cloud/services/networking -count=1`
- `make verify`

## Regression coverage

The new unit test simulates a missing recorded port, verifies the replacement ID is persisted, then verifies the next reconcile reuses that port without a second create.