### PR TITLE
🌱 Update e2e tests for v0.15

### DIFF
--- a/test/e2e/data/e2e_conf.yaml
+++ b/test/e2e/data/e2e_conf.yaml
@@ -27,8 +27,8 @@ providers:
     files:
     - sourcePath: "../data/shared/capi/metadata.yaml"
   # For clusterctl upgrade test
-  - name: "{go://sigs.k8s.io/cluster-api@v1.12}"
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.12}/core-components.yaml"
+  - name: "{go://sigs.k8s.io/cluster-api@v1.13}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.13}/core-components.yaml"
     type: "url"
     contract: v1beta2
     replacements:
@@ -36,10 +36,10 @@ providers:
       new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/capi/metadata.yaml"
-  - name: "{go://sigs.k8s.io/cluster-api@v1.10}"
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.10}/core-components.yaml"
+  - name: "{go://sigs.k8s.io/cluster-api@v1.12}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.12}/core-components.yaml"
     type: "url"
-    contract: v1beta1
+    contract: v1beta2
     replacements:
     - old: --metrics-addr=127.0.0.1:8080
       new: --metrics-addr=:8080
@@ -58,8 +58,8 @@ providers:
     files:
     - sourcePath: "../data/shared/capi/metadata.yaml"
   # For clusterctl upgrade test
-  - name: "{go://sigs.k8s.io/cluster-api@v1.12}"
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.12}/bootstrap-components.yaml"
+  - name: "{go://sigs.k8s.io/cluster-api@v1.13}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.13}/bootstrap-components.yaml"
     type: "url"
     contract: v1beta2
     replacements:
@@ -67,10 +67,10 @@ providers:
       new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/capi/metadata.yaml"
-  - name: "{go://sigs.k8s.io/cluster-api@v1.10}"
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.10}/bootstrap-components.yaml"
+  - name: "{go://sigs.k8s.io/cluster-api@v1.12}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.12}/bootstrap-components.yaml"
     type: "url"
-    contract: v1beta1
+    contract: v1beta2
     replacements:
     - old: --metrics-addr=127.0.0.1:8080
       new: --metrics-addr=:8080
@@ -89,6 +89,15 @@ providers:
     files:
     - sourcePath: "../data/shared/capi/metadata.yaml"
   # For clusterctl upgrade test
+  - name: "{go://sigs.k8s.io/cluster-api@v1.13}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.13}/control-plane-components.yaml"
+    type: "url"
+    contract: v1beta2
+    replacements:
+    - old: --metrics-addr=127.0.0.1:8080
+      new: --metrics-addr=:8080
+    files:
+    - sourcePath: "../data/shared/capi/metadata.yaml"
   - name: "{go://sigs.k8s.io/cluster-api@v1.12}"
     value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.12}/control-plane-components.yaml"
     type: "url"
@@ -98,33 +107,9 @@ providers:
       new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/capi/metadata.yaml"
-  - name: "{go://sigs.k8s.io/cluster-api@v1.10}"
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.10}/control-plane-components.yaml"
-    type: "url"
-    contract: v1beta1
-    replacements:
-    - old: --metrics-addr=127.0.0.1:8080
-      new: --metrics-addr=:8080
-    files:
-    - sourcePath: "../data/shared/capi/metadata.yaml"
 - name: openstack
   type: InfrastructureProvider
   versions:
-  # This is only for clusterctl upgrade tests
-  - name: "{go://github.com/kubernetes-sigs/cluster-api-provider-openstack@v0.12}"
-    value: "https://github.com/kubernetes-sigs/cluster-api-provider-openstack/releases/download/{go://github.com/kubernetes-sigs/cluster-api-provider-openstack@v0.12}/infrastructure-components.yaml"
-    type: url
-    contract: v1beta1
-    files:
-    - sourcePath: "../data/shared/provider/metadata.yaml"
-    - sourcePath: "./infrastructure-openstack-no-artifact/cluster-template-capi-v1beta1.yaml"
-    replacements:
-    - old: "imagePullPolicy: Always"
-      new: "imagePullPolicy: IfNotPresent"
-    - old: "--v=2"
-      new: "--v=4"
-    - old: "--leader-elect"
-      new: "--leader-elect=false\n        - --sync-period=1m"
   # This is only for clusterctl upgrade tests
   - name: "{go://github.com/kubernetes-sigs/cluster-api-provider-openstack@v0.13}"
     value: "https://github.com/kubernetes-sigs/cluster-api-provider-openstack/releases/download/{go://github.com/kubernetes-sigs/cluster-api-provider-openstack@v0.13}/infrastructure-components.yaml"
@@ -155,7 +140,22 @@ providers:
       new: "--v=4"
     - old: "--leader-elect"
       new: "--leader-elect=false\n        - --sync-period=1m"
-  - name: v0.15.99
+  # This is only for clusterctl upgrade tests
+  - name: "{go://github.com/kubernetes-sigs/cluster-api-provider-openstack@latest-v0.15}"
+    value: "https://github.com/kubernetes-sigs/cluster-api-provider-openstack/releases/download/{go://github.com/kubernetes-sigs/cluster-api-provider-openstack@latest-v0.15}/infrastructure-components.yaml"
+    type: url
+    contract: v1beta2
+    files:
+    - sourcePath: "../data/shared/provider/metadata.yaml"
+    - sourcePath: "./infrastructure-openstack-no-artifact/cluster-template.yaml"
+    replacements:
+    - old: "imagePullPolicy: Always"
+      new: "imagePullPolicy: IfNotPresent"
+    - old: "--v=2"
+      new: "--v=4"
+    - old: "--leader-elect"
+      new: "--leader-elect=false\n        - --sync-period=1m"
+  - name: v0.16.99
     value: ../../../config/default
     # This is the upcoming version.
     contract: v1beta2

--- a/test/e2e/data/shared/provider/metadata.yaml
+++ b/test/e2e/data/shared/provider/metadata.yaml
@@ -34,3 +34,6 @@ releaseSeries:
 - major: 0
   minor: 15
   contract: v1beta2
+- major: 0
+  minor: 16
+  contract: v1beta2

--- a/test/e2e/suites/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/suites/e2e/clusterctl_upgrade_test.go
@@ -20,108 +20,22 @@ package e2e
 
 import (
 	"context"
-	"fmt"
-	"io"
-	"net/http"
-	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
-	capi_framework "sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 
 	shared "sigs.k8s.io/cluster-api-provider-openstack/test/e2e/shared"
 )
 
 var (
-	capoRelease012 string
 	capoRelease013 string
 	capoRelease014 string
-	capiRelease110 string
+	capoRelease015 string
 	capiRelease112 string
+	capiRelease113 string
 )
