### PR TITLE
🐛 Allow the configured API server port in the managed control plane security group

### DIFF
--- a/controllers/openstackcluster_controller.go
+++ b/controllers/openstackcluster_controller.go
@@ -783,7 +783,11 @@ func reconcileNetworkComponents(scope *scope.WithLogger, cluster *clusterv1.Clus
 		return fmt.Errorf("failed to reconcile loadbalancer network: %w", err)
 	}
 
-	err = networkingService.ReconcileSecurityGroups(openStackCluster, clusterResourceName)
+	// The API server port is configurable, so the control plane security group
+	// must allow traffic to the port the API server actually listens on rather
+	// than assuming the default.
+	apiServerPort := getAPIServerPort(openStackCluster)
+	err = networkingService.ReconcileSecurityGroups(openStackCluster, clusterResourceName, apiServerPort)
 	if err != nil {
 		conditions.Set(openStackCluster, metav1.Condition{
 			Type:    infrav1.SecurityGroupsReadyCondition,

--- a/pkg/cloud/services/networking/securitygroups.go
+++ b/pkg/cloud/services/networking/securitygroups.go
@@ -39,8 +39,10 @@ const (
 	remoteGroupIDSelf  string = "self"
 )
 
-// ReconcileSecurityGroups reconcile the security groups.
-func (s *Service) ReconcileSecurityGroups(openStackCluster *infrav1.OpenStackCluster, clusterResourceName string) error {
+// ReconcileSecurityGroups reconcile the security groups. apiServerPort is the
+// port the core API server is exposed on, which the control plane security
+// group must allow traffic to.
+func (s *Service) ReconcileSecurityGroups(openStackCluster *infrav1.OpenStackCluster, clusterResourceName string, apiServerPort int32) error {
 	s.scope.Logger().Info("Reconciling security groups")
 	if openStackCluster.Spec.ManagedSecurityGroups == nil {
 		s.scope.Logger().V(4).Info("No need to reconcile security groups")
@@ -127,7 +129,7 @@ func (s *Service) ReconcileSecurityGroups(openStackCluster *infrav1.OpenStackClu
 	}
 
 	// create desired security groups
-	desiredSecGroupsBySuffix, err := s.generateDesiredSecGroups(openStackCluster, suffixToNameMap, observedSecGroupBySuffix)
+	desiredSecGroupsBySuffix, err := s.generateDesiredSecGroups(openStackCluster, suffixToNameMap, observedSecGroupBySuffix, apiServerPort)
 	if err != nil {
 		return err
 	}
@@ -184,7 +186,7 @@ func (r resolvedSecurityGroupRuleSpec) Matches(other rules.SecGroupRule) bool {
 		r.RemoteIPPrefix == other.RemoteIPPrefix
 }
 
-func (s *Service) generateDesiredSecGroups(openStackCluster *infrav1.OpenStackCluster, suffixToNameMap map[string]string, observedSecGroupsBySuffix map[string]*groups.SecGroup) (map[string]securityGroupSpec, error) {
+func (s *Service) generateDesiredSecGroups(openStackCluster *infrav1.OpenStackCluster, suffixToNameMap map[string]string, observedSecGroupsBySuffix map[string]*groups.SecGroup, apiServerPort int32) (map[string]securityGroupSpec, error) {
 	if openStackCluster.Spec.ManagedSecurityGroups == nil {
 		return nil, nil
 	}
@@ -222,7 +224,7 @@ func (s *Service) generateDesiredSecGroups(openStackCluster *infrav1.OpenStackCl
 	controlPlaneRules := append([]resolvedSecurityGroupRuleSpec{}, defaultRules...)
 	workerRules := append([]resolvedSecurityGroupRuleSpec{}, defaultRules...)
 
-	controlPlaneRules = append(controlPlaneRules, getSGControlPlaneHTTPS()...)
+	controlPlaneRules = append(controlPlaneRules, getSGControlPlaneHTTPS(apiServerPort)...)
 
 	// Fetch subnet to use for worker node port rules
 	// In the future IPv6 support need to be added here

--- a/pkg/cloud/services/networking/securitygroups_rules.go
+++ b/pkg/cloud/services/networking/securitygroups_rules.go
@@ -140,15 +140,16 @@ func getSGWorkerSSH(secBastionGroupID string) []resolvedSecurityGroupRuleSpec {
 	}
 }
 
-// Allow all traffic, including from outside the cluster, to access the API.
-func getSGControlPlaneHTTPS() []resolvedSecurityGroupRuleSpec {
+// Allow all traffic, including from outside the cluster, to access the API on
+// the port the API server is configured to listen on.
+func getSGControlPlaneHTTPS(apiServerPort int32) []resolvedSecurityGroupRuleSpec {
 	return []resolvedSecurityGroupRuleSpec{
 		{
 			Description:  "Kubernetes API",
 			Direction:    securityGroupRuleDirectionIngress,
 			EtherType:    securityGroupRuleEtherTypeIPv4,
-			PortRangeMin: 6443,
-			PortRangeMax: 6443,
+			PortRangeMin: int(apiServerPort),
+			PortRangeMax: int(apiServerPort),
 			Protocol:     securityGroupRuleProtocolTCP,
 		},
 	}

--- a/pkg/cloud/services/networking/securitygroups_test.go
+++ b/pkg/cloud/services/networking/securitygroups_test.go
@@ -401,7 +401,7 @@ func TestGenerateDesiredSecGroups(t *testing.T) {
 				t.Fatalf("Failed to create service: %v", err)
 			}
 
-			gotSecurityGroups, err := s.generateDesiredSecGroups(tt.openStackCluster, secGroupNames, observedSecGroupsBySuffix)
+			gotSecurityGroups, err := s.generateDesiredSecGroups(tt.openStackCluster, secGroupNames, observedSecGroupsBySuffix, 6443)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {
@@ -709,13 +709,98 @@ func TestService_ReconcileSecurityGroups(t *testing.T) {
 			openStackCluster := &infrav1.OpenStackCluster{
 				Spec: tt.openStackClusterSpec,
 			}
-			err := s.ReconcileSecurityGroups(openStackCluster, clusterResourceName)
+			err := s.ReconcileSecurityGroups(openStackCluster, clusterResourceName, 6443)
 			if tt.wantErr {
 				g.Expect(err).ToNot(BeNil(), "ReconcileSecurityGroups")
 			} else {
 				g.Expect(err).To(BeNil(), "ReconcileSecurityGroups")
 				g.Expect(openStackCluster.Status).To(Equal(tt.expectedClusterStatus), cmp.Diff(openStackCluster.Status, tt.expectedClusterStatus))
 			}
+		})
+	}
+}
+
+func TestService_ReconcileSecurityGroupsAPIServerPort(t *testing.T) {
+	const (
+		clusterResourceName = "test-cluster"
+
+		controlPlaneSGName = "k8s-cluster-test-cluster-secgroup-controlplane"
+		workerSGName       = "k8s-cluster-test-cluster-secgroup-worker"
+		bastionSGName      = "k8s-cluster-test-cluster-secgroup-bastion"
+	)
+
+	tests := []struct {
+		name          string
+		apiServerPort int32
+	}{
+		{name: "default API server port", apiServerPort: 6443},
+		{name: "custom API server port", apiServerPort: 8443},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			g := NewWithT(t)
+			log := testr.New(t)
+			mockScopeFactory := scope.NewMockScopeFactory(mockCtrl, "")
+
+			s := &Service{
+				scope:  scope.NewWithLogger(mockScopeFactory, log),
+				client: mockScopeFactory.NetworkClient,
+			}
+
+			m := mockScopeFactory.NetworkClient.EXPECT()
+			m.ListSecGroup(groups.ListOpts{Name: controlPlaneSGName}).
+				Return([]groups.SecGroup{{ID: "0", Name: controlPlaneSGName}}, nil)
+			m.ListSecGroup(groups.ListOpts{Name: workerSGName}).
+				Return([]groups.SecGroup{{ID: "1", Name: workerSGName}}, nil)
+			m.ListSecGroup(groups.ListOpts{Name: bastionSGName}).Return(nil, nil)
+
+			var apiServerRule *rules.CreateOpts
+			m.CreateSecGroupRule(gomock.Any()).DoAndReturn(func(opts rules.CreateOpts) (*rules.SecGroupRule, error) {
+				if opts.Description == "Kubernetes API" {
+					rule := opts
+					apiServerRule = &rule
+				}
+				return &rules.SecGroupRule{ID: uuid.NewString()}, nil
+			}).Times(14)
+
+			openStackCluster := &infrav1.OpenStackCluster{
+				Spec: infrav1.OpenStackClusterSpec{
+					ManagedSecurityGroups: &infrav1.ManagedSecurityGroups{},
+				},
+			}
+
+			g.Expect(s.ReconcileSecurityGroups(openStackCluster, clusterResourceName, tt.apiServerPort)).To(Succeed())
+			g.Expect(apiServerRule).ToNot(BeNil(), "expected the Kubernetes API security group rule to be created")
+			g.Expect(apiServerRule.PortRangeMin).To(Equal(int(tt.apiServerPort)))
+			g.Expect(apiServerRule.PortRangeMax).To(Equal(int(tt.apiServerPort)))
+		})
+	}
+}
+
+func TestGetSGControlPlaneHTTPS(t *testing.T) {
+	tests := []struct {
+		name          string
+		apiServerPort int32
+	}{
+		{name: "default port", apiServerPort: 6443},
+		{name: "custom port", apiServerPort: 8443},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getSGControlPlaneHTTPS(tt.apiServerPort)
+
+			g := NewWithT(t)
+			g.Expect(got).To(HaveLen(1))
+			g.Expect(got[0].Description).To(Equal("Kubernetes API"))
+			g.Expect(got[0].Direction).To(Equal(securityGroupRuleDirectionIngress))
+			g.Expect(got[0].Protocol).To(Equal(securityGroupRuleProtocolTCP))
+			g.Expect(got[0].PortRangeMin).To(Equal(int(tt.apiServerPort)))
+			g.Expect(got[0].PortRangeMax).To(Equal(int(tt.apiServerPort)))
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The managed control plane security group always allowed ingress to port 6443, regardless of the configured API server port. The Octavia load balancer listener and its pool members are created on the configured port, so a cluster using a non-default `apiServer.port` ended up with a security group that only opened the port nothing is listening on, while the port the API server is actually reachable on stayed closed.

This threads the API server port through to the security group rule generation so the `Kubernetes API` ingress rule matches the port the API server is exposed on.

**Which issue(s) this PR fixes**:
Fixes #3349

**Special notes for your reviewer**:

The port is derived with the same precedence already used for the control plane endpoint (control plane endpoint port, then `apiServer.port`, defaulting to 6443), so clusters with an explicitly configured control plane endpoint keep working unchanged.

Tests:
- `TestGetSGControlPlaneHTTPS` asserts the generated rule uses the given port for both the default (6443) and a custom port.
- `TestService_ReconcileSecurityGroupsAPIServerPort` runs `ReconcileSecurityGroups` with a custom port and asserts the created `Kubernetes API` rule opens that port.

Both tests fail if the rule is hardcoded back to 6443.

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. (No image changes.)

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- if necessary:
  - [ ] includes documentation
  - [x] adds unit tests
