### PR TITLE
🐛 fix(openstackserver): recover from Nova ERROR state

### DIFF
--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -1102,7 +1102,7 @@ func (r *OpenStackClusterReconciler) SetupWithManager(ctx context.Context, mgr c
 		Watches(
 			&infrav1alpha1.OpenStackServer{},
 			handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &infrav1.OpenStackCluster{}),
-			builder.WithPredicates(OpenStackServerReconcileComplete(log)),
+			builder.WithPredicates(OpenStackServerStatusReportable(log)),
 		).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(mgr.GetScheme(), ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
 		WithEventFilter(predicates.ResourceIsNotExternallyManaged(mgr.GetScheme(), ctrl.LoggerFrom(ctx))).

--- a/controllers/openstackmachine_controller.go
+++ b/controllers/openstackmachine_controller.go
@@ -220,7 +220,7 @@ func (r *OpenStackMachineReconciler) SetupWithManager(ctx context.Context, mgr c
 		Watches(
 			&infrav1alpha1.OpenStackServer{},
 			handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &infrav1.OpenStackMachine{}),
-			builder.WithPredicates(OpenStackServerReconcileComplete(log)),
+			builder.WithPredicates(OpenStackServerStatusReportable(log)),
 		).
 		Complete(r)
 }
@@ -355,13 +355,6 @@ func GetPortIDs(ports []infrav1.PortStatus) []string {
 
 func (r *OpenStackMachineReconciler) reconcileNormal(ctx context.Context, scope *scope.WithLogger, clusterResourceName string, openStackCluster *infrav1.OpenStackCluster, machine *clusterv1.Machine, openStackMachine *infrav1.OpenStackMachine) (_ ctrl.Result, reterr error) {
 	var err error
-
-	// If the OpenStackMachine has a terminal error condition, return early.
-	readyCond := conditions.Get(openStackMachine, clusterv1.ReadyCondition)
-	if readyCond != nil && readyCond.Status == metav1.ConditionFalse && readyCond.Reason == infrav1.InstanceStateErrorReason {
-		scope.Logger().Info("Not reconciling machine in failed state. See openStackMachine.status.conditions or previously logged error for details")
-		return ctrl.Result{}, nil
-	}
 
 	if openStackCluster.Status.Initialization == nil || !openStackCluster.Status.Initialization.Provisioned {
 		scope.Logger().Info("Cluster infrastructure is not ready yet, re-queuing machine")
@@ -561,7 +554,7 @@ func (r *OpenStackMachineReconciler) reconcileMachineState(scope *scope.WithLogg
 			Reason:  infrav1.InstanceStateErrorReason,
 			Message: errorMessage,
 		})
-		return &ctrl.Result{}
+		return &ctrl.Result{RequeueAfter: waitForInstanceBecomeActiveToReconcile}
 	case infrav1.InstanceStateDeleted:
 		// we should avoid further actions for DELETED VM
 		scope.Logger().Info("Machine instance state is DELETED, no actions")

--- a/controllers/openstackmachine_controller_test.go
+++ b/controllers/openstackmachine_controller_test.go
@@ -35,6 +35,7 @@ import (
 	conditions "sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	infrav1alpha1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha1"
@@ -595,6 +596,7 @@ func TestReconcileMachineState(t *testing.T) { //nolint:gocyclo,cyclop // this i
 		instanceState                   *infrav1.InstanceState
 		serverConditions                []metav1.Condition
 		expectRequeue                   bool
+		expectRequeueAfter              bool
 		expectedInstanceReadyCondition  *metav1.Condition
 		expectedReadyCondition          *metav1.Condition
 		expectInitializationProvisioned bool
@@ -681,9 +683,10 @@ func TestReconcileMachineState(t *testing.T) { //nolint:gocyclo,cyclop // this i
 			expectInitializationProvisioned: true,
 		},
 		{
-			name:          "Instance state ERROR sets conditions to False",
-			instanceState: ptr.To(infrav1.InstanceStateError),
-			expectRequeue: true,
+			name:               "Instance state ERROR sets conditions to False",
+			instanceState:      ptr.To(infrav1.InstanceStateError),
+			expectRequeue:      true,
+			expectRequeueAfter: true,
 			expectedInstanceReadyCondition: &metav1.Condition{
 				Type:   infrav1.InstanceReadyCondition,
 				Status: metav1.ConditionFalse,
@@ -706,7 +709,8 @@ func TestReconcileMachineState(t *testing.T) { //nolint:gocyclo,cyclop // this i
 					Message: "Server entered ERROR state: No valid host was found",
 				},
 			},
-			expectRequeue: true,
+			expectRequeue:      true,
+			expectRequeueAfter: true,
 			expectedInstanceReadyCondition: &metav1.Condition{
 				Type:    infrav1.InstanceReadyCondition,
 				Status:  metav1.ConditionFalse,
@@ -813,6 +817,11 @@ func TestReconcileMachineState(t *testing.T) { //nolint:gocyclo,cyclop // this i
 			if !tt.expectRequeue && result != nil {
 				t.Errorf("expected no requeue, got %v", result)
 			}
+			if tt.expectRequeueAfter {
+				if result == nil || result.RequeueAfter != waitForInstanceBecomeActiveToReconcile {
+					t.Errorf("expected RequeueAfter %v, got %v", waitForInstanceBecomeActiveToReconcile, result)
+				}
+			}
 
 			// Check InstanceReadyCondition
 			if tt.expectedInstanceReadyCondition != nil {
@@ -862,6 +871,91 @@ func TestReconcileMachineState(t *testing.T) { //nolint:gocyclo,cyclop // this i
 			// So we skip the failure field checks for v1beta2
 		})
 	}
+}
+
+func TestOpenStackServerStatusReportable_MachineRecoversFromError(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	errorServer := &infrav1alpha1.OpenStackServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      openStackMachineName,
+			Namespace: namespace,
+		},
+		Status: infrav1alpha1.OpenStackServerStatus{
+			Ready:         false,
+			InstanceID:    ptr.To(testInstanceID),
+			InstanceState: ptr.To(infrav1.InstanceStateError),
+			Conditions: []metav1.Condition{
+				{
+					Type:    infrav1.InstanceReadyCondition,
+					Status:  metav1.ConditionFalse,
+					Reason:  infrav1.InstanceStateErrorReason,
+					Message: "Instance is in ERROR state",
+				},
+			},
+		},
+	}
+
+	recoveredServer := errorServer.DeepCopy()
+	recoveredServer.Status.Ready = true
+	recoveredServer.Status.InstanceState = ptr.To(infrav1.InstanceStateActive)
+	recoveredServer.Status.Conditions = []metav1.Condition{
+		{
+			Type:   infrav1.InstanceReadyCondition,
+			Status: metav1.ConditionTrue,
+			Reason: infrav1.ReadyConditionReason,
+		},
+	}
+
+	pred := OpenStackServerStatusReportable(logr.Discard())
+	g.Expect(pred.Update(event.UpdateEvent{ObjectOld: errorServer, ObjectNew: recoveredServer})).To(BeTrue())
+
+	openStackMachine := &infrav1.OpenStackMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      openStackMachineName,
+			Namespace: namespace,
+		},
+		Spec: infrav1.OpenStackMachineSpec{
+			Flavor: infrav1.FlavorParam{
+				Filter: &infrav1.FlavorFilter{
+					Name: ptr.To(flavorName),
+				},
+			},
+			Image: infrav1.ImageParam{
+				Filter: &infrav1.ImageFilter{
+					Name: ptr.To("test-image"),
+				},
+			},
+		},
+	}
+	conditions.Set(openStackMachine, metav1.Condition{
+		Type:    infrav1.InstanceReadyCondition,
+		Status:  metav1.ConditionFalse,
+		Reason:  infrav1.InstanceStateErrorReason,
+		Message: "Instance is in ERROR state",
+	})
+	conditions.Set(openStackMachine, metav1.Condition{
+		Type:    clusterv1.ReadyCondition,
+		Status:  metav1.ConditionFalse,
+		Reason:  infrav1.InstanceStateErrorReason,
+		Message: "Instance is in ERROR state",
+	})
+
+	machine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-machine",
+			Namespace: namespace,
+		},
+	}
+
+	r := &OpenStackMachineReconciler{}
+	result := r.reconcileMachineState(scope.NewWithLogger(nil, logr.Discard()), openStackMachine, machine, recoveredServer)
+
+	g.Expect(result).To(BeNil())
+	g.Expect(conditions.Get(openStackMachine, clusterv1.ReadyCondition)).ToNot(BeNil())
+	g.Expect(conditions.Get(openStackMachine, clusterv1.ReadyCondition).Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(conditions.Get(openStackMachine, infrav1.InstanceReadyCondition)).ToNot(BeNil())
+	g.Expect(conditions.Get(openStackMachine, infrav1.InstanceReadyCondition).Status).To(Equal(metav1.ConditionTrue))
 }
 
 var _ = Describe("OpenStackMachine controller", func() {

--- a/controllers/openstackserver_controller.go
+++ b/controllers/openstackserver_controller.go
@@ -306,21 +306,7 @@ func (r *OpenStackServerReconciler) reconcileDelete(scope *scope.WithLogger, ope
 	return nil
 }
 
-func IsServerTerminalError(server *infrav1alpha1.OpenStackServer) bool {
-	if server.Status.InstanceState != nil && *server.Status.InstanceState == infrav1.InstanceStateError {
-		return true
-	}
-	return false
-}
-
 func (r *OpenStackServerReconciler) reconcileNormal(ctx context.Context, scope *scope.WithLogger, openStackServer *infrav1alpha1.OpenStackServer) (_ ctrl.Result, reterr error) {
-	// If the OpenStackServer is in an error state, return early.
-	if IsServerTerminalError(openStackServer) {
-		log := scope.Logger().WithValues("OpenStackServer", klog.KObj(openStackServer))
-		log.Info("Not reconciling OpenStackServer in error state. See openStackServer.status or previously logged error for details")
-		return ctrl.Result{}, nil
-	}
-
 	log := scope.Logger().WithValues("OpenStackServer", klog.KObj(openStackServer))
 	log.Info("Reconciling OpenStackServer")
 
@@ -426,6 +412,8 @@ func (r *OpenStackServerReconciler) reconcileNormal(ctx context.Context, scope *
 	state := instanceStatus.State()
 	openStackServer.Status.InstanceID = ptr.To(instanceStatus.ID())
 	openStackServer.Status.InstanceState = &state
+	// set to false by default to avoid reporting stale Ready=true.
+	openStackServer.Status.Ready = false
 
 	switch instanceStatus.State() {
 	case infrav1.InstanceStateActive:
@@ -444,7 +432,7 @@ func (r *OpenStackServerReconciler) reconcileNormal(ctx context.Context, scope *
 			Status: metav1.ConditionFalse,
 			Reason: infrav1.InstanceStateErrorReason,
 		})
-		return ctrl.Result{}, nil
+		return ctrl.Result{RequeueAfter: waitForInstanceBecomeActiveToReconcile}, nil
 	case infrav1.InstanceStateDeleted:
 		// we should avoid further actions for DELETED VM
 		scope.Logger().Info("Server instance state is DELETED, no actions")
@@ -812,9 +800,25 @@ func (r *OpenStackServerReconciler) reconcileDeleteFloatingAddressFromPool(scope
 	return r.Client.Update(context.Background(), claim)
 }
 
-// OpenStackServerReconcileComplete returns a predicate that determines if a OpenStackServer has finished reconciling.
-func OpenStackServerReconcileComplete(log logr.Logger) predicate.Funcs {
-	log = log.WithValues("predicate", "OpenStackServerReconcileComplete")
+// instanceStateReportable returns true when InstanceState is one that dependent
+// controllers (OpenStackMachine, OpenStackCluster) should observe.
+// ACTIVE, ERROR, and DELETED are reportable; BUILD, SHUTOFF, MIGRATING, etc. are not.
+func instanceStateReportable(state *infrav1.InstanceState) bool {
+	if state == nil {
+		return false
+	}
+	switch *state {
+	case infrav1.InstanceStateActive, infrav1.InstanceStateError, infrav1.InstanceStateDeleted:
+		return true
+	default:
+		return false
+	}
+}
+
+// OpenStackServerStatusReportable returns a predicate that filters out OpenstackServer status changes that should not be reported to parent controllers.
+// e.g. when a server is still reconciling, or when a server is in a non-reportable state.
+func OpenStackServerStatusReportable(log logr.Logger) predicate.Funcs {
+	log = log.WithValues("predicate", "OpenStackServerStatusReportable")
 
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
@@ -827,7 +831,7 @@ func OpenStackServerReconcileComplete(log logr.Logger) predicate.Funcs {
 			}
 			log = log.WithValues("OpenStackServer", klog.KObj(server))
 
-			if server.Status.Ready || IsServerTerminalError(server) {
+			if server.Status.Ready || instanceStateReportable(server.Status.InstanceState) {
 				log.V(5).Info("OpenStackServer finished reconciling, allowing further processing")
 				return true
 			}
@@ -850,14 +854,20 @@ func OpenStackServerReconcileComplete(log logr.Logger) predicate.Funcs {
 				return false
 			}
 
-			oldFinished := oldServer.Status.Ready || IsServerTerminalError(oldServer)
-			newFinished := newServer.Status.Ready || IsServerTerminalError(newServer)
-			if !oldFinished && newFinished {
-				log.V(5).Info("OpenStackServer finished reconciling, allowing further processing")
+			if oldServer.Status.Ready != newServer.Status.Ready {
+				log.V(5).Info("OpenStackServer Ready changed, allowing further processing")
 				return true
 			}
 
-			log.V(4).Info("OpenStackServer is still reconciling, blocking further processing")
+			oldState := oldServer.Status.InstanceState
+			newState := newServer.Status.InstanceState
+			if ptr.Deref(oldState, "") != ptr.Deref(newState, "") &&
+				(instanceStateReportable(oldState) || instanceStateReportable(newState)) {
+				log.V(5).Info("OpenStackServer reportable InstanceState changed, allowing further processing")
+				return true
+			}
+
+			log.V(4).Info("OpenStackServer status change is not reportable, blocking further processing")
 			return false
 		},
 		DeleteFunc:  func(event.DeleteEvent) bool { return true },

--- a/controllers/openstackserver_controller_test.go
+++ b/controllers/openstackserver_controller_test.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/testr"
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumes"
@@ -42,6 +43,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	infrav1alpha1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha1"
@@ -676,6 +678,8 @@ func Test_OpenStackServerReconcileCreate(t *testing.T) {
 		osServer      infrav1alpha1.OpenStackServer
 		expect        func(r *recorders)
 		wantErr       error
+		wantResult    *reconcile.Result
+		wantReady     *bool
 		wantCondition *metav1.Condition
 	}{
 		{
@@ -753,6 +757,81 @@ func Test_OpenStackServerReconcileCreate(t *testing.T) {
 				Message: "Error creating port",
 			},
 		},
+		{
+			name: "Server in ERROR state keeps reconciling and recovers when Nova returns ACTIVE",
+			osServer: infrav1alpha1.OpenStackServer{
+				Spec: infrav1alpha1.OpenStackServerSpec{
+					Flavor: ptr.To(defaultFlavor),
+					Image:  defaultImage,
+					Ports:  defaultPortOpts,
+				},
+				Status: infrav1alpha1.OpenStackServerStatus{
+					Ready:         false,
+					InstanceID:    ptr.To(instanceUUID),
+					InstanceState: ptr.To(infrav1.InstanceStateError),
+					Resolved: &infrav1alpha1.ResolvedServerSpec{
+						ImageID:  imageUUID,
+						FlavorID: flavorUUID,
+						Ports:    defaultResolvedPorts,
+					},
+					Resources: &infrav1alpha1.ServerResources{
+						Ports: defaultPortsStatus,
+					},
+				},
+			},
+			expect: func(r *recorders) {
+				listDefaultPortsWithID(r)
+				r.compute.GetServer(instanceUUID).Return(&servers.Server{
+					ID:     instanceUUID,
+					Name:   openStackServerName,
+					Status: "ACTIVE",
+				}, nil)
+			},
+			wantReady: ptr.To(true),
+			wantCondition: &metav1.Condition{
+				Type:   infrav1.InstanceReadyCondition,
+				Status: metav1.ConditionTrue,
+				Reason: infrav1.ReadyConditionReason,
+			},
+		},
+		{
+			name: "Server in ERROR state requeues while Nova still reports ERROR",
+			osServer: infrav1alpha1.OpenStackServer{
+				Spec: infrav1alpha1.OpenStackServerSpec{
+					Flavor: ptr.To(defaultFlavor),
+					Image:  defaultImage,
+					Ports:  defaultPortOpts,
+				},
+				Status: infrav1alpha1.OpenStackServerStatus{
+					Ready:         true, // stale Ready from before ERROR
+					InstanceID:    ptr.To(instanceUUID),
+					InstanceState: ptr.To(infrav1.InstanceStateError),
+					Resolved: &infrav1alpha1.ResolvedServerSpec{
+						ImageID:  imageUUID,
+						FlavorID: flavorUUID,
+						Ports:    defaultResolvedPorts,
+					},
+					Resources: &infrav1alpha1.ServerResources{
+						Ports: defaultPortsStatus,
+					},
+				},
+			},
+			expect: func(r *recorders) {
+				listDefaultPortsWithID(r)
+				r.compute.GetServer(instanceUUID).Return(&servers.Server{
+					ID:     instanceUUID,
+					Name:   openStackServerName,
+					Status: "ERROR",
+				}, nil)
+			},
+			wantResult: &reconcile.Result{RequeueAfter: waitForInstanceBecomeActiveToReconcile},
+			wantReady:  ptr.To(false),
+			wantCondition: &metav1.Condition{
+				Type:   infrav1.InstanceReadyCondition,
+				Status: metav1.ConditionFalse,
+				Reason: infrav1.InstanceStateErrorReason,
+			},
+		},
 	}
 	for i := range tests {
 		tt := &tests[i]
@@ -779,13 +858,21 @@ func Test_OpenStackServerReconcileCreate(t *testing.T) {
 			osServer.Name = openStackServerName
 			osServer.Finalizers = []string{infrav1alpha1.OpenStackServerFinalizer}
 
-			_, err := reconciler.reconcileNormal(ctx, scopeWithLogger, &tt.osServer)
+			result, err := reconciler.reconcileNormal(ctx, scopeWithLogger, &tt.osServer)
 
 			// Check error result
 			if tt.wantErr != nil {
 				g.Expect(err).To(Equal(tt.wantErr))
 			} else {
 				g.Expect(err).NotTo(HaveOccurred())
+			}
+
+			if tt.wantResult != nil {
+				g.Expect(result).To(Equal(*tt.wantResult))
+			}
+
+			if tt.wantReady != nil {
+				g.Expect(tt.osServer.Status.Ready).To(Equal(*tt.wantReady))
 			}
 
 			// Check the condition is set correctly
@@ -989,6 +1076,70 @@ func TestOpenStackServerReconciler_getOrCreateServer(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOpenStackServerStatusReportable(t *testing.T) {
+	g := NewGomegaWithT(t)
+	pred := OpenStackServerStatusReportable(logr.Discard())
+
+	building := &infrav1alpha1.OpenStackServer{
+		Status: infrav1alpha1.OpenStackServerStatus{
+			InstanceState: ptr.To(infrav1.InstanceStateBuild),
+		},
+	}
+	errorServer := &infrav1alpha1.OpenStackServer{
+		Status: infrav1alpha1.OpenStackServerStatus{
+			InstanceState: ptr.To(infrav1.InstanceStateError),
+		},
+	}
+	readyServer := &infrav1alpha1.OpenStackServer{
+		Status: infrav1alpha1.OpenStackServerStatus{
+			Ready:         true,
+			InstanceState: ptr.To(infrav1.InstanceStateActive),
+		},
+	}
+	shutoffServer := &infrav1alpha1.OpenStackServer{
+		Status: infrav1alpha1.OpenStackServerStatus{
+			InstanceState: ptr.To(infrav1.InstanceStateShutoff),
+		},
+	}
+	migratingServer := &infrav1alpha1.OpenStackServer{
+		Status: infrav1alpha1.OpenStackServerStatus{
+			InstanceState: ptr.To(infrav1.InstanceState("MIGRATING")),
+		},
+	}
+
+	t.Run("CreateFunc allows Ready and ERROR servers", func(_ *testing.T) {
+		g.Expect(pred.Create(event.CreateEvent{Object: readyServer})).To(BeTrue())
+		g.Expect(pred.Create(event.CreateEvent{Object: errorServer})).To(BeTrue())
+		g.Expect(pred.Create(event.CreateEvent{Object: building})).To(BeFalse())
+	})
+
+	t.Run("UpdateFunc allows becoming Ready", func(_ *testing.T) {
+		g.Expect(pred.Update(event.UpdateEvent{ObjectOld: building, ObjectNew: readyServer})).To(BeTrue())
+	})
+
+	t.Run("UpdateFunc allows becoming ERROR", func(_ *testing.T) {
+		g.Expect(pred.Update(event.UpdateEvent{ObjectOld: building, ObjectNew: errorServer})).To(BeTrue())
+	})
+
+	t.Run("UpdateFunc allows ERROR to Ready recovery", func(_ *testing.T) {
+		g.Expect(pred.Update(event.UpdateEvent{ObjectOld: errorServer, ObjectNew: readyServer})).To(BeTrue())
+	})
+
+	t.Run("UpdateFunc allows Ready to ERROR", func(_ *testing.T) {
+		g.Expect(pred.Update(event.UpdateEvent{ObjectOld: readyServer, ObjectNew: errorServer})).To(BeTrue())
+	})
+
+	t.Run("UpdateFunc blocks unrelated status updates while building", func(_ *testing.T) {
+		buildingUpdated := building.DeepCopy()
+		buildingUpdated.Status.Resolved = &infrav1alpha1.ResolvedServerSpec{ImageID: imageUUID}
+		g.Expect(pred.Update(event.UpdateEvent{ObjectOld: building, ObjectNew: buildingUpdated})).To(BeFalse())
+	})
+
+	t.Run("UpdateFunc blocks transitions between non-reportable InstanceStates", func(_ *testing.T) {
+		g.Expect(pred.Update(event.UpdateEvent{ObjectOld: shutoffServer, ObjectNew: migratingServer})).To(BeFalse())
+	})
 }
 
 var _ = Describe("OpenStackServer controller", func() {


### PR DESCRIPTION
Stop treating InstanceState ERROR as terminal so servers can reconcile again when Nova returns to ACTIVE.

**What this PR does / why we need it**:
OpenstackServers ending up in error due to a temporary problem were never reconciled anymore: this PR drops the notion of "terminal error" to requeue instead.

**Which issue(s) this PR fixes**:
Fixes #2622

**Special notes for your reviewer**:

* Still have a doubt with the term "Reportable": to filter out transitioning states,

**TODOs**:

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [x] adds unit tests

