### PR TITLE
🌱 Update gcb-docker-gcloud image registry and digest

### DIFF
--- a/cloudbuild-nightly.yaml
+++ b/cloudbuild-nightly.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-- name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:ff388e0dc16351e96f8464e2e185b74a7578a5ccb7a112cf3393468e59e6e2d2' # v20260205-38cfa9523f
+- name: 'registry.k8s.io/releng/gcb-docker-gcloud@sha256:b2651f57b579d925a243e308c41546d4fd895f705de091a5a8a39060e6192604' # v20260806
   entrypoint: make
   env:
   - DOCKER_CLI_EXPERIMENTAL=enabled

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,10 +5,10 @@ options:
   machineType: 'N1_HIGHCPU_8'
 steps:
 # To check if the image can handle the build, you can try it like this:
-# docker run --rm -it -v $(pwd):/workspace gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:${TAG}
+# docker run --rm -it -v $(pwd):/workspace registry.k8s.io/releng/gcb-docker-gcloud:${TAG}
 # make clean # make sure we have something to build
 # make staging-manifests
-- name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:ff388e0dc16351e96f8464e2e185b74a7578a5ccb7a112cf3393468e59e6e2d2' # v20260205-38cfa9523f
+- name: 'registry.k8s.io/releng/gcb-docker-gcloud@sha256:b2651f57b579d925a243e308c41546d4fd895f705de091a5a8a39060e6192604' # v20260806
   entrypoint: make
   env:
   - DOCKER_CLI_EXPERIMENTAL=enabled


### PR DESCRIPTION
**What this PR does / why we need it**:

Migrate from staging `gcr.io/k8s-staging-test-infra` to `registry.k8s.io/releng` and update to latest version. This way we don't have to worry about retention of the images.

Ref: https://github.com/kubernetes/k8s.io/issues/9599
This replaces the workaround in https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/3236

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests
