### PR TITLE
🌱 Setup dependabot and security scans for release-0.15

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,6 +52,56 @@ updates:
   - "area/dependency"
   - "ok-to-test"
 ## main branch config ends here
+## release-0.15 branch config starts here
+# github-actions
+- directory: "/"
+  package-ecosystem: "github-actions"
+  schedule:
+    interval: "weekly"
+    day: "monday"
+  target-branch: release-0.15
+  groups:
+    all-github-actions:
+      patterns: ["*"]
+  commit-message:
+    prefix: ":seedling:"
+    include: scope
+  cooldown:
+    default-days: 7
+  labels:
+  - "area/dependency"
+  - "ok-to-test"
+# Go directories
+- directories:
+  - "/"
+  - "/hack/tools"
+  package-ecosystem: "gomod"
+  schedule:
+    interval: "weekly"
+    day: "monday"
+  target-branch: release-0.15
+  groups:
+    all-go-mod-patch-and-minor:
+      patterns: ["*"]
+      update-types: ["patch", "minor"]
+  commit-message:
+    prefix: ":seedling:"
+    include: scope
+  ignore:
+  # Ignore controller-runtime major and minor bumps as its upgraded manually.
+  - dependency-name: "sigs.k8s.io/controller-runtime"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  # Ignore k8s major and minor bumps and its transitives modules
+  - dependency-name: "k8s.io/*"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  - dependency-name: "sigs.k8s.io/controller-tools"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  cooldown:
+    default-days: 7
+  labels:
+  - "area/dependency"
+  - "ok-to-test"
+## release-0.15 branch config ends here
 ## release-0.14 branch config starts here
 # github-actions
 - directory: "/"

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [main, release-0.14, release-0.13]
+        branch: [main, release-0.15, release-0.14, release-0.13]
     name: Trivy
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
**What this PR does / why we need it**:

Add dependabot config and security scanning for the release-0.15 branch.
Still keeping release-0.13 until v0.15.0 is out.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #3225

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