-
-// NOTE: clusterctl v1.10 cannot handle RuntimeExtensionProvider in the local
-// filesystem repository created by the CAPI v1.14 test framework. And clusterctl
-// v1.12 refuses to operate against v1beta1 management clusters. Therefore, we
-// cannot install ORC as a RuntimeExtension and have to use hooks instead.
-//
-// CAPO v0.13 was compiled against CAPI v1.11, and CAPO v0.14 against CAPI v1.12.
-// Both CAPI v1.11 and v1.12 use the v1beta2 contract and promote the IPAM API
-// from exp/ipam (v1alpha1) to api/ipam (v1beta2). This means neither v0.13 nor
-// v0.14 can run against CAPI v1.10 (the last v1beta1 release). Therefore:
-//   - The v0.13 upgrade test uses CAPI v1.11 as the starting point.
-//   - The v0.14 upgrade test uses CAPI v1.12 as the starting point.
-
-// orcInitVersion is the ORC version installed alongside the old CAPO release in
-// PreInit. v1.0.2 is the version the v0.12/v0.13/v0.14 CAPO releases were tested
-// against (see the previous InitWithRuntimeExtensionProviders entry).
-const orcInitVersion = "v1.0.2"
-
-var _ = Describe("When testing clusterctl upgrades for CAPO (v0.12=>current) and ORC (v1.0.2=>current)[clusterctl-upgrade]", func() {
-	BeforeEach(func(ctx context.Context) {
-		// Note: This gives the version without the 'v' prefix, so we need to add it below.
-		capoRelease012, err = clusterctl.ResolveRelease(ctx, "go://github.com/kubernetes-sigs/cluster-api-provider-openstack@v0.12")
-		Expect(err).ToNot(HaveOccurred(), "failed to get stable release of CAPO")
-		capoRelease012 = "v" + capoRelease012
-		// Note: This gives the version without the 'v' prefix, so we need to add it below.
-		capiRelease110, err = capi_e2e.GetStableReleaseOfMinor(ctx, "1.10")
-		Expect(err).ToNot(HaveOccurred(), "failed to get stable release of CAPI")
-		capiRelease110 = "v" + capiRelease110
-		// Note: This gives the version without the 'v' prefix, so we need to add it below.
-		// This is used as an intermediate upgrade step below, see the comment on the Upgrades field.
-		capiRelease112, err = capi_e2e.GetStableReleaseOfMinor(ctx, "1.12")
-		Expect(err).ToNot(HaveOccurred(), "failed to get stable release of CAPI")
-		capiRelease112 = "v" + capiRelease112
-	})
-
-	capi_e2e.ClusterctlUpgradeSpec(context.TODO(), func() capi_e2e.ClusterctlUpgradeSpecInput {
-		return capi_e2e.ClusterctlUpgradeSpecInput{
-			E2EConfig:                       e2eCtx.E2EConfig,
-			ClusterctlConfigPath:            e2eCtx.Environment.ClusterctlConfigPath,
-			BootstrapClusterProxy:           e2eCtx.Environment.BootstrapClusterProxy,
-			ArtifactFolder:                  e2eCtx.Settings.ArtifactFolder,
-			SkipCleanup:                     false,
-			InitWithBinary:                  "https://github.com/kubernetes-sigs/cluster-api/releases/download/" + capiRelease110 + "/clusterctl-{OS}-{ARCH}",
-			InitWithProvidersContract:       "v1beta1",
-			InitWithInfrastructureProviders: []string{"openstack:" + capoRelease012},
-			InitWithCoreProvider:            "cluster-api:" + capiRelease110,
-			InitWithBootstrapProviders:      []string{"kubeadm:" + capiRelease110},
-			InitWithControlPlaneProviders:   []string{"kubeadm:" + capiRelease110},
-			// Explicit empty slice: we install ORC manually via PreInit/PreUpgrade
-			// hooks rather than via clusterctl.
-			InitWithRuntimeExtensionProviders: []string{},
-			MgmtFlavor:                        shared.FlavorDefault,
-			WorkloadFlavor:                    shared.FlavorCapiV1Beta1,
-			InitWithKubernetesVersion:         e2eCtx.E2EConfig.MustGetVariable(shared.KubernetesKindVersion),
-			// Pin the initial workload cluster to a version the old providers
-			// (CAPI v1.10 / CAPO v0.12) can actually bootstrap.
-			WorkloadKubernetesVersion:   e2eCtx.E2EConfig.MustGetVariable(shared.KubernetesVersionUpgradeFrom),
-			UseKindForManagementCluster: true,
-			// clusterctl refuses to upgrade the core/kubeadm-bootstrap/kubeadm-control-plane
-			// providers by more than 3 minor versions in a single step, and CAPI v1.10=>current
-			// (v1.14) is a 4 minor version jump. Split the upgrade into two steps: first bump
-			// those three providers to the skew-compatible CAPI v1.12, then upgrade everything
-			// (including CAPO) to the latest version for the current contract.
-			Upgrades: []capi_e2e.ClusterctlUpgradeSpecInputUpgrade{
-				{
-					CoreProvider:          "cluster-api:" + capiRelease112,
-					BootstrapProviders:    []string{"kubeadm:" + capiRelease112},
-					ControlPlaneProviders: []string{"kubeadm:" + capiRelease112},
-				},
-			},
-			// Install ORC v1.0.2 before clusterctl init
-			PreInit: func(managementClusterProxy capi_framework.ClusterProxy) {
-				installORC(context.Background(), managementClusterProxy, orcInitVersion)
-			},
-			// Upgrade ORC to the current version right before the final upgrade step, which is
-			// also when CAPO gets upgraded to current. PreUpgrade is invoked once per entry in
-			// Upgrades above, so skip it for the first (intermediate, CAPI-only) step.
-			PreUpgrade: newORCUpgradeOnFinalStep(),
-		}
-	})
-})
 
 // CAPO v0.13 is built against CAPI v1beta2 and therefore cannot run against CAPI v1.10.
 var _ = Describe("When testing clusterctl upgrades for CAPO (v0.13=>current) and ORC (v1.0.2=>current)[clusterctl-upgrade]", func() {
@@ -200,68 +114,40 @@ var _ = Describe("When testing clusterctl upgrades for CAPO (v0.14=>current) and
 	})
 })
 
