### PR TITLE
🐛 Guard Neutron tagging by extension support

### DIFF
--- a/pkg/cloud/services/networking/floatingip.go
+++ b/pkg/cloud/services/networking/floatingip.go
@@ -58,6 +58,17 @@ func (s *Service) GetOrCreateFloatingIP(eventObject runtime.Object, openStackClu
 	fpCreateOpts.FloatingNetworkID = openStackCluster.Status.ExternalNetwork.ID
 	fpCreateOpts.Description = names.GetDescription(clusterResourceName)
 
+	// Determine standard-attr-tag support before allocating the floating IP,
+	// so that a failed extension lookup doesn't leak an allocated floating
+	// IP that CAPO never records or retries tagging for.
+	var tagsSupported bool
+	if len(openStackCluster.Spec.Tags) > 0 {
+		tagsSupported, err = s.hasStandardAttrTagExtension()
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	s.scope.Logger().Info("Creating floating IP", "ip", fpCreateOpts.FloatingIP, "floatingNetworkID", openStackCluster.Status.ExternalNetwork.ID, "description", fpCreateOpts.Description)
 
 	fp, err = s.client.CreateFloatingIP(fpCreateOpts)
@@ -67,12 +78,16 @@ func (s *Service) GetOrCreateFloatingIP(eventObject runtime.Object, openStackClu
 	}
 
 	if len(openStackCluster.Spec.Tags) > 0 {
-		mc := metrics.NewMetricPrometheusContext("floating_ip", "update")
-		_, err = s.client.ReplaceAllAttributesTags("floatingips", fp.ID, attributestags.ReplaceAllOpts{
-			Tags: openStackCluster.Spec.Tags,
-		})
-		if mc.ObserveRequest(err) != nil {
-			return nil, err
+		if tagsSupported {
+			mc := metrics.NewMetricPrometheusContext("floating_ip", "update")
+			_, err = s.client.ReplaceAllAttributesTags("floatingips", fp.ID, attributestags.ReplaceAllOpts{
+				Tags: openStackCluster.Spec.Tags,
+			})
+			if mc.ObserveRequest(err) != nil {
+				return nil, err
+			}
+		} else {
+			s.scope.Logger().V(4).Info("standard-attr-tag extension not available, skipping tag replacement", "resourceType", "floatingips", "resourceID", fp.ID)
 		}
 	}
 

--- a/pkg/cloud/services/networking/floatingip_test.go
+++ b/pkg/cloud/services/networking/floatingip_test.go
@@ -17,9 +17,12 @@ limitations under the License.
 package networking
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/go-logr/logr/testr"
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions"
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/attributestags"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/layer3/floatingips"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
@@ -35,10 +38,12 @@ func Test_GetOrCreateFloatingIP(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	tests := []struct {
-		name   string
-		ip     string
-		expect func(m *mock.MockNetworkClientMockRecorder)
-		want   *floatingips.FloatingIP
+		name    string
+		ip      string
+		tags    []string
+		expect  func(m *mock.MockNetworkClientMockRecorder)
+		want    *floatingips.FloatingIP
+		wantErr bool
 	}{
 		{
 			name: "creates floating IP when one doesn't already exist",
@@ -66,12 +71,68 @@ func Test_GetOrCreateFloatingIP(t *testing.T) {
 			},
 			want: &floatingips.FloatingIP{FloatingIP: "192.168.111.0"},
 		},
-	}
-	openStackCluster := &infrav1.OpenStackCluster{Status: infrav1.OpenStackClusterStatus{
-		ExternalNetwork: &infrav1.NetworkStatus{
-			ID: "",
+		{
+			name: "creates floating IP with tags when standard-attr-tag is not supported",
+			ip:   "192.168.111.0",
+			tags: []string{"cluster-tag"},
+			expect: func(m *mock.MockNetworkClientMockRecorder) {
+				// standard-attr-tag support must be checked before the
+				// floating IP is allocated, and ReplaceAllAttributesTags
+				// must not be called since the extension is not advertised.
+				m.ListExtensions().Return([]extensions.Extension{}, nil)
+
+				m.
+					ListFloatingIP(floatingips.ListOpts{FloatingIP: "192.168.111.0"}).
+					Return([]floatingips.FloatingIP{}, nil)
+				m.
+					CreateFloatingIP(floatingips.CreateOpts{
+						FloatingIP:  "192.168.111.0",
+						Description: "Created by cluster-api-provider-openstack cluster test-cluster",
+					}).
+					Return(&floatingips.FloatingIP{FloatingIP: "192.168.111.0"}, nil)
+			},
+			want: &floatingips.FloatingIP{FloatingIP: "192.168.111.0"},
 		},
-	}}
+		{
+			name: "creates floating IP with tags when standard-attr-tag is supported",
+			ip:   "192.168.111.0",
+			tags: []string{"cluster-tag"},
+			expect: func(m *mock.MockNetworkClientMockRecorder) {
+				standardAttrTagExt := extensions.Extension{}
+				standardAttrTagExt.Alias = "standard-attr-tag"
+				m.ListExtensions().Return([]extensions.Extension{standardAttrTagExt}, nil)
+
+				m.
+					ListFloatingIP(floatingips.ListOpts{FloatingIP: "192.168.111.0"}).
+					Return([]floatingips.FloatingIP{}, nil)
+				m.
+					CreateFloatingIP(floatingips.CreateOpts{
+						FloatingIP:  "192.168.111.0",
+						Description: "Created by cluster-api-provider-openstack cluster test-cluster",
+					}).
+					Return(&floatingips.FloatingIP{ID: "fip-1", FloatingIP: "192.168.111.0"}, nil)
+
+				m.ReplaceAllAttributesTags("floatingips", "fip-1", attributestags.ReplaceAllOpts{
+					Tags: []string{"cluster-tag"},
+				}).Return([]string{"cluster-tag"}, nil)
+			},
+			want: &floatingips.FloatingIP{ID: "fip-1", FloatingIP: "192.168.111.0"},
+		},
+		{
+			name: "tags requested, extension discovery fails before floating IP is allocated",
+			ip:   "192.168.111.0",
+			tags: []string{"cluster-tag"},
+			expect: func(m *mock.MockNetworkClientMockRecorder) {
+				m.
+					ListFloatingIP(floatingips.ListOpts{FloatingIP: "192.168.111.0"}).
+					Return([]floatingips.FloatingIP{}, nil)
+
+				// ListExtensions fails before CreateFloatingIP is ever called.
+				m.ListExtensions().Return(nil, errors.New("boom"))
+			},
+			wantErr: true,
+		},
+	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
@@ -80,6 +141,17 @@ func Test_GetOrCreateFloatingIP(t *testing.T) {
 			mockScopeFactory := scope.NewMockScopeFactory(mockCtrl, "")
 			tt.expect(mockClient.EXPECT())
 
+			openStackCluster := &infrav1.OpenStackCluster{
+				Spec: infrav1.OpenStackClusterSpec{
+					Tags: tt.tags,
+				},
+				Status: infrav1.OpenStackClusterStatus{
+					ExternalNetwork: &infrav1.NetworkStatus{
+						ID: "",
+					},
+				},
+			}
+
 			scope := scope.NewWithLogger(mockScopeFactory, log)
 			s := Service{
 				scope:  scope,
@@ -87,6 +159,10 @@ func Test_GetOrCreateFloatingIP(t *testing.T) {
 			}
 			eventObject := infrav1.OpenStackMachine{}
 			got, err := s.GetOrCreateFloatingIP(&eventObject, openStackCluster, "test-cluster", ptr.To(tt.ip))
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(got).To(Equal(tt.want))
 		})

--- a/pkg/cloud/services/networking/network.go
+++ b/pkg/cloud/services/networking/network.go
@@ -131,6 +131,19 @@ func (s *Service) ReconcileNetwork(openStackCluster *infrav1.OpenStackCluster, c
 		}
 	}
 
+	// Determine standard-attr-tag support before creating the network, so
+	// that a failed extension lookup doesn't leave behind a created network
+	// that CAPO never records in status (and therefore never retries tagging
+	// for).
+	var tagsSupported bool
+	if len(openStackCluster.Spec.Tags) > 0 {
+		var err error
+		tagsSupported, err = s.hasStandardAttrTagExtension()
+		if err != nil {
+			return err
+		}
+	}
+
 	network, err := s.client.CreateNetwork(opts)
 	if err != nil {
 		record.Warnf(openStackCluster, "FailedCreateNetwork", "Failed to create network %s: %v", networkName, err)
@@ -138,19 +151,26 @@ func (s *Service) ReconcileNetwork(openStackCluster *infrav1.OpenStackCluster, c
 	}
 	record.Eventf(openStackCluster, "SuccessfulCreateNetwork", "Created network %s with id %s", networkName, network.ID)
 
+	// appliedTags reflects the tags actually observed on the network, so
+	// that status never claims tags were applied when tagging was skipped.
+	appliedTags := network.Tags
 	if len(openStackCluster.Spec.Tags) > 0 {
-		_, err = s.client.ReplaceAllAttributesTags("networks", network.ID, attributestags.ReplaceAllOpts{
-			Tags: openStackCluster.Spec.Tags,
-		})
-		if err != nil {
-			return err
+		if tagsSupported {
+			appliedTags, err = s.client.ReplaceAllAttributesTags("networks", network.ID, attributestags.ReplaceAllOpts{
+				Tags: openStackCluster.Spec.Tags,
+			})
+			if err != nil {
+				return err
+			}
+		} else {
+			s.scope.Logger().V(4).Info("standard-attr-tag extension not available, skipping tag replacement", "resourceType", "networks", "resourceID", network.ID)
 		}
 	}
 
 	openStackCluster.Status.Network = &infrav1.NetworkStatusWithSubnets{}
 	openStackCluster.Status.Network.ID = network.ID
 	openStackCluster.Status.Network.Name = network.Name
-	openStackCluster.Status.Network.Tags = openStackCluster.Spec.Tags
+	openStackCluster.Status.Network.Tags = appliedTags
 	return nil
 }
 
@@ -244,6 +264,18 @@ func (s *Service) createSubnet(openStackCluster *infrav1.OpenStackCluster, clust
 		opts.AllocationPools = append(opts.AllocationPools, subnets.AllocationPool{Start: pool.Start, End: pool.End})
 	}
 
+	// Determine standard-attr-tag support before creating the subnet, so
+	// that a failed extension lookup doesn't leave behind a created subnet
+	// that reconciliation never retries tagging for.
+	var tagsSupported bool
+	if len(openStackCluster.Spec.Tags) > 0 {
+		var err error
+		tagsSupported, err = s.hasStandardAttrTagExtension()
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	subnet, err := s.client.CreateSubnet(opts)
 	if err != nil {
 		record.Warnf(openStackCluster, "FailedCreateSubnet", "Failed to create subnet %s: %v", name, err)
@@ -252,12 +284,16 @@ func (s *Service) createSubnet(openStackCluster *infrav1.OpenStackCluster, clust
 	record.Eventf(openStackCluster, "SuccessfulCreateSubnet", "Created subnet %s with id %s", name, subnet.ID)
 
 	if len(openStackCluster.Spec.Tags) > 0 {
-		mc := metrics.NewMetricPrometheusContext("subnet", "update")
-		_, err = s.client.ReplaceAllAttributesTags("subnets", subnet.ID, attributestags.ReplaceAllOpts{
-			Tags: openStackCluster.Spec.Tags,
-		})
-		if mc.ObserveRequest(err) != nil {
-			return nil, err
+		if tagsSupported {
+			mc := metrics.NewMetricPrometheusContext("subnet", "update")
+			_, err = s.client.ReplaceAllAttributesTags("subnets", subnet.ID, attributestags.ReplaceAllOpts{
+				Tags: openStackCluster.Spec.Tags,
+			})
+			if mc.ObserveRequest(err) != nil {
+				return nil, err
+			}
+		} else {
+			s.scope.Logger().V(4).Info("standard-attr-tag extension not available, skipping tag replacement", "resourceType", "subnets", "resourceID", subnet.ID)
 		}
 	}
 

--- a/pkg/cloud/services/networking/network_test.go
+++ b/pkg/cloud/services/networking/network_test.go
@@ -17,11 +17,14 @@ limitations under the License.
 package networking
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/go-logr/logr/testr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions"
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/attributestags"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/external"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/subnets"
@@ -144,6 +147,7 @@ func Test_ReconcileNetwork(t *testing.T) {
 		openStackCluster *infrav1.OpenStackCluster
 		expect           func(m *mock.MockNetworkClientMockRecorder)
 		want             *infrav1.OpenStackCluster
+		wantErr          bool
 	}{
 		{
 			name: "ensures status set when reconciling an existing network",
@@ -245,6 +249,116 @@ func Test_ReconcileNetwork(t *testing.T) {
 			},
 		},
 		{
+			name: "creation with tags when standard-attr-tag is not supported",
+			openStackCluster: &infrav1.OpenStackCluster{
+				Spec: infrav1.OpenStackClusterSpec{
+					Tags: []string{"cluster-tag"},
+				},
+			},
+			expect: func(m *mock.MockNetworkClientMockRecorder) {
+				// standard-attr-tag support must be checked before the network
+				// is created, and ReplaceAllAttributesTags must not be called
+				// since the extension is not advertised.
+				m.ListExtensions().Return([]extensions.Extension{}, nil)
+
+				m.
+					ListNetwork(networks.ListOpts{Name: expectedNetworkName}).
+					Return([]networks.Network{}, nil)
+
+				m.
+					CreateNetwork(createOpts{
+						AdminStateUp: gophercloud.Enabled,
+						Name:         expectedNetworkName,
+					}).
+					Return(&networks.Network{
+						ID:   fakeNetworkID,
+						Name: expectedNetworkName,
+						// Tags returned by Neutron for the created network, independent
+						// of the unapplied user-requested tags.
+						Tags: []string{"observed-tag"},
+					}, nil)
+			},
+			want: &infrav1.OpenStackCluster{
+				Spec: infrav1.OpenStackClusterSpec{
+					Tags: []string{"cluster-tag"},
+				},
+				Status: infrav1.OpenStackClusterStatus{
+					Network: &infrav1.NetworkStatusWithSubnets{
+						NetworkStatus: infrav1.NetworkStatus{
+							ID:   fakeNetworkID,
+							Name: expectedNetworkName,
+							// Tagging was skipped, so status must reflect the
+							// tags actually observed on the created network,
+							// not falsely claim the requested tags were applied.
+							Tags: []string{"observed-tag"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "creation with tags when standard-attr-tag is supported",
+			openStackCluster: &infrav1.OpenStackCluster{
+				Spec: infrav1.OpenStackClusterSpec{
+					Tags: []string{"cluster-tag"},
+				},
+			},
+			expect: func(m *mock.MockNetworkClientMockRecorder) {
+				standardAttrTagExt := extensions.Extension{}
+				standardAttrTagExt.Alias = "standard-attr-tag"
+				m.ListExtensions().Return([]extensions.Extension{standardAttrTagExt}, nil)
+
+				m.
+					ListNetwork(networks.ListOpts{Name: expectedNetworkName}).
+					Return([]networks.Network{}, nil)
+
+				m.
+					CreateNetwork(createOpts{
+						AdminStateUp: gophercloud.Enabled,
+						Name:         expectedNetworkName,
+					}).
+					Return(&networks.Network{
+						ID:   fakeNetworkID,
+						Name: expectedNetworkName,
+					}, nil)
+
+				m.ReplaceAllAttributesTags("networks", fakeNetworkID, attributestags.ReplaceAllOpts{
+					Tags: []string{"cluster-tag"},
+				}).Return([]string{"cluster-tag"}, nil)
+			},
+			want: &infrav1.OpenStackCluster{
+				Spec: infrav1.OpenStackClusterSpec{
+					Tags: []string{"cluster-tag"},
+				},
+				Status: infrav1.OpenStackClusterStatus{
+					Network: &infrav1.NetworkStatusWithSubnets{
+						NetworkStatus: infrav1.NetworkStatus{
+							ID:   fakeNetworkID,
+							Name: expectedNetworkName,
+							Tags: []string{"cluster-tag"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "creation with tags fails before creating network when standard-attr-tag discovery fails",
+			openStackCluster: &infrav1.OpenStackCluster{
+				Spec: infrav1.OpenStackClusterSpec{
+					Tags: []string{"cluster-tag"},
+				},
+			},
+			expect: func(m *mock.MockNetworkClientMockRecorder) {
+				m.
+					ListNetwork(networks.ListOpts{Name: expectedNetworkName}).
+					Return([]networks.Network{}, nil)
+
+				// ListExtensions fails before CreateNetwork is ever called.
+				m.ListExtensions().Return(nil, errors.New("boom"))
+			},
+			wantErr: true,
+		},
+		{
 			name: "creation with mtu set",
 			openStackCluster: &infrav1.OpenStackCluster{
 				Spec: infrav1.OpenStackClusterSpec{
@@ -297,7 +411,14 @@ func Test_ReconcileNetwork(t *testing.T) {
 				scope:  scope.NewWithLogger(scopeFactory, log),
 			}
 			err := s.ReconcileNetwork(tt.openStackCluster, clusterResourceName)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
 			g.Expect(err).ShouldNot(HaveOccurred())
+			if len(tt.openStackCluster.Spec.Tags) > 0 {
+				g.Expect(tt.openStackCluster.Status.Network.Tags).To(Equal(tt.want.Status.Network.Tags))
+			}
 		})
 	}
 }
@@ -565,6 +686,7 @@ func Test_ReconcileSubnet(t *testing.T) {
 		openStackCluster *infrav1.OpenStackCluster
 		expect           func(m *mock.MockNetworkClientMockRecorder)
 		want             *infrav1.OpenStackClusterStatus
+		wantErr          bool
 	}{
 		{
 			name: "ensures status set when reconciling an existing subnet",
@@ -661,6 +783,154 @@ func Test_ReconcileSubnet(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			name: "creation with tags when standard-attr-tag is not supported",
+			openStackCluster: &infrav1.OpenStackCluster{
+				Spec: infrav1.OpenStackClusterSpec{
+					Tags: []string{"cluster-tag"},
+					ManagedSubnets: []infrav1.SubnetSpec{
+						{
+							CIDR: fakeCIDR,
+						},
+					},
+				},
+				Status: infrav1.OpenStackClusterStatus{
+					Network: &infrav1.NetworkStatusWithSubnets{
+						NetworkStatus: infrav1.NetworkStatus{
+							ID: fakeNetworkID,
+						},
+					},
+				},
+			},
+			expect: func(m *mock.MockNetworkClientMockRecorder) {
+				// standard-attr-tag support must be checked before the subnet
+				// is created, and ReplaceAllAttributesTags must not be called
+				// since the extension is not advertised.
+				m.ListExtensions().Return([]extensions.Extension{}, nil)
+
+				m.
+					ListSubnet(subnets.ListOpts{NetworkID: fakeNetworkID, CIDR: fakeCIDR}).
+					Return([]subnets.Subnet{}, nil)
+
+				m.
+					CreateSubnet(subnets.CreateOpts{
+						NetworkID:   fakeNetworkID,
+						Name:        expectedSubnetName,
+						IPVersion:   4,
+						CIDR:        fakeCIDR,
+						Description: expectedSubnetDesc,
+					}).
+					Return(&subnets.Subnet{
+						ID:   fakeSubnetID,
+						Name: expectedSubnetName,
+						CIDR: fakeCIDR,
+					}, nil)
+			},
+			want: &infrav1.OpenStackClusterStatus{
+				Network: &infrav1.NetworkStatusWithSubnets{
+					NetworkStatus: infrav1.NetworkStatus{
+						ID: fakeNetworkID,
+					},
+					Subnets: []infrav1.Subnet{
+						{
+							Name: expectedSubnetName,
+							ID:   fakeSubnetID,
+							CIDR: fakeCIDR,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "creation with tags when standard-attr-tag is supported",
+			openStackCluster: &infrav1.OpenStackCluster{
+				Spec: infrav1.OpenStackClusterSpec{
+					Tags: []string{"cluster-tag"},
+					ManagedSubnets: []infrav1.SubnetSpec{
+						{
+							CIDR: fakeCIDR,
+						},
+					},
+				},
+				Status: infrav1.OpenStackClusterStatus{
+					Network: &infrav1.NetworkStatusWithSubnets{
+						NetworkStatus: infrav1.NetworkStatus{
+							ID: fakeNetworkID,
+						},
+					},
+				},
+			},
+			expect: func(m *mock.MockNetworkClientMockRecorder) {
+				standardAttrTagExt := extensions.Extension{}
+				standardAttrTagExt.Alias = "standard-attr-tag"
+				m.ListExtensions().Return([]extensions.Extension{standardAttrTagExt}, nil)
+
+				m.
+					ListSubnet(subnets.ListOpts{NetworkID: fakeNetworkID, CIDR: fakeCIDR}).
+					Return([]subnets.Subnet{}, nil)
+
+				m.
+					CreateSubnet(subnets.CreateOpts{
+						NetworkID:   fakeNetworkID,
+						Name:        expectedSubnetName,
+						IPVersion:   4,
+						CIDR:        fakeCIDR,
+						Description: expectedSubnetDesc,
+					}).
+					Return(&subnets.Subnet{
+						ID:   fakeSubnetID,
+						Name: expectedSubnetName,
+						CIDR: fakeCIDR,
+					}, nil)
+
+				m.ReplaceAllAttributesTags("subnets", fakeSubnetID, attributestags.ReplaceAllOpts{
+					Tags: []string{"cluster-tag"},
+				}).Return([]string{"cluster-tag"}, nil)
+			},
+			want: &infrav1.OpenStackClusterStatus{
+				Network: &infrav1.NetworkStatusWithSubnets{
+					NetworkStatus: infrav1.NetworkStatus{
+						ID: fakeNetworkID,
+					},
+					Subnets: []infrav1.Subnet{
+						{
+							Name: expectedSubnetName,
+							ID:   fakeSubnetID,
+							CIDR: fakeCIDR,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "creation with tags fails before creating subnet when standard-attr-tag discovery fails",
+			openStackCluster: &infrav1.OpenStackCluster{
+				Spec: infrav1.OpenStackClusterSpec{
+					Tags: []string{"cluster-tag"},
+					ManagedSubnets: []infrav1.SubnetSpec{
+						{
+							CIDR: fakeCIDR,
+						},
+					},
+				},
+				Status: infrav1.OpenStackClusterStatus{
+					Network: &infrav1.NetworkStatusWithSubnets{
+						NetworkStatus: infrav1.NetworkStatus{
+							ID: fakeNetworkID,
+						},
+					},
+				},
+			},
+			expect: func(m *mock.MockNetworkClientMockRecorder) {
+				m.
+					ListSubnet(subnets.ListOpts{NetworkID: fakeNetworkID, CIDR: fakeCIDR}).
+					Return([]subnets.Subnet{}, nil)
+
+				// ListExtensions fails before CreateSubnet is ever called.
+				m.ListExtensions().Return(nil, errors.New("boom"))
+			},
+			wantErr: true,
 		},
 		{
 			name: "creation with DNSNameservers",
@@ -1180,6 +1450,10 @@ func Test_ReconcileSubnet(t *testing.T) {
 				scope:  scope.NewWithLogger(mockScopeFactory, log),
 			}
 			err := s.ReconcileSubnet(tt.openStackCluster, clusterResourceName)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(tt.openStackCluster.Status).To(Equal(*tt.want))
 		})

--- a/pkg/cloud/services/networking/port.go
+++ b/pkg/cloud/services/networking/port.go
@@ -129,11 +129,35 @@ func (s *Service) GetPortForExternalNetwork(instanceID string, externalNetworkID
 func (s *Service) ensurePortTagsAndTrunk(port *ports.Port, eventObject runtime.Object, portSpec *infrav1.ResolvedPortSpec) error {
 	wantedTags := uniqueSortedTags(portSpec.Tags)
 	actualTags := uniqueSortedTags(port.Tags)
+
+	// hasTagSupport is populated lazily on first use so that ensurePortTagsAndTrunk
+	// performs at most one ListExtensions call, even when both the port and its
+	// trunk need tagging.
+	var hasTagSupport *bool
+	tagSupportChecked := func() (bool, error) {
+		if hasTagSupport == nil {
+			supported, err := s.hasStandardAttrTagExtension()
+			if err != nil {
+				return false, err
+			}
+			hasTagSupport = &supported
+		}
+		return *hasTagSupport, nil
+	}
+
 	// Only replace tags if there is a difference
 	if !slices.Equal(wantedTags, actualTags) && len(wantedTags) > 0 {
-		if err := s.replaceAllAttributesTags(eventObject, portResource, port.ID, wantedTags); err != nil {
-			record.Warnf(eventObject, "FailedReplaceTags", "Failed to replace port tags %s: %v", port.Name, err)
+		supported, err := tagSupportChecked()
+		if err != nil {
 			return err
+		}
+		if supported {
+			if err := s.replaceAllAttributesTags(eventObject, portResource, port.ID, wantedTags); err != nil {
+				record.Warnf(eventObject, "FailedReplaceTags", "Failed to replace port tags %s: %v", port.Name, err)
+				return err
+			}
+		} else {
+			s.scope.Logger().V(4).Info("standard-attr-tag extension not available, skipping tag replacement", "resourceType", portResource, "resourceID", port.ID)
 		}
 	}
 	if ptr.Deref(portSpec.Trunk, false) {
@@ -143,10 +167,18 @@ func (s *Service) ensurePortTagsAndTrunk(port *ports.Port, eventObject runtime.O
 			return err
 		}
 
-		if !slices.Equal(wantedTags, trunk.Tags) {
-			if err = s.replaceAllAttributesTags(eventObject, trunkResource, trunk.ID, wantedTags); err != nil {
-				record.Warnf(eventObject, "FailedReplaceTags", "Failed to replace trunk tags %s: %v", port.Name, err)
+		if len(wantedTags) > 0 && !slices.Equal(wantedTags, trunk.Tags) {
+			supported, err := tagSupportChecked()
+			if err != nil {
 				return err
+			}
+			if supported {
+				if err = s.replaceAllAttributesTags(eventObject, trunkResource, trunk.ID, wantedTags); err != nil {
+					record.Warnf(eventObject, "FailedReplaceTags", "Failed to replace trunk tags %s: %v", port.Name, err)
+					return err
+				}
+			} else {
+				s.scope.Logger().V(4).Info("standard-attr-tag extension not available, skipping tag replacement", "resourceType", trunkResource, "resourceID", trunk.ID)
 			}
 		}
 	}

--- a/pkg/cloud/services/networking/port_test.go
+++ b/pkg/cloud/services/networking/port_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package networking
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/go-logr/logr/testr"
@@ -381,6 +382,11 @@ func Test_EnsurePort(t *testing.T) {
 					return &ports.Port{ID: portID, Name: "test-port"}, nil
 				})
 
+				// Check standard-attr-tag support once, reused for both the port and trunk tag calls below.
+				standardAttrTagExt := extensions.Extension{}
+				standardAttrTagExt.Alias = "standard-attr-tag"
+				m.ListExtensions().Return([]extensions.Extension{standardAttrTagExt}, nil)
+
 				// Tag the port
 				m.ReplaceAllAttributesTags("ports", portID, attributestags.ReplaceAllOpts{
 					Tags: []string{"tag1", "tag2"},
@@ -458,6 +464,11 @@ func Test_EnsurePort(t *testing.T) {
 					NetworkID: netID,
 				}}, nil)
 
+				// Check standard-attr-tag support once, reused for both the port and trunk tag calls below.
+				standardAttrTagExt := extensions.Extension{}
+				standardAttrTagExt.Alias = "standard-attr-tag"
+				m.ListExtensions().Return([]extensions.Extension{standardAttrTagExt}, nil)
+
 				// Tag the port
 				m.ReplaceAllAttributesTags("ports", portID, attributestags.ReplaceAllOpts{
 					Tags: []string{"tag1", "tag2"},
@@ -486,6 +497,121 @@ func Test_EnsurePort(t *testing.T) {
 				NetworkID: netID,
 			},
 		},
+		{
+			name: "create port with tags and trunk when standard-attr-tag is not supported",
+			port: infrav1.ResolvedPortSpec{
+				Name:      "test-port",
+				NetworkID: netID,
+				Tags:      []string{"tag1", "tag2"},
+				Trunk:     ptr.To(true),
+			},
+			expect: func(m *mock.MockNetworkClientMockRecorder, g types.Gomega) {
+				var expectedCreateOpts ports.CreateOptsBuilder
+				expectedCreateOpts = ports.CreateOpts{
+					NetworkID: netID,
+					Name:      "test-port",
+				}
+				expectedCreateOpts = portsbinding.CreateOptsExt{
+					CreateOptsBuilder: expectedCreateOpts,
+				}
+
+				m.ListPort(ports.ListOpts{
+					Name:      "test-port",
+					NetworkID: netID,
+				}).Return(nil, nil)
+				// Create the port
+				m.CreatePort(gomock.Any()).DoAndReturn(func(builder ports.CreateOptsBuilder) (*ports.Port, error) {
+					gotCreateOpts := builder.(portsbinding.CreateOptsExt)
+					g.Expect(gotCreateOpts).To(Equal(expectedCreateOpts), cmp.Diff(gotCreateOpts, expectedCreateOpts))
+					return &ports.Port{ID: portID, Name: "test-port"}, nil
+				})
+
+				// standard-attr-tag is not advertised: checked once and reused,
+				// so neither the port nor the trunk tag call is attempted.
+				m.ListExtensions().Return([]extensions.Extension{}, nil)
+
+				// Look for existing trunk
+				m.ListTrunk(trunks.ListOpts{
+					PortID: portID,
+					Name:   "test-port",
+				}).Return([]trunks.Trunk{}, nil)
+
+				// Create the trunk
+				m.CreateTrunk(trunks.CreateOpts{
+					PortID: portID,
+					Name:   "test-port",
+				}).Return(&trunks.Trunk{ID: trunkID}, nil)
+			},
+			want: &ports.Port{ID: portID, Name: "test-port"},
+		},
+		{
+			name: "returns error when checking standard-attr-tag support fails",
+			port: infrav1.ResolvedPortSpec{
+				Name:      "test-port",
+				NetworkID: netID,
+				Tags:      []string{"tag1", "tag2"},
+			},
+			expect: func(m *mock.MockNetworkClientMockRecorder, g types.Gomega) {
+				var expectedCreateOpts ports.CreateOptsBuilder
+				expectedCreateOpts = ports.CreateOpts{
+					NetworkID: netID,
+					Name:      "test-port",
+				}
+				expectedCreateOpts = portsbinding.CreateOptsExt{
+					CreateOptsBuilder: expectedCreateOpts,
+				}
+
+				m.ListPort(ports.ListOpts{
+					Name:      "test-port",
+					NetworkID: netID,
+				}).Return(nil, nil)
+				m.CreatePort(gomock.Any()).DoAndReturn(func(builder ports.CreateOptsBuilder) (*ports.Port, error) {
+					gotCreateOpts := builder.(portsbinding.CreateOptsExt)
+					g.Expect(gotCreateOpts).To(Equal(expectedCreateOpts), cmp.Diff(gotCreateOpts, expectedCreateOpts))
+					return &ports.Port{ID: portID, Name: "test-port"}, nil
+				})
+
+				m.ListExtensions().Return(nil, errors.New("boom"))
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "trunk already exists with stale tags and desired tags are empty",
+			port: infrav1.ResolvedPortSpec{
+				Name:      "test-port",
+				NetworkID: netID,
+				Trunk:     ptr.To(true),
+			},
+			expect: func(m *mock.MockNetworkClientMockRecorder, _ types.Gomega) {
+				m.ListPort(ports.ListOpts{
+					Name:      "test-port",
+					NetworkID: netID,
+				}).Return([]ports.Port{{
+					ID:        portID,
+					Name:      "test-port",
+					NetworkID: netID,
+				}}, nil)
+
+				// Look for existing trunk, which has stale, non-empty tags.
+				m.ListTrunk(trunks.ListOpts{
+					PortID: portID,
+					Name:   "test-port",
+				}).Return([]trunks.Trunk{{
+					ID:   trunkID,
+					Tags: []string{"stale-tag"},
+				}}, nil)
+
+				// wantedTags is empty: replaceAllAttributesTags would no-op on it
+				// anyway, so neither ListExtensions nor ReplaceAllAttributesTags
+				// must be called, even though the existing trunk has stale tags.
+			},
+			want: &ports.Port{
+				ID:        portID,
+				Name:      "test-port",
+				NetworkID: netID,
+			},
+		},
 	}
 
 	eventObject := &infrav1.OpenStackMachine{}
@@ -496,10 +622,13 @@ func Test_EnsurePort(t *testing.T) {
 			defer mockCtrl.Finish()
 
 			g := NewWithT(t)
+			log := testr.New(t)
 			mockClient := mock.NewMockNetworkClient(mockCtrl)
 			tt.expect(mockClient.EXPECT(), g)
+			mockScopeFactory := scope.NewMockScopeFactory(mockCtrl, "")
 			s := Service{
 				client: mockClient,
+				scope:  scope.NewWithLogger(mockScopeFactory, log),
 			}
 			got, err := s.EnsurePort(
 				eventObject,

--- a/pkg/cloud/services/networking/router.go
+++ b/pkg/cloud/services/networking/router.go
@@ -189,6 +189,18 @@ func (s *Service) createRouter(openStackCluster *infrav1.OpenStackCluster, clust
 		}
 	}
 
+	// Determine standard-attr-tag support before creating the router, so
+	// that a failed extension lookup doesn't leave behind a created router
+	// that reconciliation never retries tagging for.
+	var tagsSupported bool
+	if len(openStackCluster.Spec.Tags) > 0 {
+		var err error
+		tagsSupported, err = s.hasStandardAttrTagExtension()
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	router, err := s.client.CreateRouter(opts)
 	if err != nil {
 		record.Warnf(openStackCluster, "FailedCreateRouter", "Failed to create router %s: %v", name, err)
@@ -197,11 +209,15 @@ func (s *Service) createRouter(openStackCluster *infrav1.OpenStackCluster, clust
 	record.Eventf(openStackCluster, "SuccessfulCreateRouter", "Created router %s with id %s", name, router.ID)
 
 	if len(openStackCluster.Spec.Tags) > 0 {
-		_, err = s.client.ReplaceAllAttributesTags("routers", router.ID, attributestags.ReplaceAllOpts{
-			Tags: openStackCluster.Spec.Tags,
-		})
-		if err != nil {
-			return nil, err
+		if tagsSupported {
+			_, err = s.client.ReplaceAllAttributesTags("routers", router.ID, attributestags.ReplaceAllOpts{
+				Tags: openStackCluster.Spec.Tags,
+			})
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			s.scope.Logger().V(4).Info("standard-attr-tag extension not available, skipping tag replacement", "resourceType", "routers", "resourceID", router.ID)
 		}
 	}
 

--- a/pkg/cloud/services/networking/router_test.go
+++ b/pkg/cloud/services/networking/router_test.go
@@ -17,10 +17,13 @@ limitations under the License.
 package networking
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/go-logr/logr/testr"
 	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions"
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/attributestags"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/layer3/routers"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/subnets"
 	. "github.com/onsi/gomega"
@@ -29,6 +32,7 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/clients/mock"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/scope"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/utils/names"
 )
 
 func TestService_DeleteRouter(t *testing.T) {
@@ -212,6 +216,110 @@ func TestService_DeleteRouter(t *testing.T) {
 			if err := s.DeleteRouter(&tt.openStackCluster, clusterResourceName); (err != nil) != tt.wantErr {
 				t.Errorf("Service.DeleteRouter() error = %v, wantErr %v", err, tt.wantErr)
 			}
+		})
+	}
+}
+
+func TestService_createRouter(t *testing.T) {
+	const (
+		clusterResourceName = "test-cluster"
+		routerName          = "k8s-clusterapi-cluster-test-cluster"
+		routerID            = "38052015-5cbc-4cb4-8e45-445d53260f60"
+		externalNetworkID   = "6f2be7de-2f6b-4bdb-b6d3-8e1f1e6b7f01"
+	)
+
+	tests := []struct {
+		name    string
+		tags    []string
+		expect  func(m *mock.MockNetworkClientMockRecorder)
+		wantErr bool
+	}{
+		{
+			name: "no tags requested, no extension lookup needed",
+			expect: func(m *mock.MockNetworkClientMockRecorder) {
+				m.CreateRouter(routers.CreateOpts{
+					Name:        routerName,
+					Description: names.GetDescription(clusterResourceName),
+					GatewayInfo: &routers.GatewayInfo{NetworkID: externalNetworkID},
+				}).Return(&routers.Router{ID: routerID}, nil)
+			},
+		},
+		{
+			name: "tags requested, standard-attr-tag not supported",
+			tags: []string{"cluster-tag"},
+			expect: func(m *mock.MockNetworkClientMockRecorder) {
+				// standard-attr-tag support must be checked before the router
+				// is created, and ReplaceAllAttributesTags must not be called
+				// since the extension is not advertised.
+				m.ListExtensions().Return([]extensions.Extension{}, nil)
+
+				m.CreateRouter(routers.CreateOpts{
+					Name:        routerName,
+					Description: names.GetDescription(clusterResourceName),
+					GatewayInfo: &routers.GatewayInfo{NetworkID: externalNetworkID},
+				}).Return(&routers.Router{ID: routerID}, nil)
+			},
+		},
+		{
+			name: "tags requested, standard-attr-tag supported",
+			tags: []string{"cluster-tag"},
+			expect: func(m *mock.MockNetworkClientMockRecorder) {
+				standardAttrTagExt := extensions.Extension{}
+				standardAttrTagExt.Alias = "standard-attr-tag"
+				m.ListExtensions().Return([]extensions.Extension{standardAttrTagExt}, nil)
+
+				m.CreateRouter(routers.CreateOpts{
+					Name:        routerName,
+					Description: names.GetDescription(clusterResourceName),
+					GatewayInfo: &routers.GatewayInfo{NetworkID: externalNetworkID},
+				}).Return(&routers.Router{ID: routerID}, nil)
+
+				m.ReplaceAllAttributesTags("routers", routerID, attributestags.ReplaceAllOpts{
+					Tags: []string{"cluster-tag"},
+				}).Return([]string{"cluster-tag"}, nil)
+			},
+		},
+		{
+			name: "tags requested, extension discovery fails before router is created",
+			tags: []string{"cluster-tag"},
+			expect: func(m *mock.MockNetworkClientMockRecorder) {
+				// ListExtensions fails before CreateRouter is ever called.
+				m.ListExtensions().Return(nil, errors.New("boom"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			g := NewWithT(t)
+			log := testr.New(t)
+
+			mockScopeFactory := scope.NewMockScopeFactory(mockCtrl, "")
+			s, err := NewService(scope.NewWithLogger(mockScopeFactory, log))
+			g.Expect(err).NotTo(HaveOccurred())
+
+			openStackCluster := &infrav1.OpenStackCluster{
+				Spec: infrav1.OpenStackClusterSpec{
+					Tags: tt.tags,
+				},
+				Status: infrav1.OpenStackClusterStatus{
+					ExternalNetwork: &infrav1.NetworkStatus{ID: externalNetworkID},
+				},
+			}
+
+			tt.expect(mockScopeFactory.NetworkClient.EXPECT())
+
+			router, err := s.createRouter(openStackCluster, clusterResourceName, routerName)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(router).To(Equal(&routers.Router{ID: routerID}))
 		})
 	}
 }

--- a/pkg/cloud/services/networking/securitygroups.go
+++ b/pkg/cloud/services/networking/securitygroups.go
@@ -78,6 +78,22 @@ func (s *Service) ReconcileSecurityGroups(openStackCluster *infrav1.OpenStackClu
 
 	// create security groups first, because desired rules use group ids.
 	observedSecGroupBySuffix := make(map[string]*groups.SecGroup)
+
+	// hasTagSupport is populated lazily on first use so that ReconcileSecurityGroups
+	// performs at most one ListExtensions call, even when multiple security groups
+	// (control plane, worker, bastion) need tagging in the same invocation.
+	var hasTagSupport *bool
+	tagSupportChecked := func() (bool, error) {
+		if hasTagSupport == nil {
+			supported, err := s.hasStandardAttrTagExtension()
+			if err != nil {
+				return false, err
+			}
+			hasTagSupport = &supported
+		}
+		return *hasTagSupport, nil
+	}
+
 	for suffix, secGroupName := range suffixToNameMap {
 		group, err := s.getOrCreateSecurityGroup(openStackCluster, secGroupName)
 		if err != nil {
@@ -92,13 +108,21 @@ func (s *Service) ReconcileSecurityGroups(openStackCluster *infrav1.OpenStackClu
 		}
 
 		if !slices.Equal(normaliseTags(openStackCluster.Spec.Tags), normaliseTags(group.Tags)) {
-			_, err = s.client.ReplaceAllAttributesTags("security-groups", group.ID, attributestags.ReplaceAllOpts{
-				Tags: openStackCluster.Spec.Tags,
-			})
+			supported, err := tagSupportChecked()
 			if err != nil {
 				return err
 			}
-			s.scope.Logger().V(5).Info("Updated tags for security group", "name", group.Name, "id", group.ID)
+			if supported {
+				_, err = s.client.ReplaceAllAttributesTags("security-groups", group.ID, attributestags.ReplaceAllOpts{
+					Tags: openStackCluster.Spec.Tags,
+				})
+				if err != nil {
+					return err
+				}
+				s.scope.Logger().V(5).Info("Updated tags for security group", "name", group.Name, "id", group.ID)
+			} else {
+				s.scope.Logger().V(4).Info("standard-attr-tag extension not available, skipping tag replacement", "resourceType", "security-groups", "resourceID", group.ID)
+			}
 		}
 	}
 

--- a/pkg/cloud/services/networking/securitygroups_test.go
+++ b/pkg/cloud/services/networking/securitygroups_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-logr/logr/testr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/security/groups"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/security/rules"
 	. "github.com/onsi/gomega"
@@ -590,6 +591,43 @@ func TestService_ReconcileSecurityGroups(t *testing.T) {
 				m.ListSecGroup(groups.ListOpts{Name: workerSGName}).
 					Return([]groups.SecGroup{{ID: "1", Name: workerSGName}}, nil)
 				m.ListSecGroup(groups.ListOpts{Name: bastionSGName}).Return(nil, nil)
+
+				// We expect a total of 14 rules to be created.
+				// Nothing actually looks at the generated
+				// rules, but we give them unique IDs anyway
+				m.CreateSecGroupRule(gomock.Any()).DoAndReturn(func(opts rules.CreateOpts) (*rules.SecGroupRule, error) {
+					log.Info("Created rule", "securityGroup", opts.SecGroupID, "description", opts.Description)
+					return &rules.SecGroupRule{ID: uuid.NewString()}, nil
+				}).Times(14)
+			},
+			expectedClusterStatus: infrav1.OpenStackClusterStatus{
+				ControlPlaneSecurityGroup: &infrav1.SecurityGroupStatus{
+					ID:   "0",
+					Name: controlPlaneSGName,
+				},
+				WorkerSecurityGroup: &infrav1.SecurityGroupStatus{
+					ID:   "1",
+					Name: workerSGName,
+				},
+			},
+		},
+		{
+			name: "Skips tag replacement for control plane and worker security groups when standard-attr-tag is not supported",
+			openStackClusterSpec: infrav1.OpenStackClusterSpec{
+				Tags:                  []string{"cluster-tag"},
+				ManagedSecurityGroups: &infrav1.ManagedSecurityGroups{},
+			},
+			expect: func(log logr.Logger, m *mock.MockNetworkClientMockRecorder) {
+				m.ListSecGroup(groups.ListOpts{Name: controlPlaneSGName}).
+					Return([]groups.SecGroup{{ID: "0", Name: controlPlaneSGName}}, nil)
+				m.ListSecGroup(groups.ListOpts{Name: workerSGName}).
+					Return([]groups.SecGroup{{ID: "1", Name: workerSGName}}, nil)
+				m.ListSecGroup(groups.ListOpts{Name: bastionSGName}).Return(nil, nil)
+
+				// standard-attr-tag support is checked once and reused for both the
+				// control plane and worker security groups, so ListExtensions is
+				// called exactly once and ReplaceAllAttributesTags is never called.
+				m.ListExtensions().Return([]extensions.Extension{}, nil)
 
 				// We expect a total of 14 rules to be created.
 				// Nothing actually looks at the generated

--- a/pkg/cloud/services/networking/service.go
+++ b/pkg/cloud/services/networking/service.go
@@ -76,3 +76,23 @@ func (s *Service) replaceAllAttributesTags(eventObject runtime.Object, resourceT
 	record.Eventf(eventObject, "SuccessfulReplaceAllAttributeTags", "Replaced all attributestags for %s with tags %s", resourceID, tags)
 	return nil
 }
+
+// hasStandardAttrTagExtension checks whether the Neutron standard-attr-tag
+// extension is available. This extension provides the tag replacement API
+// used to apply user-provided tags to networking resources. Callers must
+// skip tag replacement rather than call it when this returns false, so that
+// CAPO remains usable against OpenStack deployments that don't advertise
+// this optional extension.
+func (s *Service) hasStandardAttrTagExtension() (bool, error) {
+	allExts, err := s.client.ListExtensions()
+	if err != nil {
+		return false, err
+	}
+
+	for _, ext := range allExts {
+		if ext.Alias == "standard-attr-tag" {
+			return true, nil
+		}
+	}
+	return false, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Neutron's `standard-attr-tag` extension is optional, but CAPO currently attempts to apply user-provided tags to networking resources without first checking whether the extension is available. This causes reconciliation to fail on OpenStack environments that do not support network resource tags.

This change checks for `standard-attr-tag` before applying user-provided tags to:

- networks and subnets
- routers
- security groups
- cluster/API-server floating IPs
- ports and trunks

When the extension is unavailable, CAPO skips the unsupported tag operation and continues reconciliation. Errors returned while discovering Neutron extensions are still propagated.

The OpenStackFloatingIPPool bookkeeping tag is intentionally unchanged because it is used internally to rediscover claimed floating IPs and is therefore a functional dependency rather than optional user-provided metadata.

Focused unit coverage verifies supported, unsupported, and extension-discovery error paths, including avoiding redundant extension lookups for ports/trunks and security groups.

**Which issue(s) this PR fixes**:

Fixes #3306

**Special notes for your reviewer**:

Validation completed locally:

- `make lint`
- `make test` (525 tests)
- `git diff --check`

**TODOs**:

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [x] adds unit tests