### PR TITLE
🌱Bump Go version to 1.26.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 # Build the manager binary
 ARG GO_VERSION
-FROM golang:${GO_VERSION:-1.26.5} AS builder
+FROM golang:${GO_VERSION:-1.26.6} AS builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg goproxy=$(go env GOPROXY) to override the goproxy

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ unexport GOPATH
 TRACE ?= 0
 
 # Go
-GO_VERSION ?= 1.26.5
+GO_VERSION ?= 1.26.6
 
 # Ensure correct toolchain is used
 GOTOOLCHAIN = go$(GO_VERSION)

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@ command = "make -C docs/book build"
 publish = "docs/book/book"
 
 [build.environment]
-GO_VERSION = "1.26.5"
+GO_VERSION = "1.26.6"
 
 # Standard Netlify redirects
 [[redirects]]


### PR DESCRIPTION
Bump go version to 1.26.6 to address the following CVEs
CVE-2026-56865
CVE-2026-56864 
CVE-2026-56859 
CVE-2026-56853 
CVE-2026-56860 
CVE-2026-46600
CVE-2026-56862 
CVE-2026-56858 
CVE-2026-39821
CVE-2026-33818