-// newORCUpgradeOnFinalStep returns a PreUpgrade hook that installs the latest ORC version, but only
-// from its second invocation onwards. This is used for upgrade tests that stage the CAPI core/
-// kubeadm-bootstrap/kubeadm-control-plane providers upgrade into multiple steps (via the Upgrades
-// field): PreUpgrade is called once per step, but ORC (like the infrastructure provider) should only
-// be upgraded to current immediately before the final step, not before every intermediate step.
-func newORCUpgradeOnFinalStep() func(managementClusterProxy capi_framework.ClusterProxy) {
-	isFinalStep := false
-	return func(managementClusterProxy capi_framework.ClusterProxy) {
-		defer func() { isFinalStep = true }()
-		if !isFinalStep {
-			return
+var _ = Describe("When testing clusterctl upgrades for CAPO (v0.15=>current) and ORC (v1.0.2=>current)[clusterctl-upgrade]", func() {
+	BeforeEach(func(ctx context.Context) {
+		// Note: This gives the version without the 'v' prefix, so we need to add it below.
+		capoRelease015, err = clusterctl.ResolveRelease(ctx, "go://github.com/kubernetes-sigs/cluster-api-provider-openstack@latest-v0.15")
+		Expect(err).ToNot(HaveOccurred(), "failed to get stable release of CAPO")
+		capoRelease015 = "v" + capoRelease015
+		// Note: This gives the version without the 'v' prefix, so we need to add it below.
+		capiRelease113, err = capi_e2e.GetStableReleaseOfMinor(ctx, "1.13")
+		Expect(err).ToNot(HaveOccurred(), "failed to get stable release of CAPI")
+		capiRelease113 = "v" + capiRelease113
+	})
+
+	capi_e2e.ClusterctlUpgradeSpec(context.TODO(), func() capi_e2e.ClusterctlUpgradeSpecInput {
+		return capi_e2e.ClusterctlUpgradeSpecInput{
+			E2EConfig:                         e2eCtx.E2EConfig,
+			ClusterctlConfigPath:              e2eCtx.Environment.ClusterctlConfigPath,
+			BootstrapClusterProxy:             e2eCtx.Environment.BootstrapClusterProxy,
+			ArtifactFolder:                    e2eCtx.Settings.ArtifactFolder,
+			SkipCleanup:                       false,
+			InitWithBinary:                    "https://github.com/kubernetes-sigs/cluster-api/releases/download/" + capiRelease113 + "/clusterctl-{OS}-{ARCH}",
+			InitWithInfrastructureProviders:   []string{"openstack:" + capoRelease015},
+			InitWithCoreProvider:              "cluster-api:" + capiRelease113,
+			InitWithBootstrapProviders:        []string{"kubeadm:" + capiRelease113},
+			InitWithControlPlaneProviders:     []string{"kubeadm:" + capiRelease113},
+			InitWithRuntimeExtensionProviders: []string{"openstack-resource-controller:v1.0.2"},
+			MgmtFlavor:                        shared.FlavorDefault,
+			WorkloadFlavor:                    shared.FlavorCapiV1Beta1,
+			InitWithKubernetesVersion:         e2eCtx.E2EConfig.MustGetVariable(shared.KubernetesKindVersion),
+			// The capi-v1beta1 flavor's OpenStackMachineTemplates are pinned to
+			// the OPENSTACK_IMAGE_NAME_UPGRADE_FROM image (Kubernetes
+			// KUBERNETES_VERSION_UPGRADE_FROM), so the workload cluster's
+			// Kubernetes version must match to avoid an unexpected rollout.
+			WorkloadKubernetesVersion:   e2eCtx.E2EConfig.MustGetVariable(shared.KubernetesVersionUpgradeFrom),
+			UseKindForManagementCluster: true,
 		}
-		installLatestORC(context.Background(), managementClusterProxy, e2eCtx.E2EConfig)
-	}
-}
-
-// installLatestORC downloads and applies the install manifest for the current/latest version of
-// the OpenStack Resource Controller (ORC) to the management cluster.
-//
-// The ORC version is derived from the e2e config (the latest version with contract v1beta2), so no
-// version hardcoding is required here — updating the provider entry in the e2e config is sufficient.
-func installLatestORC(ctx context.Context, proxy capi_framework.ClusterProxy, e2eConfig *clusterctl.E2EConfig) {
-	// GetProviderLatestVersionsByContract returns strings in the format "provider-name:version",
-	// e.g. "openstack-resource-controller:v2.5.0".
-	orcVersionStrings := e2eConfig.GetProviderLatestVersionsByContract("v1beta2", "openstack-resource-controller")
-	Expect(orcVersionStrings).ToNot(BeEmpty(),
-		"No ORC version with v1beta2 contract found in e2e config; cannot install ORC for upgrade")
-
-	parts := strings.SplitN(orcVersionStrings[0], ":", 2)
-	Expect(parts).To(HaveLen(2),
-		"Unexpected ORC provider version string format (expected 'name:version'): %q", orcVersionStrings[0])
-	orcVersion := parts[1]
-
-	installORC(ctx, proxy, orcVersion)
-}
-
-// installORC downloads and applies the upstream install manifest for the given version of the
-// OpenStack Resource Controller (ORC) to the management cluster.
-func installORC(ctx context.Context, proxy capi_framework.ClusterProxy, orcVersion string) {
-	By(fmt.Sprintf("Installing ORC %s on the management cluster", orcVersion))
-
-	orcInstallURL := fmt.Sprintf(
-		"https://github.com/k-orc/openstack-resource-controller/releases/download/%s/install.yaml",
-		orcVersion,
-	)
-	By(fmt.Sprintf("Downloading ORC %s install manifest from %s", orcVersion, orcInstallURL))
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, orcInstallURL, http.NoBody)
-	Expect(err).ToNot(HaveOccurred(), "Failed to create HTTP request for ORC install manifest")
-
-	resp, err := http.DefaultClient.Do(req) //nolint:bodyclose // closed below via defer
-	Expect(err).ToNot(HaveOccurred(),
-		"Failed to download ORC %s install manifest from %s", orcVersion, orcInstallURL)
-	defer resp.Body.Close()
-
-	Expect(resp.StatusCode).To(Equal(http.StatusOK),
-		"Unexpected HTTP status %d when downloading ORC install manifest from %s", resp.StatusCode, orcInstallURL)
-
-	orcManifest, err := io.ReadAll(resp.Body)
-	Expect(err).ToNot(HaveOccurred(), "Failed to read ORC install manifest response body")
-
-	By(fmt.Sprintf("Applying ORC %s install manifest to the management cluster", orcVersion))
-	Expect(proxy.CreateOrUpdate(ctx, orcManifest)).To(Succeed(),
-		"Failed to apply ORC %s install manifest to management cluster", orcVersion)
-}
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:

Add the new "next release" (v0.16.99). Remove v0.12. Update CAPI config accordingly.
The biggest change here is the removal of all the old CAPI v1beta1 from the clusterctl upgrade tests. We had quite a lot of custom code to make that work.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #3225

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [ ] adds unit tests

/hold